### PR TITLE
Stop emitting attribute metadata for global list attributes in Matter.

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -766,6 +766,7 @@ async function collectAttributeTypeInfo(db, zclPackageId, endpointTypes) {
 }
 
 function isGlobalAttrExcludedFromMetadata(attr) {
+  // See Matter specification section "7.13. Global Elements".
   return (
     attr.manufacturerCode === null &&
     [0xfff8, 0xfff9, 0xfffa, 0xfffb].includes(attr.code)

--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -765,6 +765,13 @@ async function collectAttributeTypeInfo(db, zclPackageId, endpointTypes) {
   return endpointTypes
 }
 
+function isGlobalAttrExcludedFromMetadata(attr) {
+  return (
+    attr.manufacturerCode === null &&
+    [0xfff8, 0xfff9, 0xfffa, 0xfffb].includes(attr.code)
+  )
+}
+
 /**
  * Starts the endpoint configuration block.,
  * longDefaults: longDefaults
@@ -836,8 +843,13 @@ function endpoint_config(options) {
                     ept.id
                   )
                   .then((attributes) => {
-                    // Keep only the enabled attributes
-                    cl.attributes = attributes.filter((a) => a.isIncluded === 1)
+                    // Keep only the enabled attributes, and not the global ones
+                    // we exclude from metadata.
+                    cl.attributes = attributes.filter(
+                      (a) =>
+                        a.isIncluded === 1 &&
+                        !isGlobalAttrExcludedFromMetadata(a)
+                    )
                   })
               )
               ps.push(


### PR DESCRIPTION
The Matter stack does not expect these to have metadata, and in fact
will behave incorrectly if they do.