### PR TITLE
Sort clusters, commands and attributes in helper-endpointconfig.js

### DIFF
--- a/test/endpoint-config.test.js
+++ b/test/endpoint-config.test.js
@@ -187,7 +187,7 @@ test(
         ).toBeTruthy()
         expect(
           epc.includes(
-            '{ ZAP_REPORT_DIRECTION(REPORTED), 0x0029, 0x0101, 0x0000, ZAP_CLUSTER_MASK(SERVER), 0x0000, {{ 0, 65344, 0 }} }, /* Reporting for cluster: "Door Lock", attribute: "lock state". side: server */'
+            '{ ZAP_REPORT_DIRECTION(REPORTED), 0x0029, 0x0101, 0x0000, ZAP_CLUSTER_MASK(SERVER), 0x0000, {{ 0, 65344, 0 }} }, /* lock state */'
           )
         ).toBeTruthy()
         expect(


### PR DESCRIPTION
#### Problem

While generating `endpoint_config.h` the attributes order is sometimes moving around. This is annoying since it creates some useless noises in PRs and it may hides some local changes.

This PR sorts clusters, attributes and commands to make sure the order stay the same between multiple runs.