### PR TITLE
fix so dirty flag is not set on empty config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "zap",
-  "version": "0.0.0",
+  "version": "2022.7.21",
   "description": "Configuration tool for the Zigbee Cluster Library",
   "productName": "zap",
   "cordovaId": "",

--- a/src-electron/util/util.js
+++ b/src-electron/util/util.js
@@ -147,6 +147,7 @@ async function initializeSessionPackage(db, sessionId, options) {
                     optionDefault.optionRef
                   )
                   .then((option) => {
+                    querySession.setSessionClean(db, sessionId)
                     return querySession.insertSessionKeyValue(
                       db,
                       sessionId,

--- a/src-electron/util/util.js
+++ b/src-electron/util/util.js
@@ -147,13 +147,15 @@ async function initializeSessionPackage(db, sessionId, options) {
                     optionDefault.optionRef
                   )
                   .then((option) => {
-                    querySession.setSessionClean(db, sessionId)
                     return querySession.insertSessionKeyValue(
                       db,
                       sessionId,
                       option.optionCategory,
                       option.optionCode
                     )
+                  })
+                  .then(async () => {
+                    await querySession.setSessionClean(db, sessionId)
                   })
               })
             )


### PR DESCRIPTION
When an empty configuration is created the dirty flag is set to 0. I am still not sure if this breaks any upgrade logic but am looking into it and testing it.