### PR TITLE
Check for an involuntary signal error when the voluntary code error thrown is null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.4.6",
+  "version": "2022.4.14",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/src-script/script-util.js
+++ b/src-script/script-util.js
@@ -45,8 +45,15 @@ async function executeCmd(ctx, cmd, args) {
     c.on('exit', (code) => {
       if (code == 0) resolve(ctx)
       else {
-        console.log(`👎 Program ${cmd} exited with error code: ${code}`)
-        reject(code)
+        if (code) {
+          console.log(`👎 Program ${cmd} exited with error code: ${code}`)
+          reject(code)
+        } else {
+          console.log(
+            `👎 Program ${cmd} exited with signal code: ${c.signalCode}`
+          )
+          reject(c.signalCode)
+        }
       }
     })
     c.stdout.on('data', (data) => {


### PR DESCRIPTION
- This makes sure to throw a signal error when the code is null such …
- Verified that now zap regen errors out and gives a the following when it runs out of memory: 👎 Program node exited with signal code: SIGABRT
- ZAP#468