### PR TITLE
More fixes for command masks in endpoint config.

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -785,28 +785,28 @@ async function collectAttributes(endpointTypes, options) {
         if (
           cmd.source == dbEnum.source.client &&
           c.side == dbEnum.side.server &&
-          (!cmd.isOptional || cmd.isIncoming)
+          cmd.isIncoming
         ) {
           mask.push('incoming_server')
         }
         if (
           cmd.source == dbEnum.source.client &&
           c.side == dbEnum.side.client &&
-          (!cmd.isOptional || cmd.isOutgoing)
+          cmd.isOutgoing
         ) {
           mask.push('outgoing_client')
         }
         if (
           cmd.source == dbEnum.source.server &&
           c.side == dbEnum.side.server &&
-          (!cmd.isOptional || cmd.isOutgoing)
+          cmd.isOutgoing
         ) {
           mask.push('outgoing_server')
         }
         if (
           cmd.source == dbEnum.source.server &&
           c.side == dbEnum.side.client &&
-          (!cmd.isOptional || cmd.isIncoming)
+          cmd.isIncoming
         ) {
           mask.push('incoming_client')
         }


### PR DESCRIPTION
We were claiming a command is "incoming" or "outgoing" even if it was
not enabled, if it was mandatory.

This led consumers that looked at that state to be out of sync with
other consumers that just looked at the actual enabled state.

This PR makes sure we treat the actual enabled state, not theoretical
mandatory-or-not status, as the source of truth.