### PR TITLE
Prevent the second UPDATE from updateCommandRequestResponseReferences…

### DIFF
--- a/src-electron/db/query-command.js
+++ b/src-electron/db/query-command.js
@@ -1186,7 +1186,7 @@ SET
         )
   )
 WHERE
-  COMMAND.NAME NOT LIKE '%Response'
+  COMMAND.NAME NOT LIKE '%Response' AND COMMAND.RESPONSE_NAME IS NULL
     `
   )
 }


### PR DESCRIPTION
… to override the first one

The second request of `updateCommandRequestResponseReferences` overrides the first request that uses the response name defines in the XML definition.