### PR TITLE
Fix generation of min/max constraints.

### DIFF
--- a/src-electron/util/types.js
+++ b/src-electron/util/types.js
@@ -49,22 +49,15 @@ async function typeSize(db, zclPackageId, type) {
 async function typeSizeAttribute(db, zclPackageId, at, defaultValue = null) {
   let sizeType;
   if (at.typeInfo) {
-    if (at.typeInfo.type == dbEnum.zclType.unknown) {
-      // We have no idea what this type really is.  Just use it as-is and hope
-      // something else in the system knows about it.  This happens in unit
-      // tests.
-      sizeType = at.type;
-    } else {
-      if (!at.typeInfo.atomicType) {
-        if (at.storage != dbEnum.storageOption.external) {
-          throw new Error(
-            `ERROR: Unknown size for non-external attribute: ${at.label} / ${at.code}`
-          );
-        }
-        return 0;
+    if (!at.typeInfo.atomicType) {
+      if (at.storage != dbEnum.storageOption.external) {
+        throw new Error(
+          `ERROR: Unknown size for non-external attribute: ${at.label} / ${at.code}`
+        );
       }
-      sizeType = at.typeInfo.atomicType;
+      return 0;
     }
+    sizeType = at.typeInfo.atomicType;
   } else {
     sizeType = at.type;
   }


### PR DESCRIPTION
We should generate these for all writable attributes that have a min
or max specified in the XML.

The test change makes sure we are able to actually query size
information for our types properly in the test.  This also allows
removing some workarounds for missing atomic type info.