### PR TITLE
Fix endpoint_config handling of manufacturer-specific things.

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -412,6 +412,10 @@ function endpoint_attribute_long_defaults(options) {
   return ret
 }
 
+function asMEI(manufacturerCode, code) {
+  return "0x" + bin.int32ToHex((manufacturerCode << 16) + code);
+}
+
 /**
  * Attribute collection works like this:
  *    1.) Go over all the clusters that exist.
@@ -461,7 +465,7 @@ async function collectAttributes(endpointTypes) {
 
     ept.clusters.forEach((c) => {
       let cluster = {
-        clusterId: c.hexCode,
+        clusterId: asMEI(c.manufacturerCode, c.code),
         clusterName: c.name,
         clusterSide: c.side,
         attributeIndex: attributeIndex,
@@ -554,8 +558,8 @@ async function collectAttributes(endpointTypes) {
           let rpt = {
             direction: 'REPORTED', // or 'RECEIVED'
             endpoint: '0x' + bin.int16ToHex(ept.endpointId),
-            clusterId: c.hexCode,
-            attributeId: a.hexCode,
+            clusterId: asMEI(c.manufacturerCode, c.code),
+            attributeId: asMEI(a.manufacturerCode, a.code),
             mask: rptMask,
             mfgCode:
               a.manufacturerCode == null
@@ -597,7 +601,7 @@ async function collectAttributes(endpointTypes) {
           zap_type = "STRUCT";
         }
         let attr = {
-          id: a.hexCode, // attribute code
+          id: asMEI(a.manufacturerCode, a.code), // attribute code
           type: `ZAP_TYPE(${cHelper.asDelimitedMacro(zap_type)})`, // type
           size: typeSize, // size
           mask: mask, // array of special properties
@@ -639,8 +643,8 @@ async function collectAttributes(endpointTypes) {
           }
         }
         let command = {
-          clusterId: c.hexCode,
-          commandId: cmd.hexCode,
+          clusterId: asMEI(c.manufacturerCode, c.code),
+          commandId: asMEI(cmd.manufacturerCode, cmd.code),
           mask: mask,
           name: cmd.name,
           comment: cluster.comment,

--- a/src-electron/util/bin.ts
+++ b/src-electron/util/bin.ts
@@ -45,7 +45,7 @@ function int16ToHex(value: number, littleEndian = false) {
 }
 
 /**
- * Takes an int8 value and turns it into a hex.
+ * Takes an int32 value and turns it into a hex.
  *
  * @param {*} value
  * @returns hex string, 8 characters long without '0x'

--- a/test/endpoint-config.test.js
+++ b/test/endpoint-config.test.js
@@ -196,10 +196,10 @@ test(
       "17, 'V', 'e', 'r', 'y', ' ', 'l', 'o', 'n', 'g', ' ', 'u', 's', 'e', 'r', ' ', 'i', 'd',"
     )
     expect(epc).toContain(
-      '{ ZAP_REPORT_DIRECTION(REPORTED), 0x0029, 0x0101, 0x0000, ZAP_CLUSTER_MASK(SERVER), 0x0000, {{ 0, 65534, 0 }} }, /* lock state */'
+      '{ ZAP_REPORT_DIRECTION(REPORTED), 0x0029, 0x00000101, 0x00000000, ZAP_CLUSTER_MASK(SERVER), 0x0000, {{ 0, 65534, 0 }} }, /* lock state */'
     )
     expect(epc).toContain(
-      '{ 0x0004, ZAP_TYPE(CHAR_STRING), 33, ZAP_ATTRIBUTE_MASK(TOKENIZE), ZAP_LONG_DEFAULTS_INDEX(0) }'
+      '{ 0x00000004, ZAP_TYPE(CHAR_STRING), 33, ZAP_ATTRIBUTE_MASK(TOKENIZE), ZAP_LONG_DEFAULTS_INDEX(0) }'
     )
     expect(epc.includes(bin.hexToCBytes(bin.stringToHex('Very long user id'))))
     expect(epc).toContain('#define FIXED_NETWORKS { 1, 1, 2 }')
@@ -209,10 +209,10 @@ test(
     expect(epc).toContain('#define FIXED_ENDPOINT_TYPES { 0, 1, 2 }')
     expect(epc).toContain('#define GENERATED_DEFAULTS_COUNT (12)')
     expect(epc).toContain(
-      '{ ZAP_REPORT_DIRECTION(REPORTED), 0x002A, 0x0701, 0x0002, ZAP_CLUSTER_MASK(CLIENT), 0x0000, {{ 2, 12, 4 }} }'
+      '{ ZAP_REPORT_DIRECTION(REPORTED), 0x002A, 0x00000701, 0x00000002, ZAP_CLUSTER_MASK(CLIENT), 0x0000, {{ 2, 12, 4 }} }'
     )
     expect(epc).toContain(
-      '{ ZAP_REPORT_DIRECTION(REPORTED), 0x002A, 0x0701, 0x0003, ZAP_CLUSTER_MASK(CLIENT), 0x0000, {{ 3, 13, 6 }} }'
+      '{ ZAP_REPORT_DIRECTION(REPORTED), 0x002A, 0x00000701, 0x00000003, ZAP_CLUSTER_MASK(CLIENT), 0x0000, {{ 3, 13, 6 }} }'
     )
     expect(epc).toContain(
       `17, 'T', 'e', 's', 't', ' ', 'm', 'a', 'n', 'u', 'f', 'a', 'c', 't', 'u', 'r', 'e', 'r',`


### PR DESCRIPTION
Matter uses 32-bit ids, not 16-bit ones, with the high 16 bits
representing the manufacturer id.

This might be enough to make #370 not be a high priority issue.