### PR TITLE
Expose the 'writable' field of attributes to templates

### DIFF
--- a/src-electron/db/query-config.js
+++ b/src-electron/db/query-config.js
@@ -1156,6 +1156,7 @@ SELECT
   A.SIDE,
   A.MIN,
   A.MAX,
+  A.IS_WRITABLE,
   ETA.INCLUDED_REPORTABLE,
   ETA.MIN_INTERVAL,
   ETA.MAX_INTERVAL,
@@ -1191,6 +1192,7 @@ ORDER BY
           side: row.SIDE,
           min: row.MIN,
           max: row.MAX,
+          writable: row.IS_WRITABLE,
           reportable: {
             included: row.INCLUDED_REPORTABLE,
             minInterval: row.MIN_INTERVAL,


### PR DESCRIPTION
#### Problem
 
The `writable` field of attributes can not be accessed when one uses `{{#user_all_attributes}}`.

This field is useful if one wants to automatically generates methods/wrappers for a given configuration.