### PR TITLE
Honor JENKINS_HOME or --jenkins argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.6.6",
+  "version": "2022.6.7",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/src-electron/util/args.ts
+++ b/src-electron/util/args.ts
@@ -156,6 +156,11 @@ export function processCommandLineArguments(argv: string[]) {
       desc: 'Sets the state directory.',
       default: process.env[env.environmentVariable.stateDir.name] || '~/.zap',
     })
+    .option('jenkins', {
+      desc: 'Assume jenkins environment, enables tempState and skipPostGeneration.',
+      type: 'boolean',
+      default: process.env[env.environmentVariable.jenkinsHome.name] != null,
+    })
     .option('tempState', {
       desc: 'Use a unique temporary directory for state',
       type: 'boolean',
@@ -217,6 +222,19 @@ For more information, see ${commonUrl.projectUrl}`
     .wrap(null)
     .parse(argv)
 
+  // Apply Jenkins logic.
+  if (ret.jenkins) {
+    console.log(
+      '🔧 Detected Jenkins environment. Making necessary adjustments.'
+    )
+    if (process.env[env.environmentVariable.skipPostGen.name] == null) {
+      ret.skipPostGen = true
+    }
+    if (process.env[env.environmentVariable.uniqueStateDir.name] == null) {
+      ret.tempState = true
+    }
+  }
+
   // Collect files that are passed as loose arguments
   let allFiles = ret._.filter((arg: string | number, index: number) => {
     if (index == 0) return false
@@ -230,9 +248,10 @@ For more information, see ${commonUrl.projectUrl}`
 
   if (ret.tempState) {
     let tempDir = fs.mkdtempSync(`${os.tmpdir()}${path.sep}zap.`)
-    console.log(`Using temporary state directory: ${tempDir}`)
+    console.log(`🔧 Using temporary state directory: ${tempDir}`)
     env.setAppDirectory(tempDir)
   } else {
+    console.log(`🔧 Using state directory: ${ret.stateDirectory}`)
     env.setAppDirectory(ret.stateDirectory)
   }
 

--- a/src-electron/util/env.ts
+++ b/src-electron/util/env.ts
@@ -69,6 +69,11 @@ export const environmentVariable = {
     description:
       'Amount of millisecons zap will wait for cleanups to perform. This is workaround for some SQLite bug. If unset, default is: 1500',
   },
+  jenkinsHome: {
+    name: 'JENKINS_HOME',
+    description:
+      'When this env variable is present, zap will assume Jenkins environment. That will assume ZAP_TEMPSTATE and ZAP_SKIP_POST_GENERATION to be 1 by default.',
+  },
 }
 
 // builtin pino levels: trace=10, debug=20, info=30, warn=40


### PR DESCRIPTION
If JENKINS_HOME environment variable is present, then automatically assume ZAP_TEMPSTATE and ZAP_SKIP_POST_GENERATION.

This is to prevent setting that up in millions of Jenkins jobs, since on CI, these should always be assumed, as it guarantees isolation and decouplement from development environment.

Idea is, that the different configurations for zap in CI, compared to development environment, can be auto-detected, instead of pestering build engineers with setting tons of environment variables.

We might want to do something like this for github actions as well, but let's do this one thing at a time.