### PR TITLE
Silabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ apack_zap.package
 # Backup files
 *~
 
+# Cypress screenshots and videos
+cypress/screenshots/**
+cypress/videos/**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -320,6 +320,7 @@ pipeline
                                     currentBuild.result = 'FAILURE'
                                 }
                             }
+                          deleteDir()
                         }
                     }
                 }
@@ -384,6 +385,7 @@ pipeline
                                     currentBuild.result = 'FAILURE'
                                 }
                             }
+                          deleteDir()
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -267,6 +267,7 @@ pipeline
                 stage('Creating artifact for Mac')
                 {
                     agent { label 'bgbuild-mac' }
+                    options { skipDefaultCheckout() }
                     steps
                     {
                         script

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,8 +131,7 @@ pipeline
             {
                 script
                 {
-                    // Temporarily comment this out: sh 'rm -rf ~/.zap'
-                    withEnv(['ZAP_TEST_TIMEOUT=3600000'])
+                    withEnv(['ZAP_TEST_TIMEOUT=3600000', 'ZAP_TEMPSTATE=1'])
                     {
                         sh 'xvfb-run -a npm run test'
                     }

--- a/cypress.json
+++ b/cypress.json
@@ -2,11 +2,10 @@
   "viewportWidth": 1080,
   "viewportHeight": 920,
   "video": false,
-  "testFiles": "**/*.spec.js",
   "ignoreTestFiles": [
     "**/*.test.js",
-    "**/custom_xml/custom_xml_vendor.xml",
     "**/custom_xml/custom_xml.spec.js",
-    "**/check-required-attributes.spec.js"
+    "**/*.xml",
+    "**/*.zap"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.2.18",
+  "version": "2022.2.22",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.2.14",
+  "version": "2022.2.15",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.2.22",
+  "version": "2022.2.25",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.2.15",
+  "version": "2022.2.16",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.2.11",
+  "version": "2022.2.14",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.2.16",
+  "version": "2022.2.18",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -690,7 +690,7 @@ async function startUpMainInstance(isElectron, argv) {
   if (argv._.includes('status')) {
     console.log('⛔ Server is not running.')
     logRemoteData({ zapServerStatus: 'missing' })
-    cleanExit(0)
+    cleanExit(argv.cleanupDelay, 0)
   } else if (argv._.includes('selfCheck')) {
     return startSelfCheck(argv)
   } else if (argv._.includes('analyze')) {
@@ -708,16 +708,16 @@ async function startUpMainInstance(isElectron, argv) {
       quit: true,
     }).catch((code) => {
       console.log(code)
-      cleanExit(1)
+      cleanExit(argv.cleanupDelay, 1)
     })
   } else if (argv._.includes('stop')) {
     console.log('No server running, nothing to stop.')
-    cleanExit(0)
+    cleanExit(argv.cleanupDelay, 0)
   } else if (argv._.includes('generate')) {
     return startGeneration(argv).catch((err) => {
       console.log(err)
       env.printToStderr(`Zap generation error: ${err}`)
-      cleanExit(1)
+      cleanExit(argv.cleanupDelay, 1)
     })
   } else {
     // If we run with node only, we force no UI as it won't work.
@@ -727,8 +727,8 @@ async function startUpMainInstance(isElectron, argv) {
   }
 }
 
-function cleanExit(code) {
-  util.waitFor(1000).then(() => process.exit(code))
+function cleanExit(delay, code) {
+  util.waitFor(delay).then(() => process.exit(code))
 }
 
 exports.startGeneration = startGeneration

--- a/src-electron/ui/ui-util.ts
+++ b/src-electron/ui/ui-util.ts
@@ -61,7 +61,10 @@ function openFileConfiguration(
  * @param {*} httpPort
  * @param {*} options: uiMode, debugNavBar
  */
-async function openNewConfiguration(httpPort: number, options?: WindowCreateArgs) {
+async function openNewConfiguration(
+  httpPort: number,
+  options?: WindowCreateArgs
+) {
   window.windowCreate(httpPort, options)
 }
 
@@ -103,6 +106,7 @@ function openFileDialogAndReportResult(
   } else if (options.mode == 'directory') {
     p.properties = ['openDirectory']
   }
+  p.defaultPath = options.defaultPath
   dialog.showOpenDialog(browserWindow, p).then((result) => {
     if (!result.canceled) {
       let output = {

--- a/src-electron/util/args.ts
+++ b/src-electron/util/args.ts
@@ -171,9 +171,9 @@ export function processCommandLineArguments(argv: string[]) {
       default: false,
     })
     .option('cleanupDelay', {
-      desc: 'When shutting down zap, this provides a number of millisecons to wait for SQLite to perform cleanup. Default is: 1000',
+      desc: 'When shutting down zap, this provides a number of millisecons to wait for SQLite to perform cleanup. Default is: 1500',
       type: 'number',
-      default: process.env[env.environmentVariable.cleanupDelay.name] || '1000',
+      default: process.env[env.environmentVariable.cleanupDelay.name] || '1500',
     })
     .option('reuseZapInstance', {
       desc: `When starting zap, should zap attempt to reuse an instance of previous zap already running.`,

--- a/src-electron/util/args.ts
+++ b/src-electron/util/args.ts
@@ -170,6 +170,11 @@ export function processCommandLineArguments(argv: string[]) {
       type: 'boolean',
       default: false,
     })
+    .option('cleanupDelay', {
+      desc: 'When shutting down zap, this provides a number of millisecons to wait for SQLite to perform cleanup. Default is: 1000',
+      type: 'number',
+      default: process.env[env.environmentVariable.cleanupDelay.name] || '1000',
+    })
     .option('reuseZapInstance', {
       desc: `When starting zap, should zap attempt to reuse an instance of previous zap already running.`,
       type: 'boolean',

--- a/src-electron/util/env.ts
+++ b/src-electron/util/env.ts
@@ -64,6 +64,11 @@ export const environmentVariable = {
     description:
       'If set to 1, default behavior of zap will be to reuse existing instance.',
   },
+  cleanupDelay: {
+    name: 'ZAP_CLEANUP_DELAY',
+    description:
+      'Amount of millisecons zap will wait for cleanups to perform. This is workaround for some SQLite bug. If unset, default is: 1000',
+  },
 }
 
 // builtin pino levels: trace=10, debug=20, info=30, warn=40

--- a/src-electron/util/env.ts
+++ b/src-electron/util/env.ts
@@ -67,7 +67,7 @@ export const environmentVariable = {
   cleanupDelay: {
     name: 'ZAP_CLEANUP_DELAY',
     description:
-      'Amount of millisecons zap will wait for cleanups to perform. This is workaround for some SQLite bug. If unset, default is: 1000',
+      'Amount of millisecons zap will wait for cleanups to perform. This is workaround for some SQLite bug. If unset, default is: 1500',
   },
 }
 

--- a/src-electron/util/env.ts
+++ b/src-electron/util/env.ts
@@ -389,7 +389,7 @@ export function isMatchingVersion(
  * @returns true or false, depending on match
  */
 export function versionsCheck() {
-  let expectedNodeVersion = ['v14.x.x', 'v12.x.x']
+  let expectedNodeVersion = ['v14.x.x', 'v16.x.x']
   let expectedElectronVersion = ['12.2.x']
   let nodeVersion = process.version
   let electronVersion = process.versions.electron

--- a/src-script/zap-start.js
+++ b/src-script/zap-start.js
@@ -30,22 +30,24 @@ scriptUtil
   .then(() => scriptUtil.rebuildSpaIfNeeded())
   .then(() => scriptUtil.rebuildBackendIfNeeded())
   .then(() => {
-    let cmdArgs = [
-      'electron',
-      path.join(
-        __dirname,
-        '../dist/src-electron/main-process/electron-main.js'
-      ),
-    ]
+    let plat = process.platform
+    let cmdArgs = ['electron']
+    if (plat == 'linux') {
+      // This makes it safer to run on Linux, and latest linux distros broke this.
+      cmdArgs.push('--disable-seccomp-filter-sandbox')
+    }
+    cmdArgs.push(
+      path.join(__dirname, '../dist/src-electron/main-process/electron-main.js')
+    )
 
-//     if (process.platform == 'linux') {
-//       if (!process.env.DISPLAY) {
-//         console.log(`
-// ⛔ You are on Linux and you are attempting to run zap in UI mode without DISPLAY set.
-// ⛔ Please set your DISPLAY environment variable or run zap-start.js with a command that does not require DISPLAY.`)
-//         process.exit(1)
-//       }
-//     }
+    if (process.platform == 'linux') {
+      if (!process.env.DISPLAY) {
+        console.log(`
+⛔ You are on Linux and you are attempting to run zap in UI mode without DISPLAY set.
+⛔ Please set your DISPLAY environment variable or run zap-start.js with a command that does not require DISPLAY.`)
+        process.exit(1)
+      }
+    }
     cmdArgs.push(...args)
     return scriptUtil.executeCmd(null, 'npx', cmdArgs)
   })

--- a/src-script/zap-uitest.js
+++ b/src-script/zap-uitest.js
@@ -24,6 +24,16 @@ if (process.argv.length > 2) {
   cypressMode = process.argv[2]
 }
 
+if (cypressMode == '-?') {
+  console.log(`Usage: zap-uitest.js [ MODE | -? ]
+
+This program executes the Cypress unit tests. 
+Valid modes:
+   run  -  [default] Executes all the Cypress tests in the headless mode. You might need to run via xvfb-run in a headless environment.
+   open -  Executes Cypress UI for manual run of the tests.`)
+  process.exit(0)
+}
+
 let returnCode = 0
 let svr = scriptUtil.executeCmd(null, 'npm', ['run', 'zap-devserver'])
 
@@ -47,6 +57,7 @@ cyp
 svr.then(() => {
   if (returnCode == 0) {
     console.log('😎 All done: Cypress tests passed and server shut down.')
+    process.exit(0)
   } else {
     console.log('⛔ Error: Cypress tests failed, server shut down.')
     process.exit(returnCode)

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <div style="width: 100%; height: auto">
+  <div style="width: 800px; max-width: 800px; height: 500px; max-height: 500px">
     <q-card>
       <q-card-section
         ><q-img src="~assets/zap_splash.png">

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -19,9 +19,10 @@ limitations under the License.
       <q-card-section
         ><q-img src="~assets/zap_splash.png">
           <div class="absolute-bottom text-subtitle1 text-center">
-            Version {{ version }} (fl {{ featureLevel }}, {{ date }}, #{{
+            Version {{ version }} (feature level: {{ featureLevel }}, commit #{{
               hash
-            }})
+            }}
+            from {{ date }})
             <br />
             &copy; 2020 by the authors. Released as open-source, under terms of
             Apache 2.0 license. {{ version }}

--- a/src/store/zap/mutations.js
+++ b/src/store/zap/mutations.js
@@ -1,7 +1,6 @@
 /**
  *
  *    Copyright (c) 2020 Silicon Labs
- *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
@@ -16,9 +15,12 @@
  */
 import Vue from 'vue'
 
+const reportingMinDefault = 1
+
 export const updateShowDevTools = (state) => {
   state.showDevTools = !state.showDevTools
 }
+
 export function updateInformationText(state, text) {
   state.informationText = text
 }
@@ -50,7 +52,11 @@ export function updateAttributes(state, attributes) {
       )
     }
     if (state.attributeView.reportingMin[attribute.id] === undefined) {
-      Vue.set(state.attributeView.reportingMin, attribute.id, 0)
+      Vue.set(
+        state.attributeView.reportingMin,
+        attribute.id,
+        reportingMinDefault
+      )
     }
     if (state.attributeView.reportingMax[attribute.id] === undefined) {
       Vue.set(state.attributeView.reportingMax, attribute.id, 65534)
@@ -298,7 +304,7 @@ export function resetAttributeDefaults(state) {
       attribute.defaultValue
     )
     Vue.set(state.attributeView.storageOption, attribute.id, 'ram')
-    Vue.set(state.attributeView.reportingMin, attribute.id, 0)
+    Vue.set(state.attributeView.reportingMin, attribute.id, reportingMinDefault)
     Vue.set(state.attributeView.reportingMax, attribute.id, 65534)
     Vue.set(state.attributeView.reportableChange, attribute.id, 0)
   })


### PR DESCRIPTION
- add allowances for node 16 and prefer support for node 16 over continuing support for node 12. Node 14 is still most tested against. In reality, it should work for all three versions, but if we make decisions from now on, they will be made towards support of node 16 rather than continuing support for node 12. Node 14 should still remain fully supported.
- Cleanup some Cypress issues
- Clean up few minor UI issues with dialogs.
- allow for shutdown timer to be configurable, to assist CI a bit more.
- cleanup few binary artifact build issues