### PR TITLE
Rename the badges and remove extensive testing from the release build.

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Cypress
+name: Cypress UI tests
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build & Release
+name: Build and release packages
 
 on: push
 
@@ -19,7 +19,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v3.0.0
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Prepare Linux build environment
         if: startsWith(matrix.os, 'ubuntu')
@@ -42,15 +42,6 @@ jobs:
       - run: npm rebuild libxmljs --update-binary
       - run: npm run build-spa
       - run: npm run lint
-      - run: npm run test
-        if: startsWith(matrix.os, 'ubuntu')
-      - run: xvfb-run -a npm run self-check
-        if: startsWith(matrix.os, 'ubuntu')
-      - run: npm run gen
-      - run: npm run genmatter
-      - run: npm run gendotdot
-      - run: xvfb-run -a npm run test:e2e-ci
-        if: startsWith(matrix.os, 'ubuntu')
 
       - name: Build & Release for macOS / Windows on macOS
         uses: samuelmeuli/action-electron-builder@v1.6.0

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,4 +1,4 @@
-name: SonarCloud
+name: SonarCloud scan
 on:
   push:
     branches:

--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Zap
+name: Generation and back-end tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 # ZCL Advanced Platform
 
-![Zap](https://github.com/project-chip/zap/workflows/Zap/badge.svg)
-![Cypress](https://github.com/project-chip/zap/workflows/Cypress/badge.svg)
-![SonarCloud](https://github.com/project-chip/zap/workflows/SonarCloud/badge.svg)
+![Generation and back-end tests](https://github.com/project-chip/zap/workflows/Generation%20and%20back-end%20tests/badge.svg)
+![Cypress UI tests](https://github.com/project-chip/zap/workflows/Cypress%20UI%20tests/badge.svg)
+![SonarCloud scan](https://github.com/project-chip/zap/workflows/SonarCloud/badge.svg)
+![Build and release](https://github.com/project-chip/zap/workflows/Build%20&%20Release/badge.svg)
 
 ## What is ZAP?
 


### PR DESCRIPTION
- rename the badges
- remove cypress and back-end tests from the main release workflow