### PR TITLE
Add a storage policy for attributes.

### DIFF
--- a/src-electron/db/query-impexp.js
+++ b/src-electron/db/query-impexp.js
@@ -434,7 +434,8 @@ async function importAttributeForEndpointType(
   let selectAttributeQuery = `
 SELECT 
   A.ATTRIBUTE_ID,
-  A.REPORTING_POLICY
+  A.REPORTING_POLICY,
+  A.STORAGE_POLICY
 FROM 
   ATTRIBUTE AS A, ENDPOINT_TYPE_CLUSTER
 WHERE 
@@ -453,12 +454,15 @@ WHERE
   let atRow = await dbApi.dbGet(db, selectAttributeQuery, selectArgs)
   let attributeId
   let reportingPolicy
+  let storagePolicy
   if (atRow == null) {
     attributeId = null
     reportingPolicy = null
+    storagePolicy = null
   } else {
     attributeId = atRow.ATTRIBUTE_ID
     reportingPolicy = atRow.REPORTING_POLICY
+    storagePolicy = atRow.STORAGE_POLICY
   }
 
   // If the spec has meanwhile changed the policies to mandatory or prohibited,
@@ -467,6 +471,10 @@ WHERE
     attribute.reportable = true
   } else if (reportingPolicy == dbEnums.reportingPolicy.prohibited) {
     attribute.reportable = false
+  }
+
+  if (storagePolicy == dbEnums.storagePolicy.attributeAccessInterface) {
+    attribute.storageOption = dbEnums.storageOption.external
   }
 
   let arg = [

--- a/src-electron/db/query-loader.js
+++ b/src-electron/db/query-loader.js
@@ -141,6 +141,7 @@ INSERT INTO ATTRIBUTE (
   DEFAULT_VALUE,
   IS_OPTIONAL,
   REPORTING_POLICY,
+  STORAGE_POLICY,
   IS_NULLABLE,
   IS_SCENE_REQUIRED,
   ARRAY_TYPE,
@@ -149,7 +150,7 @@ INSERT INTO ATTRIBUTE (
   INTRODUCED_IN_REF,
   REMOVED_IN_REF
 ) VALUES (
-  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
   (SELECT SPEC_ID FROM SPEC WHERE CODE = ? AND PACKAGE_REF = ?),
   (SELECT SPEC_ID FROM SPEC WHERE CODE = ? AND PACKAGE_REF = ?)
 )`
@@ -175,6 +176,7 @@ function attributeMap(clusterId, packageId, attributes) {
     attribute.defaultValue,
     dbApi.toDbBool(attribute.isOptional),
     attribute.reportingPolicy,
+    attribute.storagePolicy,
     dbApi.toDbBool(attribute.isNullable),
     dbApi.toDbBool(attribute.isSceneRequired),
     attribute.entryType,

--- a/src-electron/db/zap-schema.sql
+++ b/src-electron/db/zap-schema.sql
@@ -263,6 +263,7 @@ CREATE TABLE IF NOT EXISTS "ATTRIBUTE" (
   "IS_SCENE_REQUIRED" integer,
   "IS_OPTIONAL" integer,
   "REPORTING_POLICY" text,
+  "STORAGE_POLICY" text,
   "IS_NULLABLE" integer,
   "ARRAY_TYPE" text,
   "MUST_USE_TIMED_WRITE" integer,

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -109,6 +109,16 @@ async function collectDataFromJsonFile(metadataFile, data) {
   returnObject.version = obj.version
   returnObject.supportCustomZclDevice = obj.supportCustomZclDevice
 
+  if ('listsUseAttributeAccessInterface' in obj) {
+    returnObject.listsUseAttributeAccessInterface =
+      obj.listsUseAttributeAccessInterface
+  }
+
+  if ('attributeAccessInterfaceAttributes' in obj) {
+    returnObject.attributeAccessInterfaceAttributes =
+      obj.attributeAccessInterfaceAttributes
+  }
+
   env.logDebug(
     `Resolving: ${returnObject.zclFiles}, version: ${returnObject.version}`
   )
@@ -522,6 +532,16 @@ function prepareCluster(cluster, context, isExtension = false) {
           attribute.$.reportingPolicy
         )
       }
+      let storagePolicy = dbEnum.storagePolicy.any
+      if (context.listsUseAttributeAccessInterface && attribute.$.entryType) {
+        storagePolicy = dbEnum.storagePolicy.attributeAccessInterface
+      } else if (
+        context.attributeAccessInterfaceAttributes &&
+        context.attributeAccessInterfaceAttributes[cluster.name] &&
+        context.attributeAccessInterfaceAttributes[cluster.name].includes(name)
+      ) {
+        storagePolicy = dbEnum.storagePolicy.attributeAccessInterface
+      }
       let att = {
         code: parseInt(attribute.$.code),
         manufacturerCode: attribute.$.manufacturerCode,
@@ -546,6 +566,7 @@ function prepareCluster(cluster, context, isExtension = false) {
         defaultValue: attribute.$.default,
         isOptional: attribute.$.optional == 'true',
         reportingPolicy: reportingPolicy,
+        storagePolicy: storagePolicy,
         isSceneRequired: attribute.$.sceneRequired == 'true',
         introducedIn: attribute.$.introducedIn,
         removedIn: attribute.$.removedIn,

--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -138,6 +138,24 @@ const reportingPolicy = {
 
 exports.reportingPolicy = reportingPolicy
 
+const storagePolicy = {
+  // Allow any storage policy to be used in the UI
+  any: 'any',
+  // Must use external storage and bypasses attribute store altogether.
+  attributeAccessInterface: 'attributeAccessInterface',
+  resolve: (txt) => {
+    switch (txt) {
+      case storagePolicy.any:
+      case storagePolicy.attributeAccess:
+        return txt
+      default:
+        return storagePolicy.any
+    }
+  },
+}
+
+exports.storagePolicy = storagePolicy
+
 // When SDK supports a custom device, these are the default values for it.
 exports.customDevice = {
   domain: 'Custom',


### PR DESCRIPTION
Some SDK implementations want to force some specific storage policy
for attributes depending on implementation decisions.  Add some
mechanisms for doing that:

* Add a way to force all lists to have an "attributeAccessInterface"
  storage policy.
* Add a way to provide a map of attributes that have an
  "attributeAccessInterface" storage policy.

For now this policy is mapped to "External" storage for endpoint
attributes, but later on I want to add another value to that enum and
use it instead of "External", because there are some optimizations we
can do for "attributeAccessInterface" that we can't do for things that
are just "External".