### PR TITLE
Silabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2021.12.11",
+  "version": "2021.12.13",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2021.12.13",
+  "version": "2021.12.14",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -162,6 +162,7 @@ ON
   C.CLUSTER_ID = SC.CLUSTER_REF
 WHERE
   SC.STRUCT_REF = ?
+ORDER BY C.CODE
     `,
       [structId]
     )
@@ -268,6 +269,7 @@ async function selectStructsWithItemsImpl(db, packageId, clusterId) {
     SELECT
       S.STRUCT_ID AS STRUCT_ID,
       S.NAME AS STRUCT_NAME,
+      (SELECT COUNT(1) FROM STRUCT_CLUSTER WHERE STRUCT_CLUSTER.STRUCT_REF = S.STRUCT_ID) AS STRUCT_CLUSTER_COUNT,
       SI.NAME AS ITEM_NAME,
       SI.FIELD_IDENTIFIER AS ITEM_IDENTIFIER,
       SI.TYPE AS ITEM_TYPE,
@@ -294,6 +296,7 @@ async function selectStructsWithItemsImpl(db, packageId, clusterId) {
     SELECT
       S.STRUCT_ID AS STRUCT_ID,
       S.NAME AS STRUCT_NAME,
+      (SELECT COUNT(1) FROM STRUCT_CLUSTER WHERE STRUCT_CLUSTER.STRUCT_REF = S.STRUCT_ID) AS STRUCT_CLUSTER_COUNT,
       SI.NAME AS ITEM_NAME,
       SI.FIELD_IDENTIFIER AS ITEM_IDENTIFIER,
       SI.TYPE AS ITEM_TYPE,
@@ -332,6 +335,7 @@ async function selectStructsWithItemsImpl(db, packageId, clusterId) {
         id: value.STRUCT_ID,
         name: value.STRUCT_NAME,
         label: value.STRUCT_NAME,
+        struct_cluster_count: value.STRUCT_CLUSTER_COUNT,
         items: [],
         itemCnt: 0,
       }

--- a/src-electron/generator/helper-zcl.js
+++ b/src-electron/generator/helper-zcl.js
@@ -116,6 +116,9 @@ async function zcl_structs(options) {
   structs.forEach((st) => {
     st.struct_contains_array = false
     st.struct_is_fabric_scoped = false
+    st.has_no_clusters = st.struct_cluster_count < 1
+    st.has_one_cluster = st.struct_cluster_count == 1
+    st.has_more_than_one_cluster = st.struct_cluster_count > 1
     st.items.forEach((i) => {
       if (i.isArray) {
         st.struct_contains_array = true

--- a/src/util/common-mixin.js
+++ b/src/util/common-mixin.js
@@ -97,11 +97,7 @@ export default {
     },
     shareConfigsAcrossEndpoints: {
       get() {
-        return parseInt(
-          this.$store.state.zap.selectedGenericOptions[
-            'shareConfigsAcrossEndpoints'
-          ]
-        )
+        return false
       },
     },
     endpointTypeIdList: {

--- a/test/gen-meta.test.js
+++ b/test/gen-meta.test.js
@@ -72,7 +72,7 @@ test(
       db,
       zclContext.packageId
     )
-    expect(attributes.length).toBe(2)
+    expect(attributes.length).toBe(4)
     expect(attributes[0].name).toBe('at1')
     expect(attributes[1].name).toBe('at2')
 
@@ -94,7 +94,11 @@ test(
     )
     for (const s of structs) {
       let clusters = await queryZcl.selectStructClusters(db, s.id)
-      if (s.name == 'SimpleStruct' || s.name == 'StructWithArray') {
+      if (s.name == 'SimpleStruct') {
+        expect(clusters.length).toBe(2)
+        expect(clusters[0].code).toBe(0xabcd)
+        expect(clusters[1].code).toBe(0xabce)
+      } else if (s.name == 'StructWithArray') {
         expect(clusters.length).toBe(1)
         expect(clusters[0].code).toBe(0xabcd)
       } else {

--- a/test/resource/meta/struct.zapt
+++ b/test/resource/meta/struct.zapt
@@ -2,6 +2,7 @@
 // Struct name: {{label}}
 // Struct contains array: {{struct_contains_array}}
 // Struct contains array of structs containing an array: {{struct_contains_nested_array}}
+// Number of structs struct is associated with: {{struct_cluster_count}}
 {{#if struct_contains_nested_array}}
 // {{label}} <- contains nested array
 {{/if}}

--- a/test/resource/meta/test1.xml
+++ b/test/resource/meta/test1.xml
@@ -49,4 +49,33 @@ limitations under the License.
       <field id="3" name="arg3" type="CHAR_STRING"/>
     </event>
   </cluster>
+  <cluster>
+    <name>Test 2</name>
+    <domain>Test</domain>
+    <description>Test 2 description</description>
+    <code>0xABCE</code>
+    <define>TEST_2</define>
+    <client tick="false" init="false">false</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="AT1" type="LIST" entryType="FabricScopedStruct" writable="false" optional="true">
+      <!-- Fabric scoped attributes are lists with a struct which contains a fabric_idx field. -->
+      <description>at1</description>
+      <access op="write" role="manage" modifier="fabric-scoped"/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="AT2" type="INT16U" writable="false" optional="true" isNullable="true">
+      <description>at2</description>
+      <access modifier="fabric-sensitive"/>
+    </attribute>
+    <command source="client" code="0x01" name="TestCommand1" optional="false">
+      <description>TestCmd1</description>
+      <arg name="A" type="INT8U" isNullable="true"/>
+      <arg name="B" type="CHAR_STRING"/>
+    </command>
+    <event code="0x0001" name="HelloEvent" priority="info" side="server">
+      <description>Example test event</description>
+      <field id="1" name="arg1" type="INT8U" isNullable="true"/>
+      <field id="2" name="arg2" type="INT32U" array="true"/>
+      <field id="3" name="arg3" type="CHAR_STRING"/>
+    </event>
+  </cluster>
 </configurator>

--- a/test/resource/meta/types.xml
+++ b/test/resource/meta/types.xml
@@ -90,6 +90,7 @@ limitations under the License.
 
   <struct name="SimpleStruct">
     <cluster code="0xABCD"/>
+    <cluster code="0xABCE"/>
     <item name="a" type="UINT8U" isNullable="true"/>
     <item name="b" type="BOOLEAN"/>
     <item name="c" enum="true" type="ENUM8"/>


### PR DESCRIPTION
- remove a broken functionality for endpoint unification which broke UI endpoint editing
- add an ability to retrieve `{{struct_cluster_count}}` from inside `zcl_struct` helper