### PR TITLE
Add support for big endian in function endpoint_attribute_list (#141)

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -245,6 +245,15 @@ function endpoint_attribute_count(options) {
 function endpoint_attribute_list(options) {
   let comment = null
 
+  let littleEndian = true
+  let pointerSize = 4
+  if (options.hash.endian == 'big') {
+    littleEndian = false
+    if (typeof options.hash.pointer != 'undefined') {
+      pointerSize = options.hash.pointer
+    }
+  }
+
   let ret = '{ \\\n'
   this.attributeList.forEach((at) => {
     if (at.comment != comment) {
@@ -267,7 +276,11 @@ function endpoint_attribute_list(options) {
     } else if (at.isMacro) {
       finalDefaultValue = at.defaultValue
     } else {
-      finalDefaultValue = `ZAP_SIMPLE_DEFAULT(${at.defaultValue})`
+      let defaultValue = at.defaultValue
+      if (!littleEndian) {
+        defaultValue = Number(defaultValue).toString(16).padStart(6,'0x0000').padEnd(2+2*pointerSize,'0')
+      }
+      finalDefaultValue = `ZAP_SIMPLE_DEFAULT(${defaultValue})`
     }
     ret += `  { ${at.id}, ${at.type}, ${at.size}, ${mask}, ${finalDefaultValue} }, /* ${at.name} */  \\\n`
   })


### PR DESCRIPTION
The function generates defaults for big endian systems.
The function can be (optional) called with:
endian=<'big'|'little'> (default='little')
pointer=<pointer size in bytes> (default=4)
Examples:
#define GENERATED_ATTRIBUTES {{ endpoint_attribute_list endian="big" pointer=4}}
#define GENERATED_ATTRIBUTES {{ endpoint_attribute_list}}

Fixes issue 141
