### PR TITLE
Ensure the letters of an all uppercase word are converted to lowercas…

### DIFF
--- a/src-electron/generator/helper-c.js
+++ b/src-electron/generator/helper-c.js
@@ -255,15 +255,20 @@ function asCamelCased(label, firstLower = true) {
   var str = label.split(/ |-|\//)
   var res = ''
   for (let i = 0; i < str.length; i++) {
+    var substr = str[i].substring(1)
+    // If the whole word is uppercase, convert it to lowercase first
+    if (substr == substr.toUpperCase()) {
+      substr = substr.toLowerCase()
+    }
     if (i == 0) {
       if (firstLower) {
-        res += str[i].charAt(0).toLowerCase() + str[i].substring(1)
+        res += str[i].charAt(0).toLowerCase() + substr
       } else {
-        res += str[i].charAt(0).toUpperCase() + str[i].substring(1)
+        res += str[i].charAt(0).toUpperCase() + substr
       }
       continue
     }
-    res += str[i].charAt(0).toUpperCase() + str[i].substring(1)
+    res += str[i].charAt(0).toUpperCase() + substr
   }
   return res
 }


### PR DESCRIPTION
…e when using the 'asCamelCased' helper method

#### Problem

When generating declarations/definitions for the `IAS Zone` cluster, the methods name contains `IASZone` while the documentation state `IasZone`.

Similarly the various types in `zcl-builtin/silabs/` expects `IasZone` and not `IASZone`.

####
 * Change the `asCamelCased` helper method to convert the remaining letters after the first one as lowercased.