### PR TITLE
Allow templates to use the pre-existing partials feature of Handlebars

### DIFF
--- a/src-electron/generator/template-engine.js
+++ b/src-electron/generator/template-engine.js
@@ -114,6 +114,17 @@ function loadOverridable(overridePath) {
 }
 
 /**
+ * Function that loads the partials.
+ *
+ * @param {*} path
+ */
+function loadPartial(name, path) {
+  return fsPromise
+    .readFile(path, 'utf8')
+    .then((data) => handlebars.registerPartial(name, data))
+}
+
+/**
  * Function that loads the helpers.
  *
  * @param {*} path
@@ -148,3 +159,4 @@ function initializeGlobalHelpers() {
 
 exports.produceContent = produceContent
 exports.loadHelper = loadHelper
+exports.loadPartial = loadPartial

--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -29,6 +29,7 @@ exports.packageType = {
   genSingleTemplate: 'gen-template',
   genHelper: 'gen-helper',
   genOverride: 'gen-override',
+  genPartial: 'gen-partial',
 }
 
 exports.packageOptionCategory = {

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -52,6 +52,13 @@ test('handlebars: each test', () => {
   expect(output).toEqual('Very simple test !')
 })
 
+test('handlebars: partials', () => {
+  handlebars.registerPartial('very_simple_test', 'Very simple test!')
+  var template = handlebars.compile('{{> very_simple_test}}')
+  var output = template()
+  expect(output).toEqual('Very simple test!')
+})
+
 test('handlebars: helper', () => {
   handlebars.registerHelper(
     'supreme_leader',


### PR DESCRIPTION
This PR allows templates to use the pre-existing **partials** feature of Handlebarjs.

In order to use a partial one would register it in the `gen-templates.json` file, similarly to how **helpers** are registered.
For example one can add to `gen-templates.json`:
```
"partials": [
    name: "chip_licence",
    path: "chip_licence.zapt"
],
```

And then the partial can be used in the a regular `.zapt` file by doing `{{> chip_licence}}`