### PR TITLE
Add field identifier to struct item queries

### DIFF
--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -364,6 +364,7 @@ async function selectAllStructItemsById(db, id) {
       db,
       `
 SELECT
+  FIELD_IDENTIFIER,
   NAME,
   TYPE,
   STRUCT_REF,
@@ -398,6 +399,7 @@ async function selectAllStructItemsByStructName(db, name, packageId) {
       db,
       `
 SELECT
+  SI.FIELD_IDENTIFIER,
   SI.NAME,
   SI.TYPE,
   SI.STRUCT_REF,


### PR DESCRIPTION
Field identifier was being used in the sort order but not actually
present in the select part of the query. It needs to be there so the
field identifier can be used in further processing.

Tested by running Matter cert tests.