### PR TITLE
Fix the "zap stop" functionality.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zap",
-  "version": "2022.4.6",
+  "version": "2022.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zap",
-      "version": "2022.4.6",
+      "version": "2022.6.7",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/runtime": "^7.14.6",
@@ -30,6 +30,7 @@
         "pino": "^7.9.2",
         "promised-handlebars": "^2.0.1",
         "properties": "^1.2.1",
+        "single-instance": "^0.0.1",
         "source-map-support": "^0.5.19",
         "sqlite3": "^5.0.2",
         "toposort": "^2.0.2",
@@ -29720,6 +29721,22 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true
+    },
+    "node_modules/single-instance": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/single-instance/-/single-instance-0.0.1.tgz",
+      "integrity": "sha1-7w8Gc/6YALZ1NEXZcFjSU/XUuO0=",
+      "dependencies": {
+        "rsvp": "^3.1.0"
+      }
+    },
+    "node_modules/single-instance/node_modules/rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "engines": {
+        "node": "0.12.* || 4.* || 6.* || >= 7.*"
+      }
     },
     "node_modules/sirv": {
       "version": "1.0.19",
@@ -59625,6 +59642,21 @@
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
           "dev": true
+        }
+      }
+    },
+    "single-instance": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/single-instance/-/single-instance-0.0.1.tgz",
+      "integrity": "sha1-7w8Gc/6YALZ1NEXZcFjSU/XUuO0=",
+      "requires": {
+        "rsvp": "^3.1.0"
+      },
+      "dependencies": {
+        "rsvp": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "2022.6.7",
+  "version": "2022.6.8",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",
@@ -109,6 +109,7 @@
     "pino": "^7.9.2",
     "promised-handlebars": "^2.0.1",
     "properties": "^1.2.1",
+    "single-instance": "^0.0.1",
     "source-map-support": "^0.5.19",
     "sqlite3": "^5.0.2",
     "toposort": "^2.0.2",

--- a/src-electron/main-process/main.ts
+++ b/src-electron/main-process/main.ts
@@ -20,19 +20,31 @@ require('source-map-support').install()
 
 import * as args from '../util/args'
 const env = require('../util/env')
+const util = require('../util/util')
 const startup = require('./startup')
 
 env.versionsCheck()
 env.setProductionEnv()
 
+let argv = args.processCommandLineArguments(process.argv)
+
+util.mainOrSecondaryInstance(
+  argv.reuseZapInstance,
+  () => {
+    startup.startUpMainInstance(
+      {
+        quitFunction: null,
+        uiEnableFunction: null,
+      },
+      argv
+    )
+  },
+  () => {
+    startup.startUpSecondaryInstance(null, argv)
+  }
+)
+
 // If the code is executed via 'node' and not via 'electron', then this
 // is where we end up.
-startup.startUpMainInstance(
-  {
-    quitFunction: null,
-    uiEnableFunction: null,
-  },
-  args.processCommandLineArguments(process.argv)
-)
 
 exports.loaded = true

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -563,7 +563,8 @@ function startUpSecondaryInstance(quitFunction, argv) {
   ipcClient.initAndConnectClient().then(() => {
     ipcClient.on(ipcServer.eventType.overAndOut, (data) => {
       logRemoteData(data)
-      quitFunction()
+      if (quitFunction != null) quitFunction()
+      else process.exit(0)
     })
 
     ipcClient.on(ipcServer.eventType.over, (data) => {

--- a/src-electron/ui/main-ui.ts
+++ b/src-electron/ui/main-ui.ts
@@ -25,6 +25,7 @@ const env = require('../util/env')
 const windowJs = require('./window')
 const startup = require('../main-process/startup')
 const uiUtil = require('./ui-util')
+const util = require('../util/util')
 
 env.versionsCheck()
 env.setProductionEnv()
@@ -72,18 +73,9 @@ function hookMainInstanceEvents(argv: args.Arguments) {
 }
 
 let argv = args.processCommandLineArguments(process.argv)
-let reuseZapInstance = argv.reuseZapInstance
-let canProceedWithThisInstance
 
-if (reuseZapInstance) {
-  canProceedWithThisInstance = app.requestSingleInstanceLock()
-} else {
-  canProceedWithThisInstance = true
-}
-if (canProceedWithThisInstance) {
-  hookMainInstanceEvents(argv)
-} else {
-  // The 'second-instance' event on app was triggered, we need
-  // to quit.
-  hookSecondInstanceEvents(argv)
-}
+util.mainOrSecondaryInstance(
+  argv.reuseZapInstance,
+  () => hookMainInstanceEvents(argv),
+  () => hookSecondInstanceEvents(argv)
+)

--- a/src-electron/util/util.js
+++ b/src-electron/util/util.js
@@ -36,6 +36,7 @@ const querySession = require('../db/query-session.js')
 const dbEnum = require('../../src-shared/db-enum.js')
 const { v4: uuidv4 } = require('uuid')
 const xml2js = require('xml2js')
+const singleInstance = require('single-instance')
 
 /**
  * Returns the CRC of the data that is passed.
@@ -552,6 +553,25 @@ function duration(nsDifference) {
   return out
 }
 
+/**
+ * This method returns true if the running instance is the first
+ * and main instance of the zap, and false if zap instance is already
+ * running.
+ *
+ */
+function mainOrSecondaryInstance(
+  allowSecondary,
+  mainInstanceCallback,
+  secondaryInstanceCallback
+) {
+  if (allowSecondary) {
+    let lock = new singleInstance('zap')
+    lock.lock().then(mainInstanceCallback).catch(secondaryInstanceCallback)
+  } else {
+    mainInstanceCallback()
+  }
+}
+
 exports.createBackupFile = createBackupFile
 exports.checksum = checksum
 exports.initializeSessionPackage = initializeSessionPackage
@@ -569,3 +589,4 @@ exports.getClusterExtensionDefault = getClusterExtensionDefault
 exports.parseXml = parseXml
 exports.readFileContentAndCrc = readFileContentAndCrc
 exports.duration = duration
+exports.mainOrSecondaryInstance = mainOrSecondaryInstance


### PR DESCRIPTION
Fix the problem where electron and node startups did not share the single instance logic.

https://github.com/project-chip/zap/issues/514

0. Bring in an external single-instance package, that is not electron specific.
1. Add a util method.
2. Converge both headless and UI startup through the same logic.