### PR TITLE
Modify helper endpoint config 4byte default

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -617,7 +617,7 @@ async function collectAttributes(endpointTypes, options) {
         // nonempty default value to use long defaults.
         // external strings and zero-length default values.
         if (
-          defaultSize > 2 ||
+          defaultSize > 4 ||
           (types.isString(a.type) &&
             attributeDefaultValue !== undefined &&
             attributeDefaultValue !== '')

--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -528,6 +528,7 @@ async function collectAttributes(endpointTypes, options) {
   let reportList = [] // Array of { direction, endpoint, clusterId, attributeId, mask, mfgCode, minOrSource, maxOrEndpoint, reportableChangeOrTimeout }
   let longDefaultsList = [] // Array of { value, size. comment }
   let attributeIndex = 0
+  let spaceForDefaultValue = options.spaceForDefaultValue !== undefined ? options.spaceForDefaultValue : 2
 
   endpointTypes.forEach((ept) => {
     let endpoint = {
@@ -617,7 +618,7 @@ async function collectAttributes(endpointTypes, options) {
         // nonempty default value to use long defaults.
         // external strings and zero-length default values.
         if (
-          defaultSize > 4 ||
+          defaultSize > spaceForDefaultValue ||
           (types.isString(a.type) &&
             attributeDefaultValue !== undefined &&
             attributeDefaultValue !== '')


### PR DESCRIPTION
Allow for size of default value size to be configurable

defaultValue in the EmberAfDefaultOrMinMaxAttributeValue is uint16_t. For targets that have 32-bit addresses, there is wasted space in the union. We can let defaultValue be uint32_t and save on rodata region, by fitting the default value in the meta data structure itself.