### PR TITLE
Fix a typo when mapping the atomics discrete property from the databa…

### DIFF
--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -184,7 +184,7 @@ exports.map = {
       name: x.NAME,
       description: x.DESCRIPTION,
       size: x.ATOMIC_SIZE,
-      discrete: x.DISCETE,
+      discrete: x.DISCRETE,
     }
   },
 


### PR DESCRIPTION
…se to js object

#### Problem

There is a small typo when retrieving the `DISCRETE` atomic field from the database. `DISCETE` should be `DISCRETE`.