### PR TITLE
Allow negative defaults for attributes

### DIFF
--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -144,6 +144,7 @@ function httpPostAttributeUpdate(db) {
   return async (request, response) => {
     let {
       action,
+      endpointTypeId,
       endpointTypeIdList,
       id,
       value,
@@ -156,7 +157,11 @@ function httpPostAttributeUpdate(db) {
     } = request.body
 
     if (!Array.isArray(endpointTypeIdList) || !endpointTypeIdList.length) {
-      response.status(StatusCodes.BAD_REQUEST).json()
+      if (endpointTypeId == 'undefined') {
+          response.status(StatusCodes.BAD_REQUEST).json()
+      } else {
+          endpointTypeIdList = [endpointTypeId];
+      }
     }
 
     let paramType

--- a/src-electron/validation/validation.js
+++ b/src-electron/validation/validation.js
@@ -107,11 +107,11 @@ function validateSpecificEndpoint(endpoint) {
 //This applies to both actual numbers as well as octet strings.
 function isValidNumberString(value) {
   //We test to see if the number is valid in hex. Decimals numbers also pass this test
-  return /^(0x|0X)?[0-9a-fA-F]+$/.test(value)
+  return /^(0x)?[\dA-F]+$/i.test(value) || Number.isInteger(Number(value));
 }
 
 function isValidFloat(value) {
-  return /^[0-9]*(\.)?[0-9]*$/.test(value)
+  return !/^0x/i.test(value) && !isNaN(Number(value));
 }
 
 function extractFloatValue(value) {
@@ -119,9 +119,9 @@ function extractFloatValue(value) {
 }
 
 function extractIntegerValue(value) {
-  if (/^[0-9]+$/.test(value)) {
+  if (/^-?\d+$/.test(value)) {
     return parseInt(value)
-  } else if (/^[0-9ABCDEF]+$/.test(value)) {
+  } else if (/^[0-9A-F]+$/i.test(value)) {
     return parseInt(value, 16)
   } else {
     return parseInt(value, 16)

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -61,14 +61,26 @@ test(
   'isValidNumberString Functions',
   () => {
     // Integer
+    expect(validation.isValidNumberString('5')).toBeTruthy()
+    expect(validation.isValidNumberString('-5')).toBeTruthy()
+    expect(validation.isValidNumberString('5.6')).toBeFalsy()
+    expect(validation.isValidNumberString('-5.6')).toBeFalsy()
+    expect(validation.isValidNumberString('.0001')).toBeFalsy()
+    expect(validation.isValidNumberString('-.0001')).toBeFalsy()
     expect(validation.isValidNumberString('0x0000')).toBeTruthy()
     expect(validation.isValidNumberString('0x0001')).toBeTruthy()
-    expect(!validation.isValidNumberString('0x00asdfajaklsf;01')).toBeTruthy()
+    expect(validation.isValidNumberString('0x000G')).toBeFalsy()
     // Float
-    expect(validation.isValidFloat('5.6')).toBeTruthy()
     expect(validation.isValidFloat('5')).toBeTruthy()
-    expect(!validation.isValidFloat('5.6....')).toBeTruthy()
+    expect(validation.isValidFloat('-5')).toBeTruthy()
+    expect(validation.isValidFloat('5.6')).toBeTruthy()
+    expect(validation.isValidFloat('-5.6')).toBeTruthy()
     expect(validation.isValidFloat('.0001')).toBeTruthy()
+    expect(validation.isValidFloat('-.0001')).toBeTruthy()
+    expect(validation.isValidFloat('0x0000')).toBeFalsy()
+    expect(validation.isValidFloat('0x0001')).toBeFalsy()
+    expect(validation.isValidFloat('0x000G')).toBeFalsy()
+    expect(validation.isValidFloat('5.6....')).toBeFalsy()
   },
   timeout.medium()
 )


### PR DESCRIPTION
#### Problem
Negative integer can not be used as defaults, since the `-` character is not taken into account.
Also ` ` is a valid `float` based on the current regex. I'm not sure if that's an expected assertion or not.

#### Changes
 * Make sure that `-` is taken into account
 * Update the `float` regex to not allow ` `, nor `.9` nor `5.` but only `1`or `1.2`.

Additionally `endpointTypeIdList` is not defined into the request body for me when I try to edit an attribute.
Since `endpointTypeId` is defined I changed the code to understand both, but I suspect that there is some other root issue.

#Fixes 327