### PR TITLE
Remove the response-matching heuristic.

### DIFF
--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -168,6 +168,7 @@ exports.map = {
       argCountArg: x.ARG_COUNT_ARG,
       argIsNullable: x.ARG_IS_NULLABLE,
       responseRef: x.RESPONSE_REF,
+      responseName: x.RESPONSE_NAME,
       isIncoming: x.INCOMING,
       isOutgoing: x.OUTGOING,
     }

--- a/test/zcl-loader-consecutive.test.js
+++ b/test/zcl-loader-consecutive.test.js
@@ -94,9 +94,9 @@ test(
       }
       expect(totalCount).toBeGreaterThan(0)
       // This is how many commands are linked to their responses
-      expect(responsesCount).toBe(120)
+      expect(responsesCount).toBe(1)
       // This seems to be the unmatched number in our XML files.
-      expect(unmatchedRequestCount).toBe(12)
+      expect(unmatchedRequestCount).toBe(46)
       expect(x.length).toBe(testUtil.totalClusterCommandCount)
       let z = await queryCommand.selectCommandById(db, x[0].id)
       expect(z.label).toBe(x[0].label)


### PR DESCRIPTION
Matter commands now all specify explicit response="" in XML, so
we can do all matching by RESPONSE_NAME.

Also, expose RESPONSE_NAME in command queries so consumers can use it,
now that it's reliable.