### PR TITLE
Silabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zap",
-  "version": "0.99.3",
+  "version": "0.99.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10149,9 +10149,9 @@
       "dev": true
     },
     "electron": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-9.4.0.tgz",
-      "integrity": "sha512-hOC4q0jkb+UDYZRy8vrZ1IANnq+jznZnbkD62OEo06nU+hIbp2IrwDRBNuSLmQ3cwZMVir0WSIA1qEVK0PkzGA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-8.2.0.tgz",
+      "integrity": "sha512-mnV43gKCrCUMHLmGws/DU/l8LhaxrFD53A4ofwtthdCqOZWGIdk1+eMphiVumXR5a3lC64XVvmXQ2k28i7F/zw==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@vue/eslint-config-standard": "^6.0.0",
     "babel-eslint": "^10.1.0",
     "devtron": "^1.4.0",
-    "electron": "^9.4.0",
+    "electron": "^8.2.0",
     "electron-builder": "^22.8.0",
     "electron-debug": "^3.2.0",
     "electron-devtools-installer": "^3.1.1",

--- a/src-electron/util/env.js
+++ b/src-electron/util/env.js
@@ -275,7 +275,7 @@ function versionsCheck() {
     'v12.15.x',
     'v12.14.x',
   ]
-  let expectedElectronVersion = ['9.4.x']
+  let expectedElectronVersion = ['8.2.x']
   let nodeVersion = process.version
   let electronVersion = process.versions.electron
   let ret = true


### PR DESCRIPTION
- downgrade again. While electron 9.4 works fine on Mac and Linux, there is a weird packaging issue on Windows. So let's stuck to 8.2 until this is resolved somehow.