### PR TITLE
Add the end-of-run cleanup action to set package.json back to 0.0.0

### DIFF
--- a/src-script/build-spa.js
+++ b/src-script/build-spa.js
@@ -22,10 +22,7 @@ let startTime = process.hrtime.bigint()
 //workaround: executeCmd()/spawn() fails silently without complaining about missing path to electron
 process.env.PATH = process.env.PATH + ':/usr/local/bin/'
 
-scriptUtil
-  .rebuildSpaIfNeeded()
-  .then(() => scriptUtil.doneStamp(startTime))
-  .catch((err) => {
-    console.log(err)
-    process.exit(1)
-  })
+scriptUtil.rebuildSpaIfNeeded().catch((err) => {
+  console.log(err)
+  process.exit(1)
+})

--- a/src-script/script-util.js
+++ b/src-script/script-util.js
@@ -257,7 +257,6 @@ async function setPackageJsonVersion(date, mode) {
       if (wasChanged) {
         fs.writeFileSync(packageJson, output)
       }
-      console.log(`🔍 Version output: ${versionPrinted}`)
       resolve(wasChanged)
     })
   })
@@ -283,12 +282,14 @@ function duration(nsDifference) {
 
 /**
  * Printout of timings at the end of a script.
+ * This function also cleans up the package.json
  *
  * @param {*} startTime
  */
-function doneStamp(startTime) {
+async function doneStamp(startTime) {
   let nsDuration = process.hrtime.bigint() - startTime
   console.log(`😎 All done: ${duration(nsDuration)}.`)
+  return setPackageJsonVersion(null, 'fake')
 }
 
 /**

--- a/src-script/zap-convert.js
+++ b/src-script/zap-convert.js
@@ -70,8 +70,8 @@ scriptUtil
   .stampVersion()
   .then(() => scriptUtil.rebuildBackendIfNeeded())
   .then(() => scriptUtil.executeCmd(ctx, 'node', cli))
+  .then(() => scriptUtil.doneStamp(startTime))
   .then(() => {
-    scriptUtil.doneStamp(startTime)
     process.exit(0)
   })
   .catch((code) => {

--- a/src-script/zap-generate.js
+++ b/src-script/zap-generate.js
@@ -92,8 +92,8 @@ scriptUtil
   .stampVersion()
   .then(() => scriptUtil.rebuildBackendIfNeeded())
   .then(() => scriptUtil.executeCmd(ctx, 'node', cli))
+  .then(() => scriptUtil.doneStamp(startTime))
   .then(() => {
-    scriptUtil.doneStamp(startTime)
     process.exit(0)
   })
   .catch((code) => {

--- a/src-script/zap-start.js
+++ b/src-script/zap-start.js
@@ -76,8 +76,8 @@ scriptUtil
     cmdArgs.push(...args)
     return scriptUtil.executeCmd(null, 'npx', cmdArgs)
   })
+  .then(() => scriptUtil.doneStamp(startTime))
   .then(() => {
-    scriptUtil.doneStamp(startTime)
     process.exit(0)
   })
   .catch((err) => {

--- a/src-script/zap-versionstamp.js
+++ b/src-script/zap-versionstamp.js
@@ -18,14 +18,9 @@
 
 const scriptUtil = require('./script-util.js')
 
-let startTime = process.hrtime.bigint()
-
 //workaround: executeCmd()/spawn() fails silently without complaining about missing path to electron
 process.env.PATH = process.env.PATH + ':/usr/local/bin/'
 
-scriptUtil
-  .stampVersion()
-  .then(() => scriptUtil.doneStamp(startTime))
-  .catch((err) => {
-    console.log(err)
-  })
+scriptUtil.stampVersion().catch((err) => {
+  console.log(err)
+})


### PR DESCRIPTION
This solves a problem, that after every zap action (generate, analyze, run UI, etc), the package.json ends up in a dirty state, because scripts insert a valid version instead of a 0.0.0.

After this change, the version is cleaned back to the committed state: 0.0.0, so anyone relying on cleanliness of submodule will be ok.

We can revisit this if we ever revisit zap versioning scheme.