### PR TITLE
Clean up server-mode for concurrent use

### DIFF
--- a/apack.json
+++ b/apack.json
@@ -4,7 +4,7 @@
   "description": "Graphical configuration tool for application and libraries based on Zigbee Cluster Library.",
   "path": [".", "node_modules/.bin/", "ZAP.app/Contents/MacOS"],
   "requiredFeatureLevel": "apack.core:9",
-  "featureLevel": 75,
+  "featureLevel": 76,
   "uc.triggerExtension": "zap",
   "executable": {
     "zap:win32.x86_64": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "zaphelp": "node src-script/zap-start.js --help",
     "zap-dotdot": "node src-script/zap-start.js --logToStdout --zcl ./zcl-builtin/dotdot/library.xml",
     "zap-devserver": "node src-script/zap-start.js server --allowCors --logToStdout --gen ./test/gen-template/zigbee/gen-templates.json --reuseZapInstance",
-    "server": "node src-script/zap-start.js server --logToStdout --gen ./test/gen-template/zigbee/gen-templates.json --reuseZapInstance",
+    "server": "node src-script/zap-start.js server --logToStdout --zcl ./zcl-builtin/silabs/zcl.json  --zcl ./zcl-builtin/matter/zcl.json --gen ./test/gen-template/zigbee/gen-templates.json --reuseZapInstance",
     "stop": "node src-script/zap-start.js stop --reuseZapInstance",
     "status": "node src-script/zap-start.js status --reuseZapInstance",
     "self-check": "node src-script/zap-start.js selfCheck -g ./test/gen-template/zigbee/gen-templates.json",

--- a/src-electron/main-process/main.ts
+++ b/src-electron/main-process/main.ts
@@ -31,16 +31,13 @@ let argv = args.processCommandLineArguments(process.argv)
 util.mainOrSecondaryInstance(
   argv.reuseZapInstance,
   () => {
-    startup.startUpMainInstance(
-      {
-        quitFunction: null,
-        uiEnableFunction: null,
-      },
-      argv
-    )
+    startup.startUpMainInstance(argv, {
+      quitFunction: null,
+      uiEnableFunction: null,
+    })
   },
   () => {
-    startup.startUpSecondaryInstance(null, argv)
+    startup.startUpSecondaryInstance(argv, { quitFunction: null })
   }
 )
 

--- a/src-electron/main-process/main.ts
+++ b/src-electron/main-process/main.ts
@@ -27,12 +27,11 @@ env.versionsCheck()
 env.setProductionEnv()
 
 let argv = args.processCommandLineArguments(process.argv)
-
 util.mainOrSecondaryInstance(
   argv.reuseZapInstance,
   () => {
     startup.startUpMainInstance(argv, {
-      quitFunction: null,
+      quitFunction: () => process.exit(0),
       uiEnableFunction: null,
     })
   },

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -664,7 +664,7 @@ async function startUpMainInstance(argv, callbacks) {
     })
   } else {
     // If we run with node only, we force no UI as it won't work.
-    if (quitFunction == null) {
+    if (uiEnableFunction == null) {
       argv.noUi = true
       argv.showUrl = true
       argv.standalone = false
@@ -674,11 +674,10 @@ async function startUpMainInstance(argv, callbacks) {
     let uiEnabled = !argv.noUi
     let zapFiles = argv.zapFiles
     let port = await startNormal(quitFunction, argv)
-    let showUrl = argv.showUrl
     if (uiEnabled && uiFunction != null) {
       uiFunction(port, zapFiles, argv.uiMode, argv.standalone)
     } else {
-      if (showUrl) {
+      if (argv.showUrl) {
         // NOTE: this is parsed/used by Studio as the default landing page.
         logRemoteData(httpServer.httpServerStartupMessage())
       }

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -554,12 +554,12 @@ function logRemoteData(data) {
  *
  * @param {*} argv
  */
-function startUpSecondaryInstance(quitFunction, argv) {
+function startUpSecondaryInstance(argv, callbacks) {
   console.log('🧐 Existing instance of zap will service this request.')
   ipcClient.initAndConnectClient().then(() => {
     ipcClient.on(ipcServer.eventType.overAndOut, (data) => {
       logRemoteData(data)
-      if (quitFunction != null) quitFunction()
+      if (callbacks.quitFunction != null) callbacks.quitFunction()
       else process.exit(0)
     })
 
@@ -598,7 +598,7 @@ function quit() {
  * @param {*} quitFunction
  * @param {*} argv
  */
-async function startUpMainInstance(callbacks, argv) {
+async function startUpMainInstance(argv, callbacks) {
   let quitFunction = callbacks.quitFunction
   let uiFunction = callbacks.uiEnableFunction
   if (quitFunction != null) {

--- a/src-electron/server/ipc-server.ts
+++ b/src-electron/server/ipc-server.ts
@@ -20,6 +20,7 @@ import ipc from 'node-ipc'
 import * as env from '../util/env'
 import * as ipcTypes from '../../src-shared/types/ipc-types'
 const path = require('path')
+const os = require('os')
 const util = require('../util/util.js')
 const watchdog = require('../main-process/watchdog')
 const httpServer = require('../server/http-server.js')
@@ -47,7 +48,11 @@ const server: ipcTypes.Server = {
  * Returns the socket path for the IPC.
  */
 function socketPath() {
-  return path.join(env.appDirectory(), 'main.ipc')
+  var defaultSocketPath =
+    process.platform == 'win32'
+      ? '\\\\.\\pipe\\' + 'zap-ipc' + '-sock'
+      : path.join(os.tmpdir(), 'zap-ipc' + '.sock')
+  return defaultSocketPath
 }
 
 function log(msg: string) {

--- a/src-electron/ui/main-ui.ts
+++ b/src-electron/ui/main-ui.ts
@@ -15,10 +15,10 @@
  *    limitations under the License.
  */
 
-const { app } = require('electron')
-
 // enable stack trace to be mapped back to the correct line number in TypeScript source files.
 require('source-map-support').install()
+
+const { app } = require('electron')
 
 import * as args from '../util/args'
 const env = require('../util/env')
@@ -31,7 +31,11 @@ env.versionsCheck()
 env.setProductionEnv()
 
 function hookSecondInstanceEvents(argv: args.Arguments) {
-  app.whenReady().then(() => startup.startUpSecondaryInstance(app.quit, argv))
+  app
+    .whenReady()
+    .then(() =>
+      startup.startUpSecondaryInstance(argv, { quitFunction: app.quit })
+    )
 }
 
 /**
@@ -41,13 +45,10 @@ function hookMainInstanceEvents(argv: args.Arguments) {
   app
     .whenReady()
     .then(() =>
-      startup.startUpMainInstance(
-        {
-          quitFunction: app.quit,
-          uiEnableFunction: uiUtil.enableUi,
-        },
-        argv
-      )
+      startup.startUpMainInstance(argv, {
+        quitFunction: app.quit,
+        uiEnableFunction: uiUtil.enableUi,
+      })
     )
     .catch((err) => {
       console.log(err)


### PR DESCRIPTION
1. Make the IPC socket reused the same way as the lock instance socket is reused.
2. Cleanup the code a bit.
3. Allow IDE to pick up tests by increasing feature level.
4. By default load all the data.
5. Fix the problem with hanging in the client generation case.