### PR TITLE
Fix error logging in sizeTypeAttribute.

### DIFF
--- a/src-electron/util/types.js
+++ b/src-electron/util/types.js
@@ -52,7 +52,7 @@ async function typeSizeAttribute(db, zclPackageId, at, defaultValue = null) {
     if (!at.typeInfo.atomicType) {
       if (at.storage != dbEnum.storageOption.external) {
         throw new Error(
-          `ERROR: Unknown size for non-external attribute: ${at.label} / ${at.code}`
+          `ERROR: Unknown size for non-external attribute: ${at.name} / ${at.code}`
         )
       }
       return 0


### PR DESCRIPTION
The passed-in object does not have a "label" property, it has a "name"
property.