### PR TITLE
Use deviceType/deviceVersion from the endpoint table instead of hardc…

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -449,8 +449,8 @@ async function collectAttributes(endpointTypes) {
     }
 
     let device = {
-      deviceId: 0,
-      deviceVersion: 1,
+      deviceId: ept.deviceIdentifier,
+      deviceVersion: ept.endpointVersion,
     }
     endpointAttributeSize = 0
     deviceList.push(device)
@@ -768,6 +768,8 @@ function endpoint_config(options) {
       let endpointTypeIds = []
       endpoints.forEach((ep) => {
         endpointTypeIds.push({
+          deviceIdentifier: ep.deviceIdentifier,
+          endpointVersion: ep.endpointVersion,
           endpointTypeId: ep.endpointTypeRef,
           endpointIdentifier: ep.endpointId,
         })
@@ -781,7 +783,9 @@ function endpoint_config(options) {
           queryEndpointType
             .selectEndpointType(db, eptId.endpointTypeId)
             .then((ept) => {
-              ept.endpointId = eptId.endpointIdentifier
+              ept.endpointId = eptId.endpointIdentifier;
+              ept.endpointVersion = eptId.endpointVersion;
+              ept.deviceIdentifier = eptId.deviceIdentifier;
               return ept
             })
         )


### PR DESCRIPTION
…oding it in helper-endpointconfig.js

#### Problem

Currently `deviceVersion` and `deviceType` are hardcoded into `helper-endpointconfig.js`
This results into the descriptor cluster `device-list` to always returns: 
```
[1638443328854] [24733:51031451] CHIP: [ZCL] ReadAttributesResponse:
[1638443328854] [24733:51031451] CHIP: [ZCL]   ClusterId: 0x0000_001D
[1638443328854] [24733:51031451] CHIP: [ZCL]   attributeId: 0x0000_0000
[1638443328854] [24733:51031451] CHIP: [ZCL]   status: Success                (0x0000)
[1638443328854] [24733:51031451] CHIP: [ZCL]   attribute TLV Type: 0x16
[1638443328854] [24733:51031451] CHIP: [TOO] OnDescriptorDeviceListListAttributeResponse: 1 entries
[1638443328854] [24733:51031451] CHIP: [TOO]   [1]: {
[1638443328854] [24733:51031451] CHIP: [TOO]     Type: 0
[1638443328854] [24733:51031451] CHIP: [TOO]     Revision: 1
[1638443328854] [24733:51031451] CHIP: [TOO]   }

```