### PR TITLE
Add responseName field to clusters in endpoint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.4.28",
+  "version": "2022.5.5",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.4.29",
+  "version": "2022.4.28",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/src-electron/db/query-endpoint.js
+++ b/src-electron/db/query-endpoint.js
@@ -214,6 +214,9 @@ SELECT
   C.IS_OPTIONAL,
   C.MUST_USE_TIMED_INVOKE,
   C.RESPONSE_NAME,
+  RC.MANUFACTURER_CODE as RESPONSE_MANUFACTURER_CODE,
+  RC.CODE AS RESPONSE_CODE,
+  C.RESPONSE_REF,
   EC.INCOMING,
   EC.OUTGOING
 FROM
@@ -222,6 +225,10 @@ LEFT JOIN
   ENDPOINT_TYPE_COMMAND AS EC
 ON
   C.COMMAND_ID = EC.COMMAND_REF
+LEFT JOIN
+  COMMAND AS RC
+ON
+  RC.COMMAND_ID = C.RESPONSE_REF
 WHERE
   C.CLUSTER_REF = ?
   AND EC.ENDPOINT_TYPE_REF = ?
@@ -242,6 +249,9 @@ ORDER BY C.CODE
       isIncoming: row['INCOMING'],
       isOutgoing: row['OUTGOING'],
       responseName: row['RESPONSE_NAME'],
+      responseManufacturerCode: row['RESPONSE_MANUFACTURER_CODE'],
+      responseCode: row['RESPONSE_CODE'],
+      responseRef: row['RESPONSE_REF'],
       hexCode: '0x' + bin.int8ToHex(row['CODE']),
     }
   })

--- a/src-electron/db/query-endpoint.js
+++ b/src-electron/db/query-endpoint.js
@@ -213,6 +213,7 @@ SELECT
   C.MANUFACTURER_CODE,
   C.IS_OPTIONAL,
   C.MUST_USE_TIMED_INVOKE,
+  C.RESPONSE_NAME,
   EC.INCOMING,
   EC.OUTGOING
 FROM
@@ -240,6 +241,7 @@ ORDER BY C.CODE
       source: row['SOURCE'],
       isIncoming: row['INCOMING'],
       isOutgoing: row['OUTGOING'],
+      responseName: row['RESPONSE_NAME'],
       hexCode: '0x' + bin.int8ToHex(row['CODE']),
     }
   })

--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -788,6 +788,7 @@ async function collectAttributes(endpointTypes, options) {
           mask: mask,
           name: cmd.name,
           comment: cluster.comment,
+          responseName: cmd.responseName,
         }
         commandList.push(command)
         cluster.commands.push(command)

--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -789,6 +789,10 @@ async function collectAttributes(endpointTypes, options) {
           name: cmd.name,
           comment: cluster.comment,
           responseName: cmd.responseName,
+          responseId:
+            cmd.responseRef !== null
+              ? asMEI(cmd.responseManufacturerCode, cmd.responseCode)
+              : null,
         }
         commandList.push(command)
         cluster.commands.push(command)


### PR DESCRIPTION
Per spec (Spec 7.17.3.1, 7.17.3.2), the GeneratedCommandList are the commands that in response to another command in AcceptedCommandList

This PR will include a "responseName" in the cluster info in endpoint config, to generate the above attributes correctly.