### PR TITLE
SDK-wide regen via sdk.json file

### DIFF
--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -45,3 +45,4 @@ jobs:
       - run: npm run genmatter
       - run: npm run gendotdot
       - run: npm run genmeta
+      - run: npm run metasdk

--- a/apack.json
+++ b/apack.json
@@ -4,7 +4,7 @@
   "description": "Graphical configuration tool for application and libraries based on Zigbee Cluster Library.",
   "path": [".", "node_modules/.bin/", "ZAP.app/Contents/MacOS"],
   "requiredFeatureLevel": "apack.core:9",
-  "featureLevel": 76,
+  "featureLevel": 77,
   "uc.triggerExtension": "zap",
   "executable": {
     "zap:win32.x86_64": {

--- a/docs/sdk-integration.md
+++ b/docs/sdk-integration.md
@@ -22,6 +22,8 @@ These two categories are decoupled and loaded separately, mostly because their m
 
 The second category (generation templates and extesions), however, follow the SDK itself. The generation templates will change, if the embedded code that they are targetting changes. Hence the breakup into these two categories.
 
+- **sdk.json**: This json file is a shortcut to the previous two meta-data elements. It allows for a single file to be used as an interface to one or more ZCL metafiles and generation templates. It can also list `*.zap` files which can be used to target automatic regeneration. See example under `test/resource/meta/sdk.json`.
+
 ## ZCL metafiles
 
 The ZAP tool loads the ZCL metadata starting from the top-level ZCL metafile.

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "pkg": "npm run build && npx pkg --out-path dist/ --compress GZip .",
     "pkg:linux": "npm run build && npx pkg -t node16-linux-x64 --output dist/zap-linux --compress GZip .",
     "pkg:win": "npm run build && npx pkg -t node16-win-x64 --output dist/zap-win.exe --compress GZip .",
-    "pkg:mac": "npm run build && npx pkg -t node16-macos-x64 --output dist/zap-macos --compress GZip ."
+    "pkg:mac": "npm run build && npx pkg -t node16-macos-x64 --output dist/zap-macos --compress GZip .",
+    "mattersdk": "node src-script/zap-start.js regenerateSdk --sdk ~/git/matter/scripts/tools/sdk.json"
   },
   "dependencies": {
     "@babel/runtime": "^7.14.6",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "pkg:linux": "npm run build && npx pkg -t node16-linux-x64 --output dist/zap-linux --compress GZip .",
     "pkg:win": "npm run build && npx pkg -t node16-win-x64 --output dist/zap-win.exe --compress GZip .",
     "pkg:mac": "npm run build && npx pkg -t node16-macos-x64 --output dist/zap-macos --compress GZip .",
-    "mattersdk": "node src-script/zap-start.js regenerateSdk --sdk ~/git/matter/scripts/tools/sdk.json"
+    "mattersdk": "node src-script/zap-start.js regenerateSdk --sdk ~/git/matter/scripts/tools/sdk.json",
+    "metasdk": "node src-script/zap-start.js regenerateSdk --sdk test/resource/meta/sdk.json"
   },
   "dependencies": {
     "@babel/runtime": "^7.14.6",

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -289,6 +289,18 @@ async function startRegenerateSdk(argv, options) {
       options.logger(`⛔ ${featureLevelMatch.message}`)
       throw featureLevelMatch.message
     }
+    options.logger('🐝 Loading ZCL information')
+    for (let key of Object.keys(sdk.zcl)) {
+      options.logger(`    👈 ${sdk.zcl[key]}`)
+    }
+    options.logger('🐝 Loading Generation templates')
+    for (let key of Object.keys(sdk.templates)) {
+      options.logger(`    👈 ${sdk.templates[key]}`)
+    }
+    options.logger('🐝 Performing generation')
+    for (let gen of sdk.generation) {
+      options.logger(`    👉 ${gen.zapFile}: ${sdk.zapFiles[gen.zapFile]}`)
+    }
     options.logger('😎 Regeneration done!')
   }
   if (options.quitFunction != null) options.quitFunction()

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -330,6 +330,7 @@ async function startRegenerateSdk(argv, options) {
         pkgIds.push(gen.template)
       }
       for (let pkgId of pkgIds) {
+        options.logger(`    👉 generating: ${pkgId} => ${outputDirectory}`)
         await generatorEngine.generateAndWriteFiles(
           db,
           sessionId,

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -311,6 +311,11 @@ async function startRegenerateSdk(argv, options) {
     sdk.templatePackageId = {}
     for (let key of Object.keys(sdk.templates)) {
       options.logger(`    👈 ${sdk.templates[key]}`)
+      let loadData = await generatorEngine.loadTemplates(
+        db,
+        path.join(sdkRoot, sdk.templates[key])
+      )
+      sdk.templatePackageId[key] = loadData.packageId
     }
     options.logger('🐝 Performing generation')
     for (let gen of sdk.generation) {

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -324,10 +324,12 @@ async function startRegenerateSdk(argv, options) {
       let loaderResult = await importJs.importDataFromFile(db, inputFile)
       let sessionId = loaderResult.sessionId
       let pkgIds = []
-      if (Array.isArray(gen.template)) {
-        pkgIds.push(...gen.template)
-      } else {
-        pkgIds.push(gen.template)
+      if (gen.template != null) {
+        if (Array.isArray(gen.template)) {
+          pkgIds.push(...gen.template)
+        } else {
+          pkgIds.push(gen.template)
+        }
       }
       for (let pkgId of pkgIds) {
         options.logger(`    👉 generating: ${pkgId} => ${outputDirectory}`)
@@ -335,7 +337,15 @@ async function startRegenerateSdk(argv, options) {
           db,
           sessionId,
           sdk.templatePackageId[pkgId],
-          outputDirectory
+          outputDirectory,
+          {
+            logger: (msg) => {
+              console.log(`    ${msg}`)
+            },
+            backup: false,
+            genResultFile: false,
+            skipPostGeneration: false,
+          }
         )
       }
     }

--- a/src-electron/util/args.ts
+++ b/src-electron/util/args.ts
@@ -80,6 +80,7 @@ export function processCommandLineArguments(argv: string[]) {
     ['server', 'Run zap in a server mode.'],
     ['stop', 'Stop zap server if one is running.'],
     ['new', 'If in client mode, start a new window on a main instance.'],
+    ['regenerateSdk', 'Perform full SDK regeneration.'],
   ])
   let y = yargs
   for (let cmd of commands.entries()) {
@@ -108,6 +109,11 @@ export function processCommandLineArguments(argv: string[]) {
       alias: ['zcl', 'z'],
       type: 'array',
       default: env.builtinSilabsZclMetafile(),
+    })
+    .option('sdk', {
+      desc: 'sdk.json file to read, for operations that act on whole SDK',
+      type: 'string',
+      default: null,
     })
     .option('generationTemplate', {
       desc: 'generation template metafile (gen-template.json) to read in.',

--- a/src-electron/util/env.ts
+++ b/src-electron/util/env.ts
@@ -424,7 +424,7 @@ export function isMatchingVersion(
  */
 export function versionsCheck() {
   let expectedNodeVersion = ['v14.x.x', 'v16.x.x']
-  let expectedElectronVersion = ['17.4.7']
+  let expectedElectronVersion = ['17.4.x', '18.x.x']
   let nodeVersion = process.version
   let electronVersion = process.versions.electron
   let ret = true

--- a/src-script/gen-log-parse
+++ b/src-script/gen-log-parse
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+//
+// If you uncomment the line in `zap-generate.js` that looks like this:
+//   //  .then(() => scriptUtil.addToJsonFile('/tmp/gen.log', cmdArgs))
+// then it will produce gen.log file.
+// This script can then be used to take that file and produce a sdk.json out of it.
+//
+// Note: this was used in Matter SDK migration, but it is useful, yet not without
+// some modifications for future cases. That's why this script is commited here.
+//
+// It is NOT part of zap runtime or anything, it's just a quick hack.
+
+const fs = require('fs')
+const fsp = fs.promises
+const path = require('path')
+const os = require('os')
+
+// This points to the root of the SDK.
+const sdkRoot = path.join(os.homedir(), 'git/matter')
+
+async function read() {
+  let data = await fsp.readFile('/tmp/gen.log')
+  let json = JSON.parse(data)
+  let allParsed = []
+  for (let one of json) {
+    let parsed = {}
+    for (let x = 0; x < one.length; x++) {
+      if (one[x] == '-z') {
+        parsed.zcl = path.relative(sdkRoot, one[x + 1])
+      } else if (one[x] == '-g') {
+        parsed.gen = path.relative(sdkRoot, one[x + 1])
+      } else if (one[x] == '-i') {
+        parsed.input = path.relative(sdkRoot, one[x + 1])
+      } else if (one[x] == '-o') {
+        parsed.output = path.relative(sdkRoot, one[x + 1])
+      }
+    }
+    allParsed.push(parsed)
+  }
+
+  let final = {}
+  final.zcl = {}
+  for (let one of allParsed) {
+    if (!Object.values(final.zcl).includes(one.zcl)) {
+      let key = 'z' + Object.keys(final.zcl).length
+      if (one.zcl.includes('extensions')) {
+        key = 'main_ext'
+      } else {
+        key = 'main'
+      }
+      final.zcl[key] = one.zcl
+    }
+  }
+
+  final.templates = {}
+  for (let one of allParsed) {
+    if (!Object.values(final.templates).includes(one.gen)) {
+      let key = 't' + Object.keys(final.templates).length
+      if (one.gen.includes('java')) {
+        key = 'java'
+      } else if (one.gen.includes('python')) {
+        key = 'python'
+      } else if (one.gen.includes('darwin')) {
+        if (one.gen.includes('CHIP')) {
+          key = 'darwin-chip'
+        } else if (one.gen.includes('test')) {
+          key = 'darwin-test'
+        } else {
+          key = 'darwin'
+        }
+      } else if (one.gen.includes('chip-tool')) {
+        if (one.gen.includes('test')) {
+          key = 'chip-tool-test'
+        } else {
+          key = 'chip-tool'
+        }
+      } else if (one.gen.includes('app/common')) {
+        key = 'app-common'
+      } else if (one.gen.includes('app/tests')) {
+        key = 'app-test'
+      } else if (one.gen.includes('placeholder')) {
+        key = 'placeholder'
+      } else if (one.gen.includes('app/zap-templates')) {
+        key = 'app-zap'
+      }
+      final.templates[key] = one.gen
+    }
+  }
+
+  final.zapFiles = {}
+  for (let one of allParsed) {
+    if (!Object.values(final.zapFiles).includes(one.input)) {
+      let key = 'z' + Object.keys(final.zapFiles).length
+      if (one.input.includes('controller-clusters.zap')) {
+        key = 'controller'
+      } else if (one.input.startsWith('examples/placeholder')) {
+        if (one.input.includes('app1')) key = 'app1'
+        else key = 'app2'
+      } else if (one.input.startsWith('examples/chef')) {
+        key = path.basename(one.input, '.zap')
+        key = 'chef_' + key.substring(9, key.length - 11)
+      } else if (one.input.startsWith('examples')) {
+        key = path.basename(one.input, '.zap')
+      }
+      final.zapFiles[key] = one.input
+    }
+  }
+
+  final.generation = []
+
+  for (let one of allParsed) {
+    let out = one.output
+    let input = Object.keys(final.zapFiles).find(
+      (key) => final.zapFiles[key] === one.input
+    )
+
+    let zcl = Object.keys(final.zcl).find((key) => final.zcl[key] === one.zcl)
+
+    let template = Object.keys(final.templates).find(
+      (key) => final.templates[key] === one.gen
+    )
+
+    let thisOne = {
+      zapFile: input,
+      output: out,
+      zcl: zcl,
+      template: template,
+    }
+    // Find existing one with same zapFile and output and zcl
+    let existing = final.generation.find((x) => {
+      return (
+        x.zapFile == thisOne.zapFile &&
+        x.output == thisOne.output &&
+        x.zcl == thisOne.zcl
+      )
+    })
+    if (existing) {
+      let ct = existing.template
+      if (Array.isArray(ct)) {
+        ct.push(thisOne.template)
+      } else {
+        existing.template = [existing.template, thisOne.template]
+      }
+    } else {
+      final.generation.push(thisOne)
+    }
+
+    final.generation.sort((a, b) => {
+      let cmp = a.zapFile.localeCompare(b.zapFile)
+      if (cmp != 0) return cmp
+      cmp = a.output.localeCompare(b.output)
+      if (cmp != 0) return cmp
+
+      cmp = a.zcl.localeCompare(b.zcl)
+      if (cmp != 0) return cmp
+      return a.template.localeCompare(b.template)
+    })
+  }
+
+  console.log(JSON.stringify(final, null, 2))
+}
+
+read().then(() => {})

--- a/src-script/script-util.js
+++ b/src-script/script-util.js
@@ -306,6 +306,26 @@ function mainPath(isElectron) {
   }
 }
 
+/**
+ * Simple function that reads a JSON file representing an array,
+ * and adds an object to it. If file doesn't exist it will create it
+ * with an array containing the passed object.
+ *
+ * @param {*} file
+ * @param {*} object
+ */
+async function addToJsonFile(file, object) {
+  let json
+  if (fs.existsSync(file)) {
+    let data = await fsp.readFile(file)
+    json = JSON.parse(data)
+  } else {
+    json = []
+  }
+  json.push(object)
+  await fsp.writeFile(file, JSON.stringify(json, null, 2))
+}
+
 exports.executeCmd = executeCmd
 exports.rebuildSpaIfNeeded = rebuildSpaIfNeeded
 exports.rebuildBackendIfNeeded = rebuildBackendIfNeeded
@@ -314,3 +334,4 @@ exports.duration = duration
 exports.doneStamp = doneStamp
 exports.mainPath = mainPath
 exports.setPackageJsonVersion = setPackageJsonVersion
+exports.addToJsonFile = addToJsonFile

--- a/src-script/zap-generate.js
+++ b/src-script/zap-generate.js
@@ -35,7 +35,9 @@ console.log(`Executing: ${cmdArgs}`)
 scriptUtil
   .stampVersion()
   .then(() => scriptUtil.rebuildBackendIfNeeded())
-  .then(() => scriptUtil.addToJsonFile('/tmp/gen.log', cmdArgs))
+  // This next line is useful if your SDK is not using the sdk.json
+  // Then you regen whole SDK, and this will output the full gen.log
+  //  .then(() => scriptUtil.addToJsonFile('/tmp/gen.log', cmdArgs))
   .then(() => scriptUtil.executeCmd(null, 'npx', cmdArgs))
   .then(() => scriptUtil.doneStamp(startTime))
   .then(() => {

--- a/src-script/zap-generate.js
+++ b/src-script/zap-generate.js
@@ -21,77 +21,21 @@ const scriptUtil = require('./script-util.js')
 
 let startTime = process.hrtime.bigint()
 
-let arg = yargs
-  .option('zcl', {
-    desc: 'Specifies zcl metafile file to be used.',
-    alias: 'z',
-    type: 'string',
-    demandOption: true,
-  })
-  .option('out', {
-    desc: 'Output directory where the generated files will go.',
-    alias: 'o',
-    type: 'string',
-    demandOption: true,
-  })
-  .option('generationTemplate', {
-    desc: 'Specifies gen-template.json file to be used.',
-    alias: 'g',
-    type: 'string',
-    demandOption: true,
-  })
-  .option('in', {
-    desc: 'Input .zap file from which to read configuration.',
-    alias: 'i',
-    type: 'string',
-    demandOption: false,
-  })
-  .option('stateDirectory', {
-    desc: 'State directory',
-    type: 'string',
-    demandOption: false,
-    default: '~/.zap',
-  })
-  .option('genResultFile', {
-    desc: 'Gen result file',
-    type: 'boolean',
-    demandOption: false,
-    default: false,
-  })
-  .demandOption(
-    ['zcl', 'out', 'generationTemplate'],
-    'Please provide required options!'
-  )
-  .help()
-  .wrap(null).argv
+let args = process.argv.slice(2)
+let executable = 'node'
+let main = scriptUtil.mainPath(false)
 
-let ctx = {}
+let cmdArgs = [executable]
+cmdArgs.push(main)
+cmdArgs.push('generate')
+cmdArgs.push('--unhandled-rejections=strict')
+cmdArgs.push(...args)
 
-let cli = [
-  scriptUtil.mainPath(false),
-  'generate',
-  '--noUi',
-  '--noServer',
-  '--stateDirectory',
-  arg.stateDirectory,
-  '--zcl',
-  arg.zcl,
-  '--generationTemplate',
-  arg.generationTemplate,
-  '--out',
-  arg.out,
-]
-if (arg.genResultFile) {
-  cli.push('--genResultFile')
-}
-if (arg.in != null) {
-  cli.push(arg.in)
-}
-
+console.log(`Executing: ${cmdArgs}`)
 scriptUtil
   .stampVersion()
   .then(() => scriptUtil.rebuildBackendIfNeeded())
-  .then(() => scriptUtil.executeCmd(ctx, 'node', cli))
+  .then(() => scriptUtil.executeCmd(null, 'npx', cmdArgs))
   .then(() => scriptUtil.doneStamp(startTime))
   .then(() => {
     process.exit(0)

--- a/src-script/zap-generate.js
+++ b/src-script/zap-generate.js
@@ -35,6 +35,7 @@ console.log(`Executing: ${cmdArgs}`)
 scriptUtil
   .stampVersion()
   .then(() => scriptUtil.rebuildBackendIfNeeded())
+  .then(() => scriptUtil.addToJsonFile('/tmp/gen.log', cmdArgs))
   .then(() => scriptUtil.executeCmd(null, 'npx', cmdArgs))
   .then(() => scriptUtil.doneStamp(startTime))
   .then(() => {

--- a/src-script/zap-start.js
+++ b/src-script/zap-start.js
@@ -42,6 +42,7 @@ scriptUtil
       case 'status':
       case 'convert':
       case 'analyze':
+      case 'regenerateSdk':
         executable = 'node'
         main = scriptUtil.mainPath(false)
         break

--- a/test/resource/meta/sdk.json
+++ b/test/resource/meta/sdk.json
@@ -1,0 +1,24 @@
+{
+  "meta": {
+    "sdkRoot": ".",
+    "description": "Unit testing SDK",
+    "requiredFeatureLevel": 77
+  },
+  "zcl": {
+    "main": "zcl.json"
+  },
+  "templates": {
+    "main": "gen-test.json"
+  },
+  "zapFiles": {
+    "test": "../test-meta.zap"
+  },
+  "generation": [
+    {
+      "zapFile": "test",
+      "output": "../../../tmp",
+      "zcl": "main",
+      "template": "main"
+    }
+  ]
+}

--- a/test/resource/test-meta.zap
+++ b/test/resource/test-meta.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 62,
+  "featureLevel": 77,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -18,15 +18,16 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../zcl-builtin/silabs/zcl.json",
-      "version": "ZCL Test Data",
-      "type": "zcl-properties"
+      "path": "meta/zcl.json",
+      "type": "zcl-properties",
+      "version": 1,
+      "description": "Unit Test Meta-data"
     },
     {
       "pathRelativity": "relativeToZap",
-      "path": "../gen-template/zigbee/gen-templates.json",
-      "version": "test-v1",
-      "type": "gen-templates-json"
+      "path": "meta/gen-test.json",
+      "type": "gen-templates-json",
+      "version": "meta-test"
     }
   ],
   "endpointTypes": [
@@ -64,5 +65,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 65535
     }
-  ]
+  ],
+  "log": []
 }


### PR DESCRIPTION
This addresses some Matter issues with regeneration, and will make Matter regen both faster and more reliable.

It goes hand in hand with a commit on Matter SDK, that includes the sdk.json file and will come later. The infrastructure for it is here now though.