### PR TITLE
Stop generating command and attribute lists for client clusters.

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -820,6 +820,13 @@ function endpoint_config(options) {
             ept.clusters = clusters // Put 'clusters' into endpoint
             let ps = []
             clusters.forEach((cl) => {
+              // No client-side attributes or commands (at least for
+              // endpoint_config purposes) in Matter.
+              if (cl.side == dbEnum.side.client) {
+                cl.attributes = []
+                cl.commands = []
+                return
+              }
               ps.push(
                 queryEndpoint
                   .selectEndpointClusterAttributes(

--- a/test/endpoint-config.test.js
+++ b/test/endpoint-config.test.js
@@ -209,12 +209,6 @@ test(
     expect(epc).toContain('#define FIXED_ENDPOINT_TYPES { 0, 1, 2 }')
     expect(epc).toContain('#define GENERATED_DEFAULTS_COUNT (12)')
     expect(epc).toContain(
-      '{ ZAP_REPORT_DIRECTION(REPORTED), 0x002A, 0x00000701, 0x00000002, ZAP_CLUSTER_MASK(CLIENT), 0x0000, {{ 2, 12, 4 }} }'
-    )
-    expect(epc).toContain(
-      '{ ZAP_REPORT_DIRECTION(REPORTED), 0x002A, 0x00000701, 0x00000003, ZAP_CLUSTER_MASK(CLIENT), 0x0000, {{ 3, 13, 6 }} }'
-    )
-    expect(epc).toContain(
       `17, 'T', 'e', 's', 't', ' ', 'm', 'a', 'n', 'u', 'f', 'a', 'c', 't', 'u', 'r', 'e', 'r',`
     )
     expect(epcLines.length).toBeGreaterThan(100)
@@ -225,7 +219,7 @@ test(
         cnt++
       }
     })
-    expect(cnt).toBe(76)
+    expect(cnt).toBe(72)
     expect(epc).toContain('#define EMBER_AF_MANUFACTURER_CODE 0x1002')
     expect(epc).toContain('#define EMBER_AF_DEFAULT_RESPONSE_POLICY_ALWAYS')
   },

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -197,7 +197,6 @@ test(
 
     // Check token IDs
     expect(header).toContain('(NVM3KEY_DOMAIN_ZIGBEE | 0xB000)')
-    expect(header).toContain('(NVM3KEY_DOMAIN_ZIGBEE | 0xB008)')
     expect(header).not.toContain('(NVM3KEY_DOMAIN_ZIGBEE | 0xB009)')
 
     // DEFINETYPES
@@ -212,8 +211,6 @@ test(
     )
 
     expect(header).toContain('uint16_t tokType_color_control_remaining_time;')
-
-    expect(header).toContain('typedef uint8_t tokType_reporting_status_client;')
 
     // DEFINETOKENS
 
@@ -294,15 +291,7 @@ test(
     )
 
     expect(header).toContain(
-      'halCommonGetToken((tokType_reporting_status_client *)ptr, TOKEN_REPORTING_STATUS_CLIENT_7);'
-    )
-
-    expect(header).toContain(
       'emberAfWriteServerAttribute(1, ZCL_BASIC_CLUSTER_ID, ZCL_APPLICATION_VERSION_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_INT8U_ATTRIBUTE_TYPE);'
-    )
-
-    expect(header).toContain(
-      'emberAfWriteClientAttribute(1, ZCL_THERMOSTAT_CLUSTER_ID, ZCL_REPORTING_STATUS_CLIENT_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_ENUM8_ATTRIBUTE_TYPE);'
     )
 
     // GENERATED_TOKEN_SAVER
@@ -323,15 +312,6 @@ test(
 
     expect(header).toContain(
       'halCommonSetToken(TOKEN_HW_VERSION_SINGLETON, data); }'
-    )
-
-    expect(header).toContain('if ( 0x0201 == clusterId )')
-    expect(header).toContain(
-      'if ( 0xFFFE == metadata->attributeId && 0x0000 == emberAfGetMfgCode(metadata) && emberAfAttributeIsClient(metadata) )'
-    )
-
-    expect(header).toContain(
-      'halCommonSetToken(TOKEN_REPORTING_STATUS_CLIENT_7, data);'
     )
 
     expect(header).toContain('if ( 1 == endpoint )')


### PR DESCRIPTION
These are not used for anything in Matter and are just taking up
space.