### PR TITLE
Silabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zap",
-  "version": "0.99.7",
+  "version": "2021.10.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12221,9 +12221,9 @@
       "dev": true
     },
     "electron": {
-      "version": "12.0.14",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.14.tgz",
-      "integrity": "sha512-RcU++BiL+DlwhP62sUTasjAOwXOloWQS3oLk4PE0s2eERNs7hr2LoKqbUpbShw9nY+aqNw4mgd+ojyBJsOE2fg==",
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.2.2.tgz",
+      "integrity": "sha512-Oma/nIfvgql9JjAxdB9gQk//qxpJaI6PgMocYMiW4kFyLi+8jS6oGn33QG3FESS//cw09KRnWmA9iutuFAuXtw==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -12232,9 +12232,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
-          "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==",
+          "version": "14.17.27",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.27.tgz",
+          "integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2021.10.16",
+  "version": "2021.10.18",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "babel-jest": "^26.6.3",
     "copy-webpack-plugin": "^6.3.2",
     "devtron": "^1.4.0",
-    "electron": "^12.0.14",
+    "electron": "^12.2.2",
     "electron-builder": "^22.11.7",
     "electron-debug": "^3.2.0",
     "electron-devtools-installer": "^3.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "noImplicitAny": true,
     "module": "commonjs",
     "sourceMap": true,
-    "target": "es2020",
+    "target": "es2019",
     "allowJs": true,
     "moduleResolution": "node",
     "baseUrl": "./src-electron",


### PR DESCRIPTION
Downgrade TypeScript target to es2019 from es2020, as es2020 is not supported in node 12.
This way, users of node 12 are again supported.