### PR TITLE
Different commands with the same name gets merged when getting the li…

### DIFF
--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -1426,7 +1426,7 @@ async function exportCommandDetailsFromAllEndpointTypesAndClusters(
   INNER JOIN CLUSTER
   ON COMMAND.CLUSTER_REF = CLUSTER.CLUSTER_ID
   WHERE ENDPOINT_TYPE_COMMAND.ENDPOINT_TYPE_REF IN (${endpointTypeIds}) AND ENDPOINT_TYPE_COMMAND.ENDPOINT_TYPE_CLUSTER_REF in (${endpointClusterIds})
-  GROUP BY COMMAND.NAME
+  GROUP BY COMMAND.NAME, COMMAND.COMMAND_ID
         `
     )
     .then((rows) => rows.map(commandMap))


### PR DESCRIPTION
…st of commands per cluster

#### Problem
Commands with the same name but for different clusters get merged because the `GROUP BY` is a bit overzealous.

Fixes #161.