### PR TITLE
Stop forcibly lowercasing case-sensitive types of attributes.

### DIFF
--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -484,7 +484,10 @@ function prepareCluster(cluster, isExtension = false) {
         code: parseInt(attribute.$.code),
         manufacturerCode: attribute.$.manufacturerCode,
         name: name,
-        type: attribute.$.type.toLowerCase(),
+        type:
+          attribute.$.type.toUpperCase() == attribute.$.type
+            ? attribute.$.type.toLowerCase()
+            : attribute.$.type,
         side: attribute.$.side,
         define: attribute.$.define,
         min: attribute.$.min,


### PR DESCRIPTION
There are three sorts of type strings we can end up with for attributes:

1) All-lowercase (e.g. "int16u").  These are already lowercase, nothing to do.
2) All-uppercase (e.g. "IUNT16U").  For now we keep lowercasing these, because
   otherwise various things that try to do upper-snake-casing of them (e.g. for
   macro names) end up with different results (specifically "INT16_U" instead
   of "INT16U");
3) Mixed-case.  In that case we assume the case is meaningful and preserve it.