### PR TITLE
Silabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2021.11.12",
+  "version": "2021.11.15",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2021.11.11",
+  "version": "2021.11.12",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/src-electron/db/query-attribute.js
+++ b/src-electron/db/query-attribute.js
@@ -297,6 +297,8 @@ async function selectAttributeDetailsFromEnabledClusters(
       define: x.DEFINE,
       mfgCode: x.MANUFACTURER_CODE,
       isWritable: x.IS_WRITABLE,
+      clusterRef: x.CLUSTER_REF,
+      clusterId: x.CLUSTER_ID,
       clusterSide: x.CLUSTER_SIDE,
       clusterName: x.CLUSTER_NAME,
       clusterDefine: x.CLUSTER_DEFINE,
@@ -325,8 +327,10 @@ async function selectAttributeDetailsFromEnabledClusters(
       db,
       `
   SELECT
-    ATTRIBUTE.ATTRIBUTE_ID,
+
+  ATTRIBUTE.ATTRIBUTE_ID,
     ATTRIBUTE.NAME,
+    ATTRIBUTE.CLUSTER_REF,
     ATTRIBUTE.CODE,
     ATTRIBUTE.SIDE,
     ATTRIBUTE.TYPE,
@@ -334,6 +338,7 @@ async function selectAttributeDetailsFromEnabledClusters(
     ATTRIBUTE.MANUFACTURER_CODE,
     ATTRIBUTE.IS_WRITABLE,
     ENDPOINT_TYPE_CLUSTER.SIDE AS CLUSTER_SIDE,
+    CLUSTER.CLUSTER_ID AS CLUSTER_ID,
     CLUSTER.NAME AS CLUSTER_NAME,
     CLUSTER.DEFINE AS CLUSTER_DEFINE,
     CLUSTER.CODE AS CLUSTER_CODE,

--- a/src-electron/db/query-command.js
+++ b/src-electron/db/query-command.js
@@ -1135,7 +1135,7 @@ ORDER BY CL.CODE, CMD.CODE, CA.FIELD_IDENTIFIER`,
  *
  * @param {*} db
  */
-async function updateCommandRequestResponseReferences(db) {
+async function updateCommandRequestResponseReferences(db, packageId) {
   // First we link up all the cases where the response_for_name is present
   await dbApi.dbUpdate(
     db,
@@ -1159,7 +1159,9 @@ SET
   )
 WHERE
   COMMAND.RESPONSE_NAME IS NOT NULL
-  `
+  AND COMMAND.PACKAGE_REF = ?
+  `,
+    [packageId]
   )
 
   // Then we link up the ones where the "response/request" names match.

--- a/src-electron/db/query-config.js
+++ b/src-electron/db/query-config.js
@@ -178,6 +178,9 @@ async function insertOrUpdateAttributeState(
     clusterRef,
     side
   )
+  if (cluster == null) {
+    throw new Error(`Could not locate cluster: ${clusterRef}`)
+  }
 
   let staticAttribute =
     await queryZcl.selectAttributeByAttributeIdAndClusterRef(
@@ -569,6 +572,7 @@ async function setEndpointDefaults(
   )
   if (pkgs == null || pkgs.length < 1)
     throw new Error('Could not locate package id for a given session.')
+
   let packageId = pkgs[0].id
   let clusters = await queryZcl.selectDeviceTypeClustersByDeviceTypeRef(
     db,

--- a/src-electron/db/query-config.js
+++ b/src-electron/db/query-config.js
@@ -673,7 +673,7 @@ async function resolveDefaultDeviceTypeAttributes(
                 insertOrUpdateAttributeState(
                   db,
                   endpointTypeId,
-                  attribute.clusterRef,
+                  attribute?.clusterRef,
                   attribute.side,
                   deviceAttribute.attributeRef,
                   [

--- a/src-electron/db/query-config.js
+++ b/src-electron/db/query-config.js
@@ -661,40 +661,39 @@ async function resolveDefaultDeviceTypeAttributes(
   endpointTypeId,
   deviceTypeRef
 ) {
-  return queryZcl
-    .selectDeviceTypeAttributesByDeviceTypeRef(db, deviceTypeRef)
-    .then((deviceTypeAttributes) =>
-      Promise.all(
-        deviceTypeAttributes.map((deviceAttribute) => {
-          if (deviceAttribute.attributeRef != null) {
-            return queryZcl
-              .selectAttributeById(db, deviceAttribute.attributeRef)
-              .then((attribute) =>
-                insertOrUpdateAttributeState(
-                  db,
-                  endpointTypeId,
-                  attribute?.clusterRef,
-                  attribute.side,
-                  deviceAttribute.attributeRef,
-                  [
-                    {
-                      key: restApi.updateKey.attributeSelected,
-                      value: true,
-                    },
-                    {
-                      key: restApi.updateKey.attributeReporting,
-                      value: deviceAttribute.isReportable == true,
-                    },
-                  ],
-                  attribute.reportMinInterval,
-                  attribute.reportMaxInterval,
-                  attribute.reportableChange
-                )
-              )
-          }
-        })
-      )
-    )
+  let deviceTypeAttributes =
+    await queryZcl.selectDeviceTypeAttributesByDeviceTypeRef(db, deviceTypeRef)
+
+  return Promise.all(
+    deviceTypeAttributes.map((deviceAttribute) => {
+      if (deviceAttribute.attributeRef != null) {
+        return queryZcl
+          .selectAttributeById(db, deviceAttribute.attributeRef)
+          .then((attribute) =>
+            insertOrUpdateAttributeState(
+              db,
+              endpointTypeId,
+              attribute?.clusterRef,
+              attribute.side,
+              deviceAttribute.attributeRef,
+              [
+                {
+                  key: restApi.updateKey.attributeSelected,
+                  value: true,
+                },
+                {
+                  key: restApi.updateKey.attributeReporting,
+                  value: deviceAttribute.isReportable == true,
+                },
+              ],
+              attribute.reportMinInterval,
+              attribute.reportMaxInterval,
+              attribute.reportableChange
+            )
+          )
+      }
+    })
+  )
 }
 
 async function resolveCommandState(db, endpointTypeId, deviceCommand) {

--- a/src-electron/db/query-loader.js
+++ b/src-electron/db/query-loader.js
@@ -1216,6 +1216,18 @@ WHERE
   )
 }
 
+/**
+ * Post loading actions.
+ *
+ * @param {*} db
+ * @param {*} packageId
+ */
+async function updateStaticEntityReferences(db, packageId) {
+  await updateEnumClusterReferences(db, packageId)
+  await updateStructClusterReferences(db, packageId)
+  await updateBitmapClusterReferences(db, packageId)
+}
+
 exports.insertGlobals = insertGlobals
 exports.insertClusterExtensions = insertClusterExtensions
 exports.insertClusters = insertClusters
@@ -1228,10 +1240,8 @@ exports.insertEnums = insertEnums
 exports.insertBitmaps = insertBitmaps
 exports.insertDeviceTypes = insertDeviceTypes
 exports.insertTags = insertTags
-exports.updateEnumClusterReferences = updateEnumClusterReferences
-exports.updateStructClusterReferences = updateStructClusterReferences
-exports.updateBitmapClusterReferences = updateBitmapClusterReferences
 exports.insertAccessModifiers = insertAccessModifiers
 exports.insertAccessOperations = insertAccessOperations
 exports.insertAccessRoles = insertAccessRoles
 exports.insertDefaultAccess = insertDefaultAccess
+exports.updateStaticEntityReferences = updateStaticEntityReferences

--- a/src-electron/db/query-loader.js
+++ b/src-electron/db/query-loader.js
@@ -1147,9 +1147,14 @@ SET
     AND
       CLUSTER.PACKAGE_REF = ?
   )
+WHERE
+  ( SELECT PACKAGE_REF
+    FROM ENUM
+    WHERE ENUM.ENUM_ID = ENUM_CLUSTER.ENUM_REF
+  ) = ?
   
 `,
-    [packageId]
+    [packageId, packageId]
   )
 }
 
@@ -1171,9 +1176,14 @@ SET
     AND
       CLUSTER.PACKAGE_REF = ?
   )
-  
+WHERE
+  (
+    SELECT PACKAGE_REF
+    FROM STRUCT
+    WHERE STRUCT.STRUCT_ID = STRUCT_CLUSTER.STRUCT_REF
+  ) = ?
 `,
-    [packageId]
+    [packageId, packageId]
   )
 }
 
@@ -1195,9 +1205,14 @@ SET
     AND
       CLUSTER.PACKAGE_REF = ?
   )
-  
+WHERE
+  (
+    SELECT PACKAGE_REF
+    FROM BITMAP
+    WHERE BITMAP.BITMAP_ID = BITMAP_CLUSTER.BITMAP_REF
+  ) = ?
 `,
-    [packageId]
+    [packageId, packageId]
   )
 }
 

--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -1209,8 +1209,14 @@ SET
       )
     AND
       COMMAND.PACKAGE_REF = ?
-  )`,
-    [packageId]
+  )
+WHERE
+  (
+    SELECT PACKAGE_REF
+    FROM COMMAND
+    WHERE COMMAND.COMMAND_ID = DEVICE_TYPE_COMMAND.COMMAND_REF
+  ) = ?`,
+    [packageId, packageId]
   )
 }
 

--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -1165,8 +1165,15 @@ SET
       )
     AND
       ATTRIBUTE.PACKAGE_REF = ?
-  )`,
-    [packageId]
+  )
+WHERE
+  (
+    SELECT PACKAGE_REF
+    FROM ATTRIBUTE
+    WHERE ATTRIBUTE.ATTRIBUTE_ID = DEVICE_TYPE_ATTRIBUTE.ATTRIBUTE_REF
+  ) = ?
+  `,
+    [packageId, packageId]
   )
 }
 

--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -1123,8 +1123,13 @@ SET
       lower(CLUSTER.NAME) = lower(DEVICE_TYPE_CLUSTER.CLUSTER_NAME)
     AND
       CLUSTER.PACKAGE_REF = ?
-  )`,
-    [packageId]
+  )
+WHERE
+  ( SELECT PACKAGE_REF
+    FROM DEVICE_TYPE
+    WHERE DEVICE_TYPE_ID = DEVICE_TYPE_CLUSTER.DEVICE_TYPE_REF
+  ) = ?`,
+    [packageId, packageId]
   )
 }
 

--- a/src-electron/rest/endpoint.js
+++ b/src-electron/rest/endpoint.js
@@ -103,7 +103,7 @@ function httpPostEndpoint(db) {
         validationIssues: validationData,
       })
     } catch (err) {
-      response.status(StatusCodes.BAD_REQUEST).send()
+      response.status(StatusCodes.INTERNAL_SERVER_ERROR).json(err)
     }
   }
 }
@@ -160,7 +160,7 @@ function httpPostEndpointType(db) {
         deviceTypeRef: deviceTypeRef,
       })
     } catch (err) {
-      response.status(StatusCodes.BAD_REQUEST).send()
+      response.status(StatusCodes.INTERNAL_SERVER_ERROR).json(err)
     }
   }
 }

--- a/src-electron/rest/endpoint.js
+++ b/src-electron/rest/endpoint.js
@@ -78,10 +78,10 @@ function httpPostEndpoint(db) {
       endpointVersion,
       deviceIdentifier,
     } = request.body
-    let sessionIdexport = request.zapSessionId
+    let sessionId = request.zapSessionId
     let newId = await queryEndpoint.insertEndpoint(
       db,
-      sessionIdexport,
+      sessionId,
       endpointId,
       endpointType,
       networkId,

--- a/src-electron/rest/file-ops.js
+++ b/src-electron/rest/file-ops.js
@@ -80,7 +80,7 @@ function httpPostFileOpen(db) {
         err.project = zapFilePath
         studio.sendSessionCreationErrorStatus(db, err)
         env.logError(JSON.stringify(err))
-        res.status(StatusCodes.BAD_REQUEST).send(err)
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json(err)
       }
     } else {
       let msg = `Opening/Loading project: Missing zap file path.`
@@ -130,9 +130,7 @@ function httpPostFileSave(db) {
       } catch (err) {
         let msg = `Unable to save project.`
         env.logError(msg, err)
-        res.status(StatusCodes.BAD_REQUEST).send({
-          error: msg,
-        })
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json(err)
       }
     } else {
       res.status(StatusCodes.BAD_REQUEST).send({ error: 'No file specified.' })

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -140,8 +140,7 @@ function httpPostCluster(db) {
         )
       })
       .catch((err) => {
-        env.logError(err)
-        response.status(StatusCodes.BAD_REQUEST).send()
+        response.status(StatusCodes.INTERNAL_SERVER_ERROR).json(err)
       })
   }
 }
@@ -388,8 +387,7 @@ function httpPostAddNewPackage(db) {
       }
       res.status(StatusCodes.OK).json(status)
     } catch (err) {
-      env.logError(err)
-      res.status(StatusCodes.BAD_REQUEST).send()
+      response.status(StatusCodes.INTERNAL_SERVER_ERROR).json(err)
     }
   }
 }
@@ -444,7 +442,7 @@ function httpPostUnifyClustersAcrossEndpoints(db) {
     //                           }}
 
     if (!Array.isArray(endpointTypeIdList) || !endpointTypeIdList.length) {
-      response.status(StatusCodes.BAD_REQUEST).json()
+      response.status(StatusCodes.BAD_REQUEST).send()
     } else {
       if (endpointTypeIdList.length == 1) {
         return response.status(StatusCodes.OK).json(resp)

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -243,6 +243,7 @@ function httpPostCommandUpdate(db) {
     let {
       action,
       endpointTypeId,
+      endpointTypeIdList,
       id,
       value,
       listType,
@@ -261,18 +262,24 @@ function httpPostCommandUpdate(db) {
       default:
         break
     }
-    await queryConfig.insertOrUpdateCommandState(
-      db,
-      endpointTypeId,
-      clusterRef,
-      commandSide,
-      id,
-      value,
-      isIncoming
+
+    await Promise.all(
+      endpointTypeIdList.map((endpointTypeId) =>
+        queryConfig.insertOrUpdateCommandState(
+          db,
+          endpointTypeId,
+          clusterRef,
+          commandSide,
+          id,
+          value,
+          isIncoming
+        )
+      )
     )
+
     response.status(StatusCodes.OK).json({
       action: action,
-      endpointTypeId: endpointTypeId,
+      endpointTypeIdList: endpointTypeIdList,
       id: id,
       added: value,
       listType: listType,

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -23,6 +23,7 @@
 
 const env = require('../util/env')
 const queryZcl = require('../db/query-zcl.js')
+const queryAttribute = require('../db/query-attribute.js')
 const queryConfig = require('../db/query-config.js')
 const queryEndpointType = require('../db/query-endpoint-type.js')
 const queryEndpoint = require('../db/query-endpoint.js')
@@ -153,7 +154,7 @@ function httpPostAttributeUpdate(db) {
   return async (request, response) => {
     let {
       action,
-      endpointTypeId,
+      endpointTypeIdList,
       id,
       value,
       listType,
@@ -163,6 +164,11 @@ function httpPostAttributeUpdate(db) {
       reportMaxInterval,
       reportableChange,
     } = request.body
+
+    if (!Array.isArray(endpointTypeIdList) || !endpointTypeIdList.length) {
+      response.status(StatusCodes.BAD_REQUEST).json()
+    }
+
     let paramType
     switch (listType) {
       case restApi.updateKey.attributeStorage:
@@ -178,35 +184,44 @@ function httpPostAttributeUpdate(db) {
         ? null
         : [{ key: listType, value: value, type: paramType }]
 
-    await queryConfig.insertOrUpdateAttributeState(
-      db,
-      endpointTypeId,
-      clusterRef,
-      attributeSide,
-      id,
-      paramArray,
-      reportMinInterval,
-      reportMaxInterval,
-      reportableChange
+    // all endpoints
+    await Promise.all(
+      endpointTypeIdList.map((endpointTypeId) =>
+        queryConfig.insertOrUpdateAttributeState(
+          db,
+          endpointTypeId,
+          clusterRef,
+          attributeSide,
+          id,
+          paramArray,
+          reportMinInterval,
+          reportMaxInterval,
+          reportableChange
+        )
+      )
     )
 
-    let eptAttr = await queryZcl.selectEndpointTypeAttribute(
+    // send latest value to frontend to update UI
+    let eptAttr = queryZcl.selectEndpointTypeAttribute(
       db,
-      endpointTypeId,
+      endpointTypeIdList[0],
       id,
       clusterRef
     )
 
+    // only return 1 validation result.
+    // error isn't endpoint specific.
+    // endpointTypeId doesn't matter since all attributes are the seame.
     let validationData = await validation.validateAttribute(
       db,
-      endpointTypeId,
+      endpointTypeIdList[0],
       id,
       clusterRef
     )
 
     response.status(StatusCodes.OK).json({
       action: action,
-      endpointTypeId: endpointTypeId,
+      endpointTypeIdList: endpointTypeIdList,
       clusterRef: clusterRef,
       id: id,
       added: value,
@@ -403,18 +418,133 @@ function httpPostAddNewPackage(db) {
  */
 function httpPostUnifyAttributesAcrossEndpoints(db) {
   return async (request, response) => {
-    //   let { endpointTypeIdList } = request.query
-    //   queryAttribute.selectAttributeDetailsFromAllEndpointTypesAndClustersUtil(db,
-    //     )
-    //   let clusters =
-    //     await queryEndpointType.selectAllClustersDetailsFromEndpointTypes(
-    //       db,
-    //       endpointTypeIdList
-    //     )
-    //   console.log(JSON.stringify(clusters))
-    //   response.status(StatusCodes.OK).json({
-    //     clusters,
-    //   })
+    let { endpointTypeIdList } = request.body
+    let resp = { oldState: {}, newState: {} }
+
+    // let respJson = {oldState: {
+    //                            endpointTypeId_1: [{cluster_state_1, cluster_state_2}],
+    //                            endpointTypeId_2: [{cluster_state_1, cluster_state_2}],
+    //                           },
+    //                 newState: {
+    //                            endpointTypeId_1: [{cluster_state_1, cluster_state_2}],
+    //                            endpointTypeId_2: [{cluster_state_1, cluster_state_2}],
+    //                           }}
+
+    if (!Array.isArray(endpointTypeIdList) || !endpointTypeIdList.length) {
+      response.status(StatusCodes.BAD_REQUEST).json()
+    } else {
+      if (endpointTypeIdList.length == 1) {
+        return response.status(StatusCodes.OK).json(resp)
+      }
+
+      let endpointsAndClusters =
+        await queryEndpointType.selectClustersAndEndpointDetailsFromEndpointTypes(
+          db,
+          endpointTypeIdList.map((x) => {
+            return { endpointTypeId: x }
+          })
+        )
+
+      let unifiedAttributesInfo =
+        await queryAttribute.selectAttributeDetailsFromEnabledClusters(
+          db,
+          endpointsAndClusters
+        )
+      unifiedAttributesInfo.forEach((entry) => {
+        // global attribute do not have cluserRefs field
+        // let's fix it up for the attribute update API.
+        if (entry.clusterRef == null) {
+          entry.clusterRef = entry.clusterId
+        }
+      })
+
+      let oldEndpointAttributesInfo = await Promise.all(
+        endpointsAndClusters.map((endpointsAndCluster) =>
+          queryAttribute
+            .selectAttributeDetailsFromEnabledClusters(db, [
+              endpointsAndCluster,
+            ])
+            .then((attrDetails) => {
+              // global attributes are not tied to specific Clusters
+              if (attrDetails.clusterRef == null) {
+                queryEndpoint.selectEndpointClusters(db)
+              }
+            })
+        )
+      )
+
+      // align all cluster states
+      if (endpointTypeIdList.length > 1) {
+        endpointTypeIdList.forEach((endpointTypeId) => {
+          unifiedAttributesInfo.forEach((attr) =>
+            queryConfig.insertOrUpdateAttributeState(
+              db,
+              endpointTypeId,
+              attr.clusterRef,
+              attr.side,
+              attr.id,
+              [
+                { key: restApi.updateKey.attributeSelected, value: 1 },
+                {
+                  key: restApi.updateKey.attributeStorage,
+                  value: `"${attr.storageOption}"`,
+                },
+                {
+                  key: restApi.updateKey.attributeSingleton,
+                  value: attr.isSingleton,
+                },
+                {
+                  key: restApi.updateKey.attributeBounded,
+                  value: attr.isAttributeBounded,
+                },
+                {
+                  key: restApi.updateKey.attributeDefault,
+                  value: attr.defaultValue,
+                },
+                {
+                  key: restApi.updateKey.attributeReporting,
+                  value: attr.isAttributeReportable,
+                },
+              ],
+              attr.attributeReportableMinValue,
+              attr.attributeReportableMaxValue,
+              attr.attributeReportableChange
+            )
+          )
+        })
+      }
+
+      resp.oldState = []
+      endpointTypeIdList.forEach((endpointTypeId, index) => {
+        resp.oldState.push({
+          endpointTypeId: endpointTypeId,
+          attributes: oldEndpointAttributesInfo[index],
+        })
+      })
+
+      let newEndpointClusterInfos = await Promise.all(
+        endpointTypeIdList.map((endpointTypeId) =>
+          queryEndpointType.selectAllClustersDetailsFromEndpointTypes(db, [
+            { endpointTypeId },
+          ])
+        )
+      ).then((endpointClusterInfos) =>
+        // sort by name
+        endpointClusterInfos.map((clus) =>
+          clus.sort((a, b) => a.name.localeCompare(b.name))
+        )
+      )
+
+      resp.newState = []
+      endpointTypeIdList.forEach((endpointTypeId, index) => {
+        resp.newState.push({
+          endpointTypeId: endpointTypeId,
+          attributes: newEndpointClusterInfos[index],
+        })
+      })
+
+      response.status(StatusCodes.OK).json(resp)
+    }
   }
 }
 
@@ -456,7 +586,7 @@ function httpPostUnifyClustersAcrossEndpoints(db) {
           })
         )
 
-      let oldEndpointClusterInfos = await Promise.all(
+      let oldEndpointAttributesInfo = await Promise.all(
         endpointTypeIdList.map((endpointTypeId) =>
           queryEndpointType.selectAllClustersDetailsFromEndpointTypes(db, [
             { endpointTypeId },
@@ -488,7 +618,7 @@ function httpPostUnifyClustersAcrossEndpoints(db) {
       endpointTypeIdList.forEach((endpointTypeId, index) => {
         resp.oldState.push({
           endpointTypeId: endpointTypeId,
-          clusters: oldEndpointClusterInfos[index],
+          clusters: oldEndpointAttributesInfo[index],
         })
       })
 
@@ -513,23 +643,23 @@ function httpPostUnifyClustersAcrossEndpoints(db) {
         })
       })
 
-      env.logInfo(`Unifying cluster states across endpoint`)
-      env.logInfo(`Before:`)
-      resp.oldState.forEach((ep) => {
-        ep.clusters.forEach((clus) => {
-          env.logInfo(
-            `ep: ${ep}, clus_id:${clus.id}, name:${clus.name}, side:${clus.side}, enabled:${clus.enabled}`
-          )
-        })
-      })
-      env.logInfo(`After:`)
-      resp.newState.forEach((ep) => {
-        ep.clusters.forEach((clus) => {
-          env.logInfo(
-            `ep_id: ${ep.endpointTypeId}, clus_id:${clus.id}, name:${clus.name}, side:${clus.side}, enabled:${clus.enabled}`
-          )
-        })
-      })
+      // env.logInfo(`Unifying cluster states across endpoint`)
+      // env.logInfo(`Before:`)
+      // resp.oldState.forEach((ep) => {
+      //   ep.clusters.forEach((clus) => {
+      //     env.logInfo(
+      //       `ep_id: ${ep.endpointTypeId}, clus_id:${clus.id}, name:${clus.name}, side:${clus.side}, enabled:${clus.enabled}`
+      //     )
+      //   })
+      // })
+      // env.logInfo(`After:`)
+      // resp.newState.forEach((ep) => {
+      //   ep.clusters.forEach((clus) => {
+      //     env.logInfo(
+      //       `ep_id: ${ep.endpointTypeId}, clus_id:${clus.id}, name:${clus.name}, side:${clus.side}, enabled:${clus.enabled}`
+      //     )
+      //   })
+      // })
       response.status(StatusCodes.OK).json(resp)
     }
   }

--- a/src-electron/zcl/zcl-loader.js
+++ b/src-electron/zcl/zcl-loader.js
@@ -242,11 +242,13 @@ async function qualifyZclFile(
  * @returns Promise to deal with the post-loading cleanup.
  */
 async function processZclPostLoading(db, packageId) {
+  // These queries must make sure that they update ONLY the entities under a given packageId.
+
   await queryLoader.updateEnumClusterReferences(db, packageId)
   await queryLoader.updateStructClusterReferences(db, packageId)
   await queryLoader.updateBitmapClusterReferences(db, packageId)
   await queryZcl.updateDeviceTypeEntityReferences(db, packageId)
-  return queryCommand.updateCommandRequestResponseReferences(db)
+  return queryCommand.updateCommandRequestResponseReferences(db, packageId)
 }
 
 exports.loadZcl = loadZcl

--- a/src-electron/zcl/zcl-loader.js
+++ b/src-electron/zcl/zcl-loader.js
@@ -244,9 +244,7 @@ async function qualifyZclFile(
 async function processZclPostLoading(db, packageId) {
   // These queries must make sure that they update ONLY the entities under a given packageId.
 
-  await queryLoader.updateEnumClusterReferences(db, packageId)
-  await queryLoader.updateStructClusterReferences(db, packageId)
-  await queryLoader.updateBitmapClusterReferences(db, packageId)
+  await queryLoader.updateStaticEntityReferences(db, packageId)
   await queryZcl.updateDeviceTypeEntityReferences(db, packageId)
   return queryCommand.updateCommandRequestResponseReferences(db, packageId)
 }

--- a/src/components/ZclCommandManager.vue
+++ b/src/components/ZclCommandManager.vue
@@ -28,11 +28,7 @@ limitations under the License.
     >
       <template v-slot:header="props">
         <q-tr :props="props">
-          <q-th
-            v-for="col in props.cols"
-            :key="col.name"
-            :props="props"
-          >
+          <q-th v-for="col in props.cols" :key="col.name" :props="props">
             {{ col.label }}
           </q-th>
         </q-tr>
@@ -53,18 +49,24 @@ limitations under the License.
               content-class="bg-white text-black"
               style="overflow-wrap: break-word; padding: 0px"
             >
-            <template v-slot="scope">
-              <div class="row items-center" items-center style="padding: 0px"  @click.stop="scope.cancel">
-                <q-icon
-                  name="warning"
-                  class="text-amber q-mr-sm"
-                  style="font-size: 1.5rem"
-                ></q-icon>
-                <div class="vertical-middle text-subtitle2">
-                The outgoing command is mandatory for the cluster and device type configuration you have enabled
+              <template v-slot="scope">
+                <div
+                  class="row items-center"
+                  items-center
+                  style="padding: 0px"
+                  @click.stop="scope.cancel"
+                >
+                  <q-icon
+                    name="warning"
+                    class="text-amber q-mr-sm"
+                    style="font-size: 1.5rem"
+                  ></q-icon>
+                  <div class="vertical-middle text-subtitle2">
+                    The outgoing command is mandatory for the cluster and device
+                    type configuration you have enabled
+                  </div>
                 </div>
-              </div>
-               </template>
+              </template>
             </q-popup-edit>
           </q-td>
           <q-td key="out" :props="props" auto-width>
@@ -76,8 +78,8 @@ limitations under the License.
                 (selectionClients.includes(selectedCluster.id) &&
                   props.row.source == 'client') ||
                 (selectionServers.includes(selectedCluster.id) &&
-                  props.row.source == 'server'  ||
-                  props.row.source == 'either')
+                  props.row.source == 'server') ||
+                props.row.source == 'either'
               "
               indeterminate-value="false"
               keep-color
@@ -102,8 +104,8 @@ limitations under the License.
                 (selectionServers.includes(selectedCluster.id) &&
                   props.row.source == 'client') ||
                 (selectionClients.includes(selectedCluster.id) &&
-                  props.row.source == 'server' ||
-                  props.row.source == 'either')
+                  props.row.source == 'server') ||
+                props.row.source == 'either'
               "
               @input="
                 handleCommandSelection(
@@ -118,8 +120,9 @@ limitations under the License.
           <q-td key="direction" :props="props" auto-width>{{
             props.row.source === 'client'
               ? 'Client ➞ Server'
-              : props.row.source === 'server' ? 'Server ➞ Client'
-                : "Client ↔ Server"
+              : props.row.source === 'server'
+              ? 'Server ➞ Client'
+              : 'Client ↔ Server'
           }}</q-td>
           <q-td key="commandId" :props="props" auto-width>{{
             asHex(props.row.code, 2)
@@ -182,18 +185,24 @@ export default {
   },
   methods: {
     displayCommandWarning(row) {
-      return this.isCommandRequired(row) &&
-      ((this.selectionClients.includes(this.selectedCluster.id) &&
-                  row.source == 'client') ||
-                (this.selectionServers.includes(this.selectedCluster.id) &&
-                  row.source == 'server'))
-      && !this.selectionOut.includes(this.hashCommandIdClusterId(row.id, this.selectedCluster.id)) ||
-        this.isCommandRequired(row) && (
-        (this.selectionClients.includes(this.selectedCluster.id) &&
-                  row.source == 'server') ||
-                (this.selectionServers.includes(this.selectedCluster.id) &&
-                  row.source == 'client'))
-      && !this.selectionIn.includes(this.hashCommandIdClusterId(row.id, this.selectedCluster.id))
+      return (
+        (this.isCommandRequired(row) &&
+          ((this.selectionClients.includes(this.selectedCluster.id) &&
+            row.source == 'client') ||
+            (this.selectionServers.includes(this.selectedCluster.id) &&
+              row.source == 'server')) &&
+          !this.selectionOut.includes(
+            this.hashCommandIdClusterId(row.id, this.selectedCluster.id)
+          )) ||
+        (this.isCommandRequired(row) &&
+          ((this.selectionClients.includes(this.selectedCluster.id) &&
+            row.source == 'server') ||
+            (this.selectionServers.includes(this.selectedCluster.id) &&
+              row.source == 'client')) &&
+          !this.selectionIn.includes(
+            this.hashCommandIdClusterId(row.id, this.selectedCluster.id)
+          ))
+      )
     },
     handleCommandSelection(list, listType, commandData, clusterId) {
       // We determine the ID that we need to toggle within the list.
@@ -210,7 +219,7 @@ export default {
       }
       let editContext = {
         action: 'boolean',
-        endpointTypeId: this.selectedEndpointTypeId,
+        endpointTypeIdList: this.endpointTypeIdList,
         id: commandData.id,
         value: addedValue,
         listType: listType,

--- a/src/store/zap/actions.js
+++ b/src/store/zap/actions.js
@@ -716,7 +716,6 @@ export function unifyClustersAndAttributesAcrossEndpoints(context, data) {
       endpointTypeIdList,
     })
     .then((response) => {
-      // reload UI?
       console.log(restApi.uri.unifyClustersAcrossEndpoints)
     })
 

--- a/src/util/editable-attributes-mixin.js
+++ b/src/util/editable-attributes-mixin.js
@@ -121,7 +121,7 @@ export default {
     setAttributeSelection(enable, listType, attributeData, clusterId) {
       let editContext = {
         action: 'boolean',
-        endpointTypeId: this.selectedEndpointTypeId,
+        endpointTypeIdList: this.endpointTypeIdList,
         id: attributeData.id,
         value: enable,
         listType: listType,
@@ -168,7 +168,7 @@ export default {
       if (newValue) {
         let editContext = {
           action: 'text',
-          endpointTypeId: this.selectedEndpointTypeId,
+          endpointTypeIdList: this.endpointTypeIdList,
           id: attributeData.id,
           value: newValue,
           listType: listType,
@@ -195,7 +195,7 @@ export default {
 
       let editContext = {
         action: 'boolean',
-        endpointTypeId: this.selectedEndpointTypeId,
+        endpointTypeIdList: this.endpointTypeIdList,
         id: attributeData.id,
         value: addedValue,
         listType: listType,

--- a/test/custom-cluster.test.js
+++ b/test/custom-cluster.test.js
@@ -1,0 +1,115 @@
+/**
+ *
+ *    Copyright (c) 2021 Silicon Labs
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ * @jest-environment node
+ */
+
+const dbApi = require('../src-electron/db/db-api.js')
+const zclLoader = require('../src-electron/zcl/zcl-loader.js')
+const env = require('../src-electron/util/env.ts')
+const testUtil = require('./test-util.js')
+const querySession = require('../src-electron/db/query-session.js')
+const queryPackage = require('../src-electron/db/query-package.js')
+const util = require('../src-electron/util/util.js')
+let db
+let sid
+let mfgCode = 0xbead
+
+beforeAll(async () => {
+  env.setDevelopmentEnv()
+  let file = env.sqliteTestFile('custom-cluster')
+  db = await dbApi.initDatabaseAndLoadSchema(
+    file,
+    env.schemaFile(),
+    env.zapVersion()
+  )
+  await zclLoader.loadZcl(db, env.builtinSilabsZclMetafile())
+  let userSession = await querySession.ensureZapUserAndSession(
+    db,
+    'USER',
+    'SESSION'
+  )
+  sid = userSession.sessionId
+  return util.initializeSessionPackage(db, sid, {
+    zcl: env.builtinSilabsZclMetafile(),
+    template: env.builtinTemplateMetafile(),
+  })
+}, testUtil.timeout.medium())
+
+afterAll(() => dbApi.closeDatabase(db), testUtil.timeout.short())
+
+test(
+  'Test bead cluster loading',
+  async () => {
+    x = await dbApi.dbAll(
+      db,
+      'SELECT * FROM CLUSTER WHERE MANUFACTURER_CODE = ?',
+      [mfgCode]
+    )
+    expect(x.length).toEqual(0)
+
+    x = await dbApi.dbAll(
+      db,
+      'SELECT * FROM ATTRIBUTE WHERE MANUFACTURER_CODE = ?',
+      [mfgCode]
+    )
+    expect(x.length).toEqual(0)
+
+    x = await dbApi.dbAll(
+      db,
+      'SELECT * FROM COMMAND WHERE MANUFACTURER_CODE = ?',
+      [mfgCode]
+    )
+    expect(x.length).toEqual(0)
+
+    let result = await zclLoader.loadIndividualFile(
+      db,
+      testUtil.customClusterXml,
+      sid
+    )
+    expect(result.succeeded).toBeTruthy()
+    expect(result.packageId).not.toBeNull()
+    expect(result.packageId).not.toBeUndefined()
+
+    await queryPackage.insertSessionPackage(db, sid, result.packageId, false)
+
+    x = await dbApi.dbAll(
+      db,
+      'SELECT * FROM CLUSTER WHERE MANUFACTURER_CODE = ?',
+      [mfgCode]
+    )
+    expect(x.length).toEqual(1)
+
+    x = await dbApi.dbAll(
+      db,
+      'SELECT * FROM ATTRIBUTE WHERE MANUFACTURER_CODE = ?',
+      [mfgCode]
+    )
+    expect(x.length).toEqual(2)
+
+    x = await dbApi.dbAll(
+      db,
+      'SELECT * FROM COMMAND WHERE MANUFACTURER_CODE = ?',
+      [mfgCode]
+    )
+    expect(x.length).toEqual(1)
+
+    x = await queryPackage.getSessionPackages(db, sid)
+    expect(x.length).toEqual(2)
+  },
+  testUtil.timeout.medium()
+)

--- a/test/custom-cluster.test.js
+++ b/test/custom-cluster.test.js
@@ -53,42 +53,50 @@ beforeAll(async () => {
 
 afterAll(() => dbApi.closeDatabase(db), testUtil.timeout.short())
 
-test('Test initial state of load', async () => {
-  x = await dbApi.dbAll(
-    db,
-    'SELECT * FROM CLUSTER WHERE MANUFACTURER_CODE = ?',
-    [mfgCode]
-  )
-  expect(x.length).toEqual(0)
+test(
+  'Test initial state of load',
+  async () => {
+    x = await dbApi.dbAll(
+      db,
+      'SELECT * FROM CLUSTER WHERE MANUFACTURER_CODE = ?',
+      [mfgCode]
+    )
+    expect(x.length).toEqual(0)
 
-  x = await dbApi.dbAll(
-    db,
-    'SELECT * FROM ATTRIBUTE WHERE MANUFACTURER_CODE = ?',
-    [mfgCode]
-  )
-  expect(x.length).toEqual(0)
+    x = await dbApi.dbAll(
+      db,
+      'SELECT * FROM ATTRIBUTE WHERE MANUFACTURER_CODE = ?',
+      [mfgCode]
+    )
+    expect(x.length).toEqual(0)
 
-  x = await dbApi.dbAll(
-    db,
-    'SELECT * FROM COMMAND WHERE MANUFACTURER_CODE = ?',
-    [mfgCode]
-  )
-  expect(x.length).toEqual(0)
-})
+    x = await dbApi.dbAll(
+      db,
+      'SELECT * FROM COMMAND WHERE MANUFACTURER_CODE = ?',
+      [mfgCode]
+    )
+    expect(x.length).toEqual(0)
+  },
+  testUtil.timeout.medium()
+)
 
-test('Load custom file and insert a package into the session', async () => {
-  let result = await zclLoader.loadIndividualFile(
-    db,
-    testUtil.customClusterXml,
-    sid
-  )
-  expect(result.succeeded).toBeTruthy()
-  expect(result.packageId).not.toBeNull()
-  expect(result.packageId).not.toBeUndefined()
+test(
+  'Load custom file and insert a package into the session',
+  async () => {
+    let result = await zclLoader.loadIndividualFile(
+      db,
+      testUtil.customClusterXml,
+      sid
+    )
+    expect(result.succeeded).toBeTruthy()
+    expect(result.packageId).not.toBeNull()
+    expect(result.packageId).not.toBeUndefined()
 
-  customPackageId = result.packageId
-  await queryPackage.insertSessionPackage(db, sid, result.packageId, false)
-})
+    customPackageId = result.packageId
+    await queryPackage.insertSessionPackage(db, sid, result.packageId, false)
+  },
+  testUtil.timeout.medium()
+)
 
 test(
   'Validate custom load and multiple packages in a session',

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -109,7 +109,5 @@ exports.totalServerAttributeCount = 2962
 exports.totalSpecCount = 24
 exports.totalEnumCount = 209
 exports.totalEnumItemCount = 1595
-exports.longTimeout = 12000
-
 exports.totalDotDotEnums = 104
 exports.totalDotDotEnumItems = 637


### PR DESCRIPTION
- clean up some REST errors
- work towards custom XML restoration: this seems very broken now, so I'm starting with adding some actual unit tests and the like
- add the endpoint equalizing feature (Jing)
- fix the several post-loading queries: turns out that custom XML was not just "broken". What was in fact "broken" was the fact that when you loadin the custom XML, the post-loading actions, who were not properly `packageId` sensitive in fact wrecked the device type and many other linkages in the schema. So all those queries had to be reworked, to properly consider the second package ID.