### PR TITLE
Stop assuming that attribute types are always lowercased.

### DIFF
--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -1421,7 +1421,8 @@ async function selectAtomicSizeFromType(db, packageId, type) {
   let row = await dbApi.dbGet(
     db,
     'SELECT ATOMIC_SIZE FROM ATOMIC WHERE PACKAGE_REF = ? AND NAME = ?',
-    [packageId, type]
+    // The types in the ATOMIC table are always lowercase.
+    [packageId, type.toLowerCase()]
   )
   if (row == null) {
     return null

--- a/src-electron/util/types.js
+++ b/src-electron/util/types.js
@@ -171,6 +171,7 @@ function isFloat(type) {
  * @returns true if the said type is a string prefixed by one byte length
  */
 function isOneBytePrefixedString(type) {
+  type = type.toLowerCase();
   return type == 'char_string' || type == 'octet_string'
 }
 /**
@@ -180,6 +181,7 @@ function isOneBytePrefixedString(type) {
  * @returns true if the said type is a string prefixed by two byte length
  */
 function isTwoBytePrefixedString(type) {
+  type = type.toLowerCase();
   return type == 'long_char_string' || type == 'long_octet_string'
 }
 


### PR DESCRIPTION
I've verified that with these changes Matter codegen is unaffected by
dropping our forced lowercasing of attribute types from
zcl-loader-silabs.js.  Not including that change for now, since it
might break Zigbee bits.