### PR TITLE
Fixing packageIds issue for custom xml

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -40,11 +40,11 @@
 <dt><a href="#module_DB API_ device type database access">DB API: device type database access</a></dt>
 <dd><p>This module provides queries for device types.</p>
 </dd>
-<dt><a href="#module_DB API_ endpoint configuration queries against the database.">DB API: endpoint configuration queries against the database.</a></dt>
-<dd><p>This module provides queries for endpoint configuration.</p>
-</dd>
 <dt><a href="#module_DB API_ endpoint type queries against the database.">DB API: endpoint type queries against the database.</a></dt>
 <dd><p>This module provides queries for endpoint type.</p>
+</dd>
+<dt><a href="#module_DB API_ endpoint configuration queries against the database.">DB API: endpoint configuration queries against the database.</a></dt>
+<dd><p>This module provides queries for endpoint configuration.</p>
 </dd>
 <dt><a href="#module_DB API_ zcl database access">DB API: zcl database access</a></dt>
 <dd><p>This module provides queries for enums.</p>
@@ -61,13 +61,13 @@
 <dt><a href="#module_DB API_ package-based queries.">DB API: package-based queries.</a></dt>
 <dd><p>This module provides queries related to packages.</p>
 </dd>
-<dt><a href="#module_DB API_ session related queries.">DB API: session related queries.</a></dt>
-<dd><p>This module provides session related queries.</p>
-</dd>
 <dt><a href="#module_DB API_ zcl database access">DB API: zcl database access</a></dt>
 <dd><p>This module provides queries for ZCL static entities
 inside a single session. Things like:
    all visible clusters, etc.</p>
+</dd>
+<dt><a href="#module_DB API_ session related queries.">DB API: session related queries.</a></dt>
+<dd><p>This module provides session related queries.</p>
 </dd>
 <dt><a href="#module_DB API_ zcl database access">DB API: zcl database access</a></dt>
 <dd><p>This module provides queries for enums.</p>
@@ -494,25 +494,25 @@ things were successful or not.</p>
 ## Functions
 
 <dl>
-<dt><a href="#selectAllDiscriminators">selectAllDiscriminators(db, packageId)</a> ⇒</dt>
+<dt><a href="#selectAllDiscriminators">selectAllDiscriminators(db, packageIds)</a> ⇒</dt>
 <dd></dd>
 <dt><a href="#selectDataTypeById">selectDataTypeById(db, id)</a> ⇒</dt>
 <dd><p>Gathers the data type information of an entry based on data type id along
 with its actual type from disciminator table.</p>
 </dd>
-<dt><a href="#selectDataTypeByName">selectDataTypeByName(db, name, packageId)</a> ⇒</dt>
+<dt><a href="#selectDataTypeByName">selectDataTypeByName(db, name, packageIds)</a> ⇒</dt>
 <dd><p>Gathers the data type information of an entry based on data type name along
 with its actual type from disciminator table.</p>
 </dd>
 <dt><a href="#selectAllDataTypes">selectAllDataTypes(db, packageId)</a> ⇒</dt>
 <dd><p>Gathers All the data types</p>
 </dd>
-<dt><a href="#selectSizeFromType">selectSizeFromType(db, packageId, value)</a> ⇒</dt>
+<dt><a href="#selectSizeFromType">selectSizeFromType(db, packageIds, value)</a> ⇒</dt>
 <dd><p>Return the size of the given value whether it be a reference to it in the data
 type table in the form of a number or be it the name of the type in the form
 if string.</p>
 </dd>
-<dt><a href="#selectNumberByName">selectNumberByName(db, name, packageId)</a> ⇒</dt>
+<dt><a href="#selectNumberByName">selectNumberByName(db, name, packageIds)</a> ⇒</dt>
 <dd><p>Select an number matched by name.</p>
 </dd>
 <dt><a href="#selectNumberById">selectNumberById(db, name)</a> ⇒</dt>
@@ -527,7 +527,7 @@ if string.</p>
 <dt><a href="#selectStringById">selectStringById(db, packageId)</a> ⇒</dt>
 <dd><p>Select String by ID.</p>
 </dd>
-<dt><a href="#selectStringByName">selectStringByName(db, name, packageId)</a> ⇒</dt>
+<dt><a href="#selectStringByName">selectStringByName(db, name, packageIds)</a> ⇒</dt>
 <dd><p>Select String by name.</p>
 </dd>
 <dt><a href="#attributeDefault">attributeDefault()</a> ⇒</dt>
@@ -640,10 +640,10 @@ the indexes in attribute table.</p>
    2.) If client is included on at least one endpoint add client atts.
    3.) If server is included on at least one endpoint add server atts.</p>
 </dd>
-<dt><a href="#collectAttributeSizes">collectAttributeSizes(endpointTypes)</a> ⇒</dt>
+<dt><a href="#collectAttributeSizes">collectAttributeSizes(db, zclPackageIds, endpointTypes)</a> ⇒</dt>
 <dd><p>This function goes over all the attributes and populates sizes.</p>
 </dd>
-<dt><a href="#collectAttributeTypeInfo">collectAttributeTypeInfo(endpointTypes)</a> ⇒</dt>
+<dt><a href="#collectAttributeTypeInfo">collectAttributeTypeInfo(db, zclPackageIds, endpointTypes)</a> ⇒</dt>
 <dd><p>This function goes over all attributes and populates atomic types.</p>
 </dd>
 <dt><a href="#endpoint_config">endpoint_config(options)</a> ⇒</dt>
@@ -755,13 +755,6 @@ queries that are needed to load the attribute state</p>
 <dd><p>Function that actually loads the data out of a state object.
 Session at this point is blank, and has no packages.</p>
 </dd>
-<dt><a href="#readDataFromFile">readDataFromFile(filePath)</a> ⇒</dt>
-<dd><p>Reads the data from the file and resolves with the state object if all is good.</p>
-</dd>
-<dt><a href="#importDataFromFile">importDataFromFile(db, filePath)</a> ⇒</dt>
-<dd><p>Writes the data from the file into a new session.
-NOTE: This function does NOT initialize session packages.</p>
-</dd>
 <dt><a href="#importSessionKeyValues">importSessionKeyValues(db, sessionId, keyValuePairs)</a></dt>
 <dd><p>Resolves with a promise that imports session key values.</p>
 </dd>
@@ -771,6 +764,13 @@ with the succesfull writing into the database.</p>
 </dd>
 <dt><a href="#readJsonData">readJsonData(filePath, data)</a> ⇒</dt>
 <dd><p>Parses JSON file and creates a state object out of it, which is passed further down the chain.</p>
+</dd>
+<dt><a href="#readDataFromFile">readDataFromFile(filePath)</a> ⇒</dt>
+<dd><p>Reads the data from the file and resolves with the state object if all is good.</p>
+</dd>
+<dt><a href="#importDataFromFile">importDataFromFile(db, filePath)</a> ⇒</dt>
+<dd><p>Writes the data from the file into a new session.
+NOTE: This function does NOT initialize session packages.</p>
 </dd>
 <dt><a href="#initSessionTimers">initSessionTimers()</a></dt>
 <dd><p>Start session specific validation.</p>
@@ -962,37 +962,6 @@ that will be resolved when all the XML files are done, or rejected if at least o
 <dd><p>Toplevel function that loads the xml library file
 and orchestrates the promise chain.</p>
 </dd>
-<dt><a href="#recordToplevelPackage">recordToplevelPackage(db, metadataFile, crc)</a> ⇒</dt>
-<dd><p>Records the toplevel package information and resolves into packageId</p>
-</dd>
-<dt><a href="#recordVersion">recordVersion(db, ctx)</a></dt>
-<dd><p>Records the version into the database.</p>
-</dd>
-<dt><a href="#loadZclMetafiles">loadZclMetafiles(db, metadataFile)</a> ⇒</dt>
-<dd><p>Toplevel function that loads the zcl file and passes it off to the correct zcl loader.</p>
-</dd>
-<dt><a href="#loadZcl">loadZcl(db, metadataFile)</a> ⇒</dt>
-<dd><p>Loads individual zcl.json metafile.</p>
-</dd>
-<dt><a href="#loadIndividualFile">loadIndividualFile(db, filePath, sessionId)</a></dt>
-<dd><p>Load individual custom XML files.</p>
-</dd>
-<dt><a href="#bindValidationScript">bindValidationScript(db, basePackageId)</a></dt>
-<dd><p>This function creates a validator function with signatuee fn(stringToValidateOn)</p>
-</dd>
-<dt><a href="#getSchemaAndValidationScript">getSchemaAndValidationScript(db, basePackageId)</a></dt>
-<dd><p>Returns an object with zclSchema and zclValidation elements.</p>
-</dd>
-<dt><a href="#qualifyZclFile">qualifyZclFile(db, info, parentPackageId)</a> ⇒</dt>
-<dd><p>Promises to qualify whether zcl file needs to be reloaded.
-If yes, the it will resolve with {filePath, data, packageId}
-If not, then it will resolve with {error}</p>
-</dd>
-<dt><a href="#processZclPostLoading">processZclPostLoading(db)</a> ⇒</dt>
-<dd><p>Promises to perform a post loading step.</p>
-</dd>
-<dt><a href="#getDiscriminatorMap">getDiscriminatorMap(db, packageId)</a> ⇒</dt>
-<dd></dd>
 <dt><a href="#collectDataFromJsonFile">collectDataFromJsonFile(ctx)</a> ⇒</dt>
 <dd><p>Promises to read the JSON file and resolve all the data.</p>
 </dd>
@@ -1054,52 +1023,52 @@ attributes and commands in a same way as cluster or clusterExtension</p>
 <dt><a href="#prepareDataType">prepareDataType(a, dataType, typeMap)</a> ⇒</dt>
 <dd><p>Prepare Data Types for database table insertion.</p>
 </dd>
-<dt><a href="#processDataType">processDataType(db, filePath, packageId, data, dataType)</a> ⇒</dt>
+<dt><a href="#processDataType">processDataType(db, filePath, packageId, knownPackages, data, dataType)</a> ⇒</dt>
 <dd><p>Processes Data Type.</p>
 </dd>
 <dt><a href="#prepareNumber">prepareNumber(a, dataType)</a> ⇒</dt>
 <dd><p>Prepare numbers for database table insertion.</p>
 </dd>
-<dt><a href="#processNumber">processNumber(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processNumber">processNumber(db, filePath, packageId, knownPackages, data)</a> ⇒</dt>
 <dd><p>Processes Numbers.</p>
 </dd>
 <dt><a href="#prepareString">prepareString(a, dataType)</a> ⇒</dt>
 <dd><p>Prepare strings for database table insertion.</p>
 </dd>
-<dt><a href="#processString">processString(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processString">processString(db, filePath, packageId, knownPackages, data)</a> ⇒</dt>
 <dd><p>Processes Strings.</p>
 </dd>
 <dt><a href="#prepareEnumOrBitmapAtomic">prepareEnumOrBitmapAtomic(a, dataType)</a> ⇒</dt>
 <dd><p>Prepare enums or bitmaps for database table insertion.</p>
 </dd>
-<dt><a href="#processEnumAtomic">processEnumAtomic(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processEnumAtomic">processEnumAtomic(db, filePath, packageId, knownPackages, data)</a> ⇒</dt>
 <dd><p>Processes the enums.</p>
 </dd>
 <dt><a href="#prepareEnumOrBitmap">prepareEnumOrBitmap(a, dataType)</a> ⇒</dt>
 <dd><p>Prepare enums or bitmaps for database table insertion.</p>
 </dd>
-<dt><a href="#processEnum">processEnum(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processEnum">processEnum(db, filePath, packageId, knownPackages, data)</a> ⇒</dt>
 <dd><p>Processes the enums.</p>
 </dd>
-<dt><a href="#processEnumItems">processEnumItems(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processEnumItems">processEnumItems(db, filePath, packageId, knownPackages, data)</a> ⇒</dt>
 <dd><p>Processes the enum Items.</p>
 </dd>
-<dt><a href="#processBitmapAtomic">processBitmapAtomic(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processBitmapAtomic">processBitmapAtomic(db, filePath, packageId, knownPackages, data)</a> ⇒</dt>
 <dd><p>Processes the bitmaps.</p>
 </dd>
-<dt><a href="#processBitmap">processBitmap(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processBitmap">processBitmap(db, filePath, packageId, knownPackages, data)</a> ⇒</dt>
 <dd><p>Processes the bitmaps.</p>
 </dd>
-<dt><a href="#processBitmapFields">processBitmapFields(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processBitmapFields">processBitmapFields(db, filePath, packageId, knownPackages, data)</a> ⇒</dt>
 <dd><p>Processes the bitmap fields.</p>
 </dd>
 <dt><a href="#prepareStruct">prepareStruct(a, dataType)</a> ⇒</dt>
 <dd><p>Prepare structs for database table insertion.</p>
 </dd>
-<dt><a href="#processStruct">processStruct(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processStruct">processStruct(db, filePath, packageId, knownPackages, data)</a> ⇒</dt>
 <dd><p>Processes the structs.</p>
 </dd>
-<dt><a href="#processStructItems">processStructItems(db, filePath, packageId, data)</a> ⇒</dt>
+<dt><a href="#processStructItems">processStructItems(db, filePath, packageIds, data)</a> ⇒</dt>
 <dd><p>Processes the struct Items.</p>
 </dd>
 <dt><a href="#prepareDeviceType">prepareDeviceType(deviceType)</a> ⇒</dt>
@@ -1166,6 +1135,37 @@ e.g. for ClusterExtensions.</p>
 <dd><p>Toplevel function that loads the toplevel metafile
 and orchestrates the promise chain.</p>
 </dd>
+<dt><a href="#recordToplevelPackage">recordToplevelPackage(db, metadataFile, crc)</a> ⇒</dt>
+<dd><p>Records the toplevel package information and resolves into packageId</p>
+</dd>
+<dt><a href="#recordVersion">recordVersion(db, ctx)</a></dt>
+<dd><p>Records the version into the database.</p>
+</dd>
+<dt><a href="#loadZclMetafiles">loadZclMetafiles(db, metadataFile)</a> ⇒</dt>
+<dd><p>Toplevel function that loads the zcl file and passes it off to the correct zcl loader.</p>
+</dd>
+<dt><a href="#loadZcl">loadZcl(db, metadataFile)</a> ⇒</dt>
+<dd><p>Loads individual zcl.json metafile.</p>
+</dd>
+<dt><a href="#loadIndividualFile">loadIndividualFile(db, filePath, sessionId)</a></dt>
+<dd><p>Load individual custom XML files.</p>
+</dd>
+<dt><a href="#bindValidationScript">bindValidationScript(db, basePackageId)</a></dt>
+<dd><p>This function creates a validator function with signatuee fn(stringToValidateOn)</p>
+</dd>
+<dt><a href="#getSchemaAndValidationScript">getSchemaAndValidationScript(db, basePackageId)</a></dt>
+<dd><p>Returns an object with zclSchema and zclValidation elements.</p>
+</dd>
+<dt><a href="#qualifyZclFile">qualifyZclFile(db, info, parentPackageId)</a> ⇒</dt>
+<dd><p>Promises to qualify whether zcl file needs to be reloaded.
+If yes, the it will resolve with {filePath, data, packageId}
+If not, then it will resolve with {error}</p>
+</dd>
+<dt><a href="#processZclPostLoading">processZclPostLoading(db)</a> ⇒</dt>
+<dd><p>Promises to perform a post loading step.</p>
+</dd>
+<dt><a href="#getDiscriminatorMap">getDiscriminatorMap(db, packageIds)</a> ⇒</dt>
+<dd></dd>
 </dl>
 
 <a name="module_DB API_ External URLs."></a>
@@ -1520,24 +1520,20 @@ This module provides cache for commonly used static database queries.
   - [~isCached(key, packageId)](#module*DB API* zcl database access..isCached) ⇒
   - [~selectAtomicType(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicType)
   - [~selectAtomicById(db, packageId)](#module*DB API* zcl database access..selectAtomicById)
-  - [~createCache(db, packageId)](#module*DB API* zcl database access..createCache) ⇒
-  - [~selectAtomicTypeFromCache(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicTypeFromCache)
-  - [~selectAllAtomicsFromCache(db, packageId)](#module*DB API* zcl database access..selectAllAtomicsFromCache)
-  - [~selectAtomicByIdFromCache(db, packageId)](#module*DB API* zcl database access..selectAtomicByIdFromCache)
   - [~selectAllBitmaps(db)](#module*DB API* zcl database access..selectAllBitmaps) ⇒
   - [~selectAllEnums(db, packageId)](#module*DB API* zcl database access..selectAllEnums) ⇒
   - [~selectClusterEnums(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterEnums) ⇒
   - [~selectAllEnumItemsById(db, id)](#module*DB API* zcl database access..selectAllEnumItemsById) ⇒
   - [~selectAllEnumItems(db, packageId)](#module*DB API* zcl database access..selectAllEnumItems) ⇒
   - [~selectEnumById(db, id)](#module*DB API* zcl database access..selectEnumById) ⇒
-  - [~selectEnumByName(db, name, packageId)](#module*DB API* zcl database access..selectEnumByName) ⇒
+  - [~selectEnumByName(db, name, packageIds)](#module*DB API* zcl database access..selectEnumByName) ⇒
   - [~selectSessionClusterByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionClusterByCode) ⇒
   - [~selectAllSessionClusters(db, sessionId)](#module*DB API* zcl database access..selectAllSessionClusters) ⇒
   - [~selectSessionAttributeByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionAttributeByCode) ⇒
   - [~selectSessionCommandByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionCommandByCode) ⇒
   - [~selectClusterBitmaps(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterBitmaps) ⇒
   - [~selectAllDomains(db)](#module*DB API* zcl database access..selectAllDomains) ⇒
-  - [~selectAllStructsWithItemCount(db)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
+  - [~selectAllStructsWithItemCount(db, packageIds)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
   - [~selectStructClusters(db, structId)](#module*DB API* zcl database access..selectStructClusters) ⇒
   - [~selectEnumClusters(db, enumId)](#module*DB API* zcl database access..selectEnumClusters) ⇒
   - [~selectBitmapClusters(db, enumId)](#module*DB API* zcl database access..selectBitmapClusters) ⇒
@@ -1618,60 +1614,6 @@ Locates atomic type based on a type name. Query is not case sensitive.
 <a name="module_DB API_ zcl database access..selectAtomicById"></a>
 
 ### DB API: zcl database access~selectAtomicById(db, packageId)
-
-Retrieves atomic type by a given Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..createCache"></a>
-
-### DB API: zcl database access~createCache(db, packageId) ⇒
-
-Function that populates cache.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
-**Returns**: Newly created cache object, after it's put into the cache.
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicTypeFromCache"></a>
-
-### DB API: zcl database access~selectAtomicTypeFromCache(db, packageId, typeName)
-
-Locates atomic type based on a type name. Query is not case sensitive.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| typeName  | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAllAtomicsFromCache"></a>
-
-### DB API: zcl database access~selectAllAtomicsFromCache(db, packageId)
-
-Retrieves all atomic types under a given package Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicByIdFromCache"></a>
-
-### DB API: zcl database access~selectAtomicByIdFromCache(db, packageId)
 
 Retrieves atomic type by a given Id.
 
@@ -1768,18 +1710,18 @@ Select an enum matched by its primary key.
 
 <a name="module_DB API_ zcl database access..selectEnumByName"></a>
 
-### DB API: zcl database access~selectEnumByName(db, name, packageId) ⇒
+### DB API: zcl database access~selectEnumByName(db, name, packageIds) ⇒
 
 Select an enum matched by name.
 
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: enum or undefined
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| name      | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| name       | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectSessionClusterByCode"></a>
 
@@ -1867,7 +1809,7 @@ Retrieves all the domains in the database.
 
 <a name="module_DB API_ zcl database access..selectAllStructsWithItemCount"></a>
 
-### DB API: zcl database access~selectAllStructsWithItemCount(db) ⇒
+### DB API: zcl database access~selectAllStructsWithItemCount(db, packageIds) ⇒
 
 Retrieves all the structs in the database, including the count
 of items.
@@ -1875,9 +1817,10 @@ of items.
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: Promise that resolves with the rows of structs.
 
-| Param | Type            |
-| ----- | --------------- |
-| db    | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectStructClusters"></a>
 
@@ -2095,24 +2038,20 @@ This module provides queries for atomic type queries.
   - [~isCached(key, packageId)](#module*DB API* zcl database access..isCached) ⇒
   - [~selectAtomicType(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicType)
   - [~selectAtomicById(db, packageId)](#module*DB API* zcl database access..selectAtomicById)
-  - [~createCache(db, packageId)](#module*DB API* zcl database access..createCache) ⇒
-  - [~selectAtomicTypeFromCache(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicTypeFromCache)
-  - [~selectAllAtomicsFromCache(db, packageId)](#module*DB API* zcl database access..selectAllAtomicsFromCache)
-  - [~selectAtomicByIdFromCache(db, packageId)](#module*DB API* zcl database access..selectAtomicByIdFromCache)
   - [~selectAllBitmaps(db)](#module*DB API* zcl database access..selectAllBitmaps) ⇒
   - [~selectAllEnums(db, packageId)](#module*DB API* zcl database access..selectAllEnums) ⇒
   - [~selectClusterEnums(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterEnums) ⇒
   - [~selectAllEnumItemsById(db, id)](#module*DB API* zcl database access..selectAllEnumItemsById) ⇒
   - [~selectAllEnumItems(db, packageId)](#module*DB API* zcl database access..selectAllEnumItems) ⇒
   - [~selectEnumById(db, id)](#module*DB API* zcl database access..selectEnumById) ⇒
-  - [~selectEnumByName(db, name, packageId)](#module*DB API* zcl database access..selectEnumByName) ⇒
+  - [~selectEnumByName(db, name, packageIds)](#module*DB API* zcl database access..selectEnumByName) ⇒
   - [~selectSessionClusterByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionClusterByCode) ⇒
   - [~selectAllSessionClusters(db, sessionId)](#module*DB API* zcl database access..selectAllSessionClusters) ⇒
   - [~selectSessionAttributeByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionAttributeByCode) ⇒
   - [~selectSessionCommandByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionCommandByCode) ⇒
   - [~selectClusterBitmaps(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterBitmaps) ⇒
   - [~selectAllDomains(db)](#module*DB API* zcl database access..selectAllDomains) ⇒
-  - [~selectAllStructsWithItemCount(db)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
+  - [~selectAllStructsWithItemCount(db, packageIds)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
   - [~selectStructClusters(db, structId)](#module*DB API* zcl database access..selectStructClusters) ⇒
   - [~selectEnumClusters(db, enumId)](#module*DB API* zcl database access..selectEnumClusters) ⇒
   - [~selectBitmapClusters(db, enumId)](#module*DB API* zcl database access..selectBitmapClusters) ⇒
@@ -2193,60 +2132,6 @@ Locates atomic type based on a type name. Query is not case sensitive.
 <a name="module_DB API_ zcl database access..selectAtomicById"></a>
 
 ### DB API: zcl database access~selectAtomicById(db, packageId)
-
-Retrieves atomic type by a given Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..createCache"></a>
-
-### DB API: zcl database access~createCache(db, packageId) ⇒
-
-Function that populates cache.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
-**Returns**: Newly created cache object, after it's put into the cache.
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicTypeFromCache"></a>
-
-### DB API: zcl database access~selectAtomicTypeFromCache(db, packageId, typeName)
-
-Locates atomic type based on a type name. Query is not case sensitive.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| typeName  | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAllAtomicsFromCache"></a>
-
-### DB API: zcl database access~selectAllAtomicsFromCache(db, packageId)
-
-Retrieves all atomic types under a given package Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicByIdFromCache"></a>
-
-### DB API: zcl database access~selectAtomicByIdFromCache(db, packageId)
 
 Retrieves atomic type by a given Id.
 
@@ -2343,18 +2228,18 @@ Select an enum matched by its primary key.
 
 <a name="module_DB API_ zcl database access..selectEnumByName"></a>
 
-### DB API: zcl database access~selectEnumByName(db, name, packageId) ⇒
+### DB API: zcl database access~selectEnumByName(db, name, packageIds) ⇒
 
 Select an enum matched by name.
 
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: enum or undefined
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| name      | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| name       | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectSessionClusterByCode"></a>
 
@@ -2442,7 +2327,7 @@ Retrieves all the domains in the database.
 
 <a name="module_DB API_ zcl database access..selectAllStructsWithItemCount"></a>
 
-### DB API: zcl database access~selectAllStructsWithItemCount(db) ⇒
+### DB API: zcl database access~selectAllStructsWithItemCount(db, packageIds) ⇒
 
 Retrieves all the structs in the database, including the count
 of items.
@@ -2450,9 +2335,10 @@ of items.
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: Promise that resolves with the rows of structs.
 
-| Param | Type            |
-| ----- | --------------- |
-| db    | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectStructClusters"></a>
 
@@ -2664,24 +2550,20 @@ This module provides queries for enums.
   - [~isCached(key, packageId)](#module*DB API* zcl database access..isCached) ⇒
   - [~selectAtomicType(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicType)
   - [~selectAtomicById(db, packageId)](#module*DB API* zcl database access..selectAtomicById)
-  - [~createCache(db, packageId)](#module*DB API* zcl database access..createCache) ⇒
-  - [~selectAtomicTypeFromCache(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicTypeFromCache)
-  - [~selectAllAtomicsFromCache(db, packageId)](#module*DB API* zcl database access..selectAllAtomicsFromCache)
-  - [~selectAtomicByIdFromCache(db, packageId)](#module*DB API* zcl database access..selectAtomicByIdFromCache)
   - [~selectAllBitmaps(db)](#module*DB API* zcl database access..selectAllBitmaps) ⇒
   - [~selectAllEnums(db, packageId)](#module*DB API* zcl database access..selectAllEnums) ⇒
   - [~selectClusterEnums(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterEnums) ⇒
   - [~selectAllEnumItemsById(db, id)](#module*DB API* zcl database access..selectAllEnumItemsById) ⇒
   - [~selectAllEnumItems(db, packageId)](#module*DB API* zcl database access..selectAllEnumItems) ⇒
   - [~selectEnumById(db, id)](#module*DB API* zcl database access..selectEnumById) ⇒
-  - [~selectEnumByName(db, name, packageId)](#module*DB API* zcl database access..selectEnumByName) ⇒
+  - [~selectEnumByName(db, name, packageIds)](#module*DB API* zcl database access..selectEnumByName) ⇒
   - [~selectSessionClusterByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionClusterByCode) ⇒
   - [~selectAllSessionClusters(db, sessionId)](#module*DB API* zcl database access..selectAllSessionClusters) ⇒
   - [~selectSessionAttributeByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionAttributeByCode) ⇒
   - [~selectSessionCommandByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionCommandByCode) ⇒
   - [~selectClusterBitmaps(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterBitmaps) ⇒
   - [~selectAllDomains(db)](#module*DB API* zcl database access..selectAllDomains) ⇒
-  - [~selectAllStructsWithItemCount(db)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
+  - [~selectAllStructsWithItemCount(db, packageIds)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
   - [~selectStructClusters(db, structId)](#module*DB API* zcl database access..selectStructClusters) ⇒
   - [~selectEnumClusters(db, enumId)](#module*DB API* zcl database access..selectEnumClusters) ⇒
   - [~selectBitmapClusters(db, enumId)](#module*DB API* zcl database access..selectBitmapClusters) ⇒
@@ -2762,60 +2644,6 @@ Locates atomic type based on a type name. Query is not case sensitive.
 <a name="module_DB API_ zcl database access..selectAtomicById"></a>
 
 ### DB API: zcl database access~selectAtomicById(db, packageId)
-
-Retrieves atomic type by a given Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..createCache"></a>
-
-### DB API: zcl database access~createCache(db, packageId) ⇒
-
-Function that populates cache.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
-**Returns**: Newly created cache object, after it's put into the cache.
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicTypeFromCache"></a>
-
-### DB API: zcl database access~selectAtomicTypeFromCache(db, packageId, typeName)
-
-Locates atomic type based on a type name. Query is not case sensitive.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| typeName  | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAllAtomicsFromCache"></a>
-
-### DB API: zcl database access~selectAllAtomicsFromCache(db, packageId)
-
-Retrieves all atomic types under a given package Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicByIdFromCache"></a>
-
-### DB API: zcl database access~selectAtomicByIdFromCache(db, packageId)
 
 Retrieves atomic type by a given Id.
 
@@ -2912,18 +2740,18 @@ Select an enum matched by its primary key.
 
 <a name="module_DB API_ zcl database access..selectEnumByName"></a>
 
-### DB API: zcl database access~selectEnumByName(db, name, packageId) ⇒
+### DB API: zcl database access~selectEnumByName(db, name, packageIds) ⇒
 
 Select an enum matched by name.
 
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: enum or undefined
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| name      | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| name       | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectSessionClusterByCode"></a>
 
@@ -3011,7 +2839,7 @@ Retrieves all the domains in the database.
 
 <a name="module_DB API_ zcl database access..selectAllStructsWithItemCount"></a>
 
-### DB API: zcl database access~selectAllStructsWithItemCount(db) ⇒
+### DB API: zcl database access~selectAllStructsWithItemCount(db, packageIds) ⇒
 
 Retrieves all the structs in the database, including the count
 of items.
@@ -3019,9 +2847,10 @@ of items.
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: Promise that resolves with the rows of structs.
 
-| Param | Type            |
-| ----- | --------------- |
-| db    | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectStructClusters"></a>
 
@@ -3350,17 +3179,17 @@ we have to link the foreign keys.
 | ----- | --------------- |
 | db    | <code>\*</code> |
 
-<a name="module_DB API_ endpoint configuration queries against the database."></a>
-
-## DB API: endpoint configuration queries against the database.
-
-This module provides queries for endpoint configuration.
-
 <a name="module_DB API_ endpoint type queries against the database."></a>
 
 ## DB API: endpoint type queries against the database.
 
 This module provides queries for endpoint type.
+
+<a name="module_DB API_ endpoint configuration queries against the database."></a>
+
+## DB API: endpoint configuration queries against the database.
+
+This module provides queries for endpoint configuration.
 
 <a name="module_DB API_ zcl database access"></a>
 
@@ -3375,24 +3204,20 @@ This module provides queries for enums.
   - [~isCached(key, packageId)](#module*DB API* zcl database access..isCached) ⇒
   - [~selectAtomicType(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicType)
   - [~selectAtomicById(db, packageId)](#module*DB API* zcl database access..selectAtomicById)
-  - [~createCache(db, packageId)](#module*DB API* zcl database access..createCache) ⇒
-  - [~selectAtomicTypeFromCache(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicTypeFromCache)
-  - [~selectAllAtomicsFromCache(db, packageId)](#module*DB API* zcl database access..selectAllAtomicsFromCache)
-  - [~selectAtomicByIdFromCache(db, packageId)](#module*DB API* zcl database access..selectAtomicByIdFromCache)
   - [~selectAllBitmaps(db)](#module*DB API* zcl database access..selectAllBitmaps) ⇒
   - [~selectAllEnums(db, packageId)](#module*DB API* zcl database access..selectAllEnums) ⇒
   - [~selectClusterEnums(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterEnums) ⇒
   - [~selectAllEnumItemsById(db, id)](#module*DB API* zcl database access..selectAllEnumItemsById) ⇒
   - [~selectAllEnumItems(db, packageId)](#module*DB API* zcl database access..selectAllEnumItems) ⇒
   - [~selectEnumById(db, id)](#module*DB API* zcl database access..selectEnumById) ⇒
-  - [~selectEnumByName(db, name, packageId)](#module*DB API* zcl database access..selectEnumByName) ⇒
+  - [~selectEnumByName(db, name, packageIds)](#module*DB API* zcl database access..selectEnumByName) ⇒
   - [~selectSessionClusterByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionClusterByCode) ⇒
   - [~selectAllSessionClusters(db, sessionId)](#module*DB API* zcl database access..selectAllSessionClusters) ⇒
   - [~selectSessionAttributeByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionAttributeByCode) ⇒
   - [~selectSessionCommandByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionCommandByCode) ⇒
   - [~selectClusterBitmaps(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterBitmaps) ⇒
   - [~selectAllDomains(db)](#module*DB API* zcl database access..selectAllDomains) ⇒
-  - [~selectAllStructsWithItemCount(db)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
+  - [~selectAllStructsWithItemCount(db, packageIds)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
   - [~selectStructClusters(db, structId)](#module*DB API* zcl database access..selectStructClusters) ⇒
   - [~selectEnumClusters(db, enumId)](#module*DB API* zcl database access..selectEnumClusters) ⇒
   - [~selectBitmapClusters(db, enumId)](#module*DB API* zcl database access..selectBitmapClusters) ⇒
@@ -3473,60 +3298,6 @@ Locates atomic type based on a type name. Query is not case sensitive.
 <a name="module_DB API_ zcl database access..selectAtomicById"></a>
 
 ### DB API: zcl database access~selectAtomicById(db, packageId)
-
-Retrieves atomic type by a given Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..createCache"></a>
-
-### DB API: zcl database access~createCache(db, packageId) ⇒
-
-Function that populates cache.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
-**Returns**: Newly created cache object, after it's put into the cache.
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicTypeFromCache"></a>
-
-### DB API: zcl database access~selectAtomicTypeFromCache(db, packageId, typeName)
-
-Locates atomic type based on a type name. Query is not case sensitive.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| typeName  | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAllAtomicsFromCache"></a>
-
-### DB API: zcl database access~selectAllAtomicsFromCache(db, packageId)
-
-Retrieves all atomic types under a given package Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicByIdFromCache"></a>
-
-### DB API: zcl database access~selectAtomicByIdFromCache(db, packageId)
 
 Retrieves atomic type by a given Id.
 
@@ -3623,18 +3394,18 @@ Select an enum matched by its primary key.
 
 <a name="module_DB API_ zcl database access..selectEnumByName"></a>
 
-### DB API: zcl database access~selectEnumByName(db, name, packageId) ⇒
+### DB API: zcl database access~selectEnumByName(db, name, packageIds) ⇒
 
 Select an enum matched by name.
 
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: enum or undefined
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| name      | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| name       | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectSessionClusterByCode"></a>
 
@@ -3722,7 +3493,7 @@ Retrieves all the domains in the database.
 
 <a name="module_DB API_ zcl database access..selectAllStructsWithItemCount"></a>
 
-### DB API: zcl database access~selectAllStructsWithItemCount(db) ⇒
+### DB API: zcl database access~selectAllStructsWithItemCount(db, packageIds) ⇒
 
 Retrieves all the structs in the database, including the count
 of items.
@@ -3730,9 +3501,10 @@ of items.
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: Promise that resolves with the rows of structs.
 
-| Param | Type            |
-| ----- | --------------- |
-| db    | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectStructClusters"></a>
 
@@ -3963,13 +3735,13 @@ This module provides queries for ZCL loading
   - [~insertNumber(db, packageId, data)](#module*DB API* zcl loading queries..insertNumber)
   - [~insertString(db, packageId, data)](#module*DB API* zcl loading queries..insertString)
   - [~insertEnumAtomic(db, packageId, data)](#module*DB API* zcl loading queries..insertEnumAtomic)
-  - [~insertEnum(db, packageId, data)](#module*DB API* zcl loading queries..insertEnum)
-  - [~insertEnumItems(db, packageId, data)](#module*DB API* zcl loading queries..insertEnumItems)
+  - [~insertEnum(db, packageIds, data)](#module*DB API* zcl loading queries..insertEnum)
+  - [~insertEnumItems(db, packageId, knownPackages, data)](#module*DB API* zcl loading queries..insertEnumItems)
   - [~insertBitmapAtomic(db, packageId, data)](#module*DB API* zcl loading queries..insertBitmapAtomic)
-  - [~insertBitmap(db, packageId, data)](#module*DB API* zcl loading queries..insertBitmap)
-  - [~insertBitmapFields(db, packageId, data)](#module*DB API* zcl loading queries..insertBitmapFields)
-  - [~insertStruct(db, packageId, data)](#module*DB API* zcl loading queries..insertStruct)
-  - [~insertStructItems(db, packageId, data)](#module*DB API* zcl loading queries..insertStructItems)
+  - [~insertBitmap(db, packageIds, data)](#module*DB API* zcl loading queries..insertBitmap)
+  - [~insertBitmapFields(db, packageId, knownPackages, data)](#module*DB API* zcl loading queries..insertBitmapFields)
+  - [~insertStruct(db, packageIds, data)](#module*DB API* zcl loading queries..insertStruct)
+  - [~insertStructItems(db, packageIds, data)](#module*DB API* zcl loading queries..insertStructItems)
 
 <a name="module_DB API_ zcl loading queries..insertGlobals"></a>
 
@@ -4262,7 +4034,7 @@ Baseline enums are enums such as ENUM8, ENUM16 defined in the xml files
 
 <a name="module_DB API_ zcl loading queries..insertEnum"></a>
 
-### DB API: zcl loading queries~insertEnum(db, packageId, data)
+### DB API: zcl loading queries~insertEnum(db, packageIds, data)
 
 Insert all Enums into the Enum Table.
 Note: Unlike insertEnumAtomic this function adds the enums which are not
@@ -4270,25 +4042,26 @@ baseline enums.
 
 **Kind**: inner method of [<code>DB API: zcl loading queries</code>](#module*DB API* zcl loading queries)
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
+| data       | <code>\*</code> |
 
 <a name="module_DB API_ zcl loading queries..insertEnumItems"></a>
 
-### DB API: zcl loading queries~insertEnumItems(db, packageId, data)
+### DB API: zcl loading queries~insertEnumItems(db, packageId, knownPackages, data)
 
 Insert all Enum Items into the Enum Item Table.
 
 **Kind**: inner method of [<code>DB API: zcl loading queries</code>](#module*DB API* zcl loading queries)
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="module_DB API_ zcl loading queries..insertBitmapAtomic"></a>
 
@@ -4308,7 +4081,7 @@ the xml files
 
 <a name="module_DB API_ zcl loading queries..insertBitmap"></a>
 
-### DB API: zcl loading queries~insertBitmap(db, packageId, data)
+### DB API: zcl loading queries~insertBitmap(db, packageIds, data)
 
 Insert all Bitmaps into the Bitmap Table.
 Note: Unlike insertBitmapAtomic this function adds the bitmaps which are not
@@ -4316,65 +4089,60 @@ baseline bitmaps.
 
 **Kind**: inner method of [<code>DB API: zcl loading queries</code>](#module*DB API* zcl loading queries)
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
+| data       | <code>\*</code> |
 
 <a name="module_DB API_ zcl loading queries..insertBitmapFields"></a>
 
-### DB API: zcl loading queries~insertBitmapFields(db, packageId, data)
+### DB API: zcl loading queries~insertBitmapFields(db, packageId, knownPackages, data)
 
 Insert all Bitmap fields into the Bitmap field Table.
 
 **Kind**: inner method of [<code>DB API: zcl loading queries</code>](#module*DB API* zcl loading queries)
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="module_DB API_ zcl loading queries..insertStruct"></a>
 
-### DB API: zcl loading queries~insertStruct(db, packageId, data)
+### DB API: zcl loading queries~insertStruct(db, packageIds, data)
 
 Insert all Structs into the Struct Table.
 
 **Kind**: inner method of [<code>DB API: zcl loading queries</code>](#module*DB API* zcl loading queries)
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
+| data       | <code>\*</code> |
 
 <a name="module_DB API_ zcl loading queries..insertStructItems"></a>
 
-### DB API: zcl loading queries~insertStructItems(db, packageId, data)
+### DB API: zcl loading queries~insertStructItems(db, packageIds, data)
 
 Insert all Struct items into the Struct Item Table.
 
 **Kind**: inner method of [<code>DB API: zcl loading queries</code>](#module*DB API* zcl loading queries)
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
+| data       | <code>\*</code> |
 
 <a name="module_DB API_ package-based queries."></a>
 
 ## DB API: package-based queries.
 
 This module provides queries related to packages.
-
-<a name="module_DB API_ session related queries."></a>
-
-## DB API: session related queries.
-
-This module provides session related queries.
 
 <a name="module_DB API_ zcl database access"></a>
 
@@ -4391,24 +4159,20 @@ all visible clusters, etc.
   - [~isCached(key, packageId)](#module*DB API* zcl database access..isCached) ⇒
   - [~selectAtomicType(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicType)
   - [~selectAtomicById(db, packageId)](#module*DB API* zcl database access..selectAtomicById)
-  - [~createCache(db, packageId)](#module*DB API* zcl database access..createCache) ⇒
-  - [~selectAtomicTypeFromCache(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicTypeFromCache)
-  - [~selectAllAtomicsFromCache(db, packageId)](#module*DB API* zcl database access..selectAllAtomicsFromCache)
-  - [~selectAtomicByIdFromCache(db, packageId)](#module*DB API* zcl database access..selectAtomicByIdFromCache)
   - [~selectAllBitmaps(db)](#module*DB API* zcl database access..selectAllBitmaps) ⇒
   - [~selectAllEnums(db, packageId)](#module*DB API* zcl database access..selectAllEnums) ⇒
   - [~selectClusterEnums(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterEnums) ⇒
   - [~selectAllEnumItemsById(db, id)](#module*DB API* zcl database access..selectAllEnumItemsById) ⇒
   - [~selectAllEnumItems(db, packageId)](#module*DB API* zcl database access..selectAllEnumItems) ⇒
   - [~selectEnumById(db, id)](#module*DB API* zcl database access..selectEnumById) ⇒
-  - [~selectEnumByName(db, name, packageId)](#module*DB API* zcl database access..selectEnumByName) ⇒
+  - [~selectEnumByName(db, name, packageIds)](#module*DB API* zcl database access..selectEnumByName) ⇒
   - [~selectSessionClusterByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionClusterByCode) ⇒
   - [~selectAllSessionClusters(db, sessionId)](#module*DB API* zcl database access..selectAllSessionClusters) ⇒
   - [~selectSessionAttributeByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionAttributeByCode) ⇒
   - [~selectSessionCommandByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionCommandByCode) ⇒
   - [~selectClusterBitmaps(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterBitmaps) ⇒
   - [~selectAllDomains(db)](#module*DB API* zcl database access..selectAllDomains) ⇒
-  - [~selectAllStructsWithItemCount(db)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
+  - [~selectAllStructsWithItemCount(db, packageIds)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
   - [~selectStructClusters(db, structId)](#module*DB API* zcl database access..selectStructClusters) ⇒
   - [~selectEnumClusters(db, enumId)](#module*DB API* zcl database access..selectEnumClusters) ⇒
   - [~selectBitmapClusters(db, enumId)](#module*DB API* zcl database access..selectBitmapClusters) ⇒
@@ -4489,60 +4253,6 @@ Locates atomic type based on a type name. Query is not case sensitive.
 <a name="module_DB API_ zcl database access..selectAtomicById"></a>
 
 ### DB API: zcl database access~selectAtomicById(db, packageId)
-
-Retrieves atomic type by a given Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..createCache"></a>
-
-### DB API: zcl database access~createCache(db, packageId) ⇒
-
-Function that populates cache.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
-**Returns**: Newly created cache object, after it's put into the cache.
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicTypeFromCache"></a>
-
-### DB API: zcl database access~selectAtomicTypeFromCache(db, packageId, typeName)
-
-Locates atomic type based on a type name. Query is not case sensitive.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| typeName  | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAllAtomicsFromCache"></a>
-
-### DB API: zcl database access~selectAllAtomicsFromCache(db, packageId)
-
-Retrieves all atomic types under a given package Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicByIdFromCache"></a>
-
-### DB API: zcl database access~selectAtomicByIdFromCache(db, packageId)
 
 Retrieves atomic type by a given Id.
 
@@ -4639,18 +4349,18 @@ Select an enum matched by its primary key.
 
 <a name="module_DB API_ zcl database access..selectEnumByName"></a>
 
-### DB API: zcl database access~selectEnumByName(db, name, packageId) ⇒
+### DB API: zcl database access~selectEnumByName(db, name, packageIds) ⇒
 
 Select an enum matched by name.
 
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: enum or undefined
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| name      | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| name       | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectSessionClusterByCode"></a>
 
@@ -4738,7 +4448,7 @@ Retrieves all the domains in the database.
 
 <a name="module_DB API_ zcl database access..selectAllStructsWithItemCount"></a>
 
-### DB API: zcl database access~selectAllStructsWithItemCount(db) ⇒
+### DB API: zcl database access~selectAllStructsWithItemCount(db, packageIds) ⇒
 
 Retrieves all the structs in the database, including the count
 of items.
@@ -4746,9 +4456,10 @@ of items.
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: Promise that resolves with the rows of structs.
 
-| Param | Type            |
-| ----- | --------------- |
-| db    | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectStructClusters"></a>
 
@@ -4941,6 +4652,12 @@ Query for attributes by side.
 | side      | <code>\*</code> |
 | packageId | <code>\*</code> |
 
+<a name="module_DB API_ session related queries."></a>
+
+## DB API: session related queries.
+
+This module provides session related queries.
+
 <a name="module_DB API_ zcl database access"></a>
 
 ## DB API: zcl database access
@@ -4954,24 +4671,20 @@ This module provides queries for enums.
   - [~isCached(key, packageId)](#module*DB API* zcl database access..isCached) ⇒
   - [~selectAtomicType(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicType)
   - [~selectAtomicById(db, packageId)](#module*DB API* zcl database access..selectAtomicById)
-  - [~createCache(db, packageId)](#module*DB API* zcl database access..createCache) ⇒
-  - [~selectAtomicTypeFromCache(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicTypeFromCache)
-  - [~selectAllAtomicsFromCache(db, packageId)](#module*DB API* zcl database access..selectAllAtomicsFromCache)
-  - [~selectAtomicByIdFromCache(db, packageId)](#module*DB API* zcl database access..selectAtomicByIdFromCache)
   - [~selectAllBitmaps(db)](#module*DB API* zcl database access..selectAllBitmaps) ⇒
   - [~selectAllEnums(db, packageId)](#module*DB API* zcl database access..selectAllEnums) ⇒
   - [~selectClusterEnums(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterEnums) ⇒
   - [~selectAllEnumItemsById(db, id)](#module*DB API* zcl database access..selectAllEnumItemsById) ⇒
   - [~selectAllEnumItems(db, packageId)](#module*DB API* zcl database access..selectAllEnumItems) ⇒
   - [~selectEnumById(db, id)](#module*DB API* zcl database access..selectEnumById) ⇒
-  - [~selectEnumByName(db, name, packageId)](#module*DB API* zcl database access..selectEnumByName) ⇒
+  - [~selectEnumByName(db, name, packageIds)](#module*DB API* zcl database access..selectEnumByName) ⇒
   - [~selectSessionClusterByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionClusterByCode) ⇒
   - [~selectAllSessionClusters(db, sessionId)](#module*DB API* zcl database access..selectAllSessionClusters) ⇒
   - [~selectSessionAttributeByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionAttributeByCode) ⇒
   - [~selectSessionCommandByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionCommandByCode) ⇒
   - [~selectClusterBitmaps(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterBitmaps) ⇒
   - [~selectAllDomains(db)](#module*DB API* zcl database access..selectAllDomains) ⇒
-  - [~selectAllStructsWithItemCount(db)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
+  - [~selectAllStructsWithItemCount(db, packageIds)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
   - [~selectStructClusters(db, structId)](#module*DB API* zcl database access..selectStructClusters) ⇒
   - [~selectEnumClusters(db, enumId)](#module*DB API* zcl database access..selectEnumClusters) ⇒
   - [~selectBitmapClusters(db, enumId)](#module*DB API* zcl database access..selectBitmapClusters) ⇒
@@ -5052,60 +4765,6 @@ Locates atomic type based on a type name. Query is not case sensitive.
 <a name="module_DB API_ zcl database access..selectAtomicById"></a>
 
 ### DB API: zcl database access~selectAtomicById(db, packageId)
-
-Retrieves atomic type by a given Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..createCache"></a>
-
-### DB API: zcl database access~createCache(db, packageId) ⇒
-
-Function that populates cache.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
-**Returns**: Newly created cache object, after it's put into the cache.
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicTypeFromCache"></a>
-
-### DB API: zcl database access~selectAtomicTypeFromCache(db, packageId, typeName)
-
-Locates atomic type based on a type name. Query is not case sensitive.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| typeName  | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAllAtomicsFromCache"></a>
-
-### DB API: zcl database access~selectAllAtomicsFromCache(db, packageId)
-
-Retrieves all atomic types under a given package Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicByIdFromCache"></a>
-
-### DB API: zcl database access~selectAtomicByIdFromCache(db, packageId)
 
 Retrieves atomic type by a given Id.
 
@@ -5202,18 +4861,18 @@ Select an enum matched by its primary key.
 
 <a name="module_DB API_ zcl database access..selectEnumByName"></a>
 
-### DB API: zcl database access~selectEnumByName(db, name, packageId) ⇒
+### DB API: zcl database access~selectEnumByName(db, name, packageIds) ⇒
 
 Select an enum matched by name.
 
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: enum or undefined
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| name      | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| name       | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectSessionClusterByCode"></a>
 
@@ -5301,7 +4960,7 @@ Retrieves all the domains in the database.
 
 <a name="module_DB API_ zcl database access..selectAllStructsWithItemCount"></a>
 
-### DB API: zcl database access~selectAllStructsWithItemCount(db) ⇒
+### DB API: zcl database access~selectAllStructsWithItemCount(db, packageIds) ⇒
 
 Retrieves all the structs in the database, including the count
 of items.
@@ -5309,9 +4968,10 @@ of items.
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: Promise that resolves with the rows of structs.
 
-| Param | Type            |
-| ----- | --------------- |
-| db    | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectStructClusters"></a>
 
@@ -5517,24 +5177,20 @@ This module provides queries for ZCL static queries.
   - [~isCached(key, packageId)](#module*DB API* zcl database access..isCached) ⇒
   - [~selectAtomicType(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicType)
   - [~selectAtomicById(db, packageId)](#module*DB API* zcl database access..selectAtomicById)
-  - [~createCache(db, packageId)](#module*DB API* zcl database access..createCache) ⇒
-  - [~selectAtomicTypeFromCache(db, packageId, typeName)](#module*DB API* zcl database access..selectAtomicTypeFromCache)
-  - [~selectAllAtomicsFromCache(db, packageId)](#module*DB API* zcl database access..selectAllAtomicsFromCache)
-  - [~selectAtomicByIdFromCache(db, packageId)](#module*DB API* zcl database access..selectAtomicByIdFromCache)
   - [~selectAllBitmaps(db)](#module*DB API* zcl database access..selectAllBitmaps) ⇒
   - [~selectAllEnums(db, packageId)](#module*DB API* zcl database access..selectAllEnums) ⇒
   - [~selectClusterEnums(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterEnums) ⇒
   - [~selectAllEnumItemsById(db, id)](#module*DB API* zcl database access..selectAllEnumItemsById) ⇒
   - [~selectAllEnumItems(db, packageId)](#module*DB API* zcl database access..selectAllEnumItems) ⇒
   - [~selectEnumById(db, id)](#module*DB API* zcl database access..selectEnumById) ⇒
-  - [~selectEnumByName(db, name, packageId)](#module*DB API* zcl database access..selectEnumByName) ⇒
+  - [~selectEnumByName(db, name, packageIds)](#module*DB API* zcl database access..selectEnumByName) ⇒
   - [~selectSessionClusterByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionClusterByCode) ⇒
   - [~selectAllSessionClusters(db, sessionId)](#module*DB API* zcl database access..selectAllSessionClusters) ⇒
   - [~selectSessionAttributeByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionAttributeByCode) ⇒
   - [~selectSessionCommandByCode(db, sessionId)](#module*DB API* zcl database access..selectSessionCommandByCode) ⇒
   - [~selectClusterBitmaps(db, packageId, clusterId)](#module*DB API* zcl database access..selectClusterBitmaps) ⇒
   - [~selectAllDomains(db)](#module*DB API* zcl database access..selectAllDomains) ⇒
-  - [~selectAllStructsWithItemCount(db)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
+  - [~selectAllStructsWithItemCount(db, packageIds)](#module*DB API* zcl database access..selectAllStructsWithItemCount) ⇒
   - [~selectStructClusters(db, structId)](#module*DB API* zcl database access..selectStructClusters) ⇒
   - [~selectEnumClusters(db, enumId)](#module*DB API* zcl database access..selectEnumClusters) ⇒
   - [~selectBitmapClusters(db, enumId)](#module*DB API* zcl database access..selectBitmapClusters) ⇒
@@ -5615,60 +5271,6 @@ Locates atomic type based on a type name. Query is not case sensitive.
 <a name="module_DB API_ zcl database access..selectAtomicById"></a>
 
 ### DB API: zcl database access~selectAtomicById(db, packageId)
-
-Retrieves atomic type by a given Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..createCache"></a>
-
-### DB API: zcl database access~createCache(db, packageId) ⇒
-
-Function that populates cache.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
-**Returns**: Newly created cache object, after it's put into the cache.
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicTypeFromCache"></a>
-
-### DB API: zcl database access~selectAtomicTypeFromCache(db, packageId, typeName)
-
-Locates atomic type based on a type name. Query is not case sensitive.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| typeName  | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAllAtomicsFromCache"></a>
-
-### DB API: zcl database access~selectAllAtomicsFromCache(db, packageId)
-
-Retrieves all atomic types under a given package Id.
-
-**Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
-<a name="module_DB API_ zcl database access..selectAtomicByIdFromCache"></a>
-
-### DB API: zcl database access~selectAtomicByIdFromCache(db, packageId)
 
 Retrieves atomic type by a given Id.
 
@@ -5765,18 +5367,18 @@ Select an enum matched by its primary key.
 
 <a name="module_DB API_ zcl database access..selectEnumByName"></a>
 
-### DB API: zcl database access~selectEnumByName(db, name, packageId) ⇒
+### DB API: zcl database access~selectEnumByName(db, name, packageIds) ⇒
 
 Select an enum matched by name.
 
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: enum or undefined
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| name      | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| name       | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectSessionClusterByCode"></a>
 
@@ -5864,7 +5466,7 @@ Retrieves all the domains in the database.
 
 <a name="module_DB API_ zcl database access..selectAllStructsWithItemCount"></a>
 
-### DB API: zcl database access~selectAllStructsWithItemCount(db) ⇒
+### DB API: zcl database access~selectAllStructsWithItemCount(db, packageIds) ⇒
 
 Retrieves all the structs in the database, including the count
 of items.
@@ -5872,9 +5474,10 @@ of items.
 **Kind**: inner method of [<code>DB API: zcl database access</code>](#module*DB API* zcl database access)  
 **Returns**: Promise that resolves with the rows of structs.
 
-| Param | Type            |
-| ----- | --------------- |
-| db    | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_DB API_ zcl database access..selectStructClusters"></a>
 
@@ -6098,7 +5701,6 @@ Query for attributes by side.
   - [~hbInstance()](#module*JS API* generator logic..hbInstance) ⇒
   - [~makeSynchronizablePromise(promise)](#module*JS API* generator logic..makeSynchronizablePromise)
   - [~collectBlocks(resultArray, options, context)](#module*JS API* generator logic..collectBlocks) ⇒
-  - [~ensureZclPackageId(context)](#module*JS API* generator logic..ensureZclPackageId) ⇒
   - [~ensureZclPackageIds(context)](#module*JS API* generator logic..ensureZclPackageIds) ⇒
   - [~ensureTemplatePackageId(context)](#module*JS API* generator logic..ensureTemplatePackageId) ⇒
   - [~ensureEndpointTypeIds(context)](#module*JS API* generator logic..ensureEndpointTypeIds) ⇒
@@ -6461,19 +6063,6 @@ executing promises for each, and collecting them into the outgoing string.
 | options     | <code>\*</code> | Options passed from a block helper.      |
 | context     | <code>\*</code> | The context from within this was called. |
 
-<a name="module_JS API_ generator logic..ensureZclPackageId"></a>
-
-### JS API: generator logic~ensureZclPackageId(context) ⇒
-
-Returns the promise that resolves with the ZCL properties package id.
-
-**Kind**: inner method of [<code>JS API: generator logic</code>](#module*JS API* generator logic)  
-**Returns**: promise that resolves with the package id.
-
-| Param   | Type            |
-| ------- | --------------- |
-| context | <code>\*</code> |
-
 <a name="module_JS API_ generator logic..ensureZclPackageIds"></a>
 
 ### JS API: generator logic~ensureZclPackageIds(context) ⇒
@@ -6682,7 +6271,7 @@ This module contains the API for templating. For more detailed instructions, rea
   - [~asOffset(hex)](#module*Templating API* C formatting helpers..asOffset)
   - [~asDelimitedMacro(label)](#module*Templating API* C formatting helpers..asDelimitedMacro)
   - [~asHex(label)](#module*Templating API* C formatting helpers..asHex) ⇒
-  - [~asUnderlyingTypeHelper(dataType, context, packageId)](#module*Templating API* C formatting helpers..asUnderlyingTypeHelper) ⇒
+  - [~asUnderlyingTypeHelper(dataType, context, packageIds)](#module*Templating API* C formatting helpers..asUnderlyingTypeHelper) ⇒
   - [~asUnderlyingType(value)](#module*Templating API* C formatting helpers..asUnderlyingType) ⇒
   - [~asType(label)](#module*Templating API* C formatting helpers..asType) ⇒
   - [~asSymbol(label)](#module*Templating API* C formatting helpers..asSymbol) ⇒
@@ -6695,8 +6284,8 @@ This module contains the API for templating. For more detailed instructions, rea
   - [~asUnderscoreUppercase(str)](#module*Templating API* C formatting helpers..asUnderscoreUppercase) ⇒
   - [~asCliType(size, isSigned)](#module*Templating API* C formatting helpers..asCliType) ⇒
   - [~as_zcl_cli_type(str, optional, isSigned)](#module*Templating API* C formatting helpers..as_zcl_cli_type)
-  - [~dataTypeForBitmap(db, bitmap_name, packageId)](#module*Templating API* C formatting helpers..dataTypeForBitmap)
-  - [~dataTypeForEnum(db, enum_name, packageId)](#module*Templating API* C formatting helpers..dataTypeForEnum)
+  - [~dataTypeForBitmap(db, bitmap_name, packageIds)](#module*Templating API* C formatting helpers..dataTypeForBitmap)
+  - [~dataTypeForEnum(db, enum_name, packageIds)](#module*Templating API* C formatting helpers..dataTypeForEnum)
   - [~addOne(number)](#module*Templating API* C formatting helpers..addOne)
   - [~is_number_greater_than(num1, num2)](#module*Templating API* C formatting helpers..is_number_greater_than) ⇒
   - [~cluster_extension(options)](#module*Templating API* C formatting helpers..cluster_extension) ⇒
@@ -6749,7 +6338,7 @@ otherwise it is assumed decimal and converted to hex.
 
 <a name="module_Templating API_ C formatting helpers..asUnderlyingTypeHelper"></a>
 
-### Templating API: C formatting helpers~asUnderlyingTypeHelper(dataType, context, packageId) ⇒
+### Templating API: C formatting helpers~asUnderlyingTypeHelper(dataType, context, packageIds) ⇒
 
 This function is a helper function for asUnderlyingType and assists in
 returning the correct C type for the given data type
@@ -6757,11 +6346,11 @@ returning the correct C type for the given data type
 **Kind**: inner method of [<code>Templating API: C formatting helpers</code>](#module*Templating API* C formatting helpers)  
 **Returns**: The appropriate C type for the given data type
 
-| Param     | Type            |
-| --------- | --------------- |
-| dataType  | <code>\*</code> |
-| context   | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| dataType   | <code>\*</code> |
+| context    | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_Templating API_ C formatting helpers..asUnderlyingType"></a>
 
@@ -6918,7 +6507,7 @@ Returns the cli type representation.
 
 <a name="module_Templating API_ C formatting helpers..dataTypeForBitmap"></a>
 
-### Templating API: C formatting helpers~dataTypeForBitmap(db, bitmap_name, packageId)
+### Templating API: C formatting helpers~dataTypeForBitmap(db, bitmap_name, packageIds)
 
 Returns the type of bitmap based on the bitmap's name
 
@@ -6928,21 +6517,21 @@ Returns the type of bitmap based on the bitmap's name
 | ----------- | --------------- |
 | db          | <code>\*</code> |
 | bitmap_name | <code>\*</code> |
-| packageId   | <code>\*</code> |
+| packageIds  | <code>\*</code> |
 
 <a name="module_Templating API_ C formatting helpers..dataTypeForEnum"></a>
 
-### Templating API: C formatting helpers~dataTypeForEnum(db, enum_name, packageId)
+### Templating API: C formatting helpers~dataTypeForEnum(db, enum_name, packageIds)
 
 Returns the type of enum
 
 **Kind**: inner method of [<code>Templating API: C formatting helpers</code>](#module*Templating API* C formatting helpers)
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| enum_name | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| enum_name  | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_Templating API_ C formatting helpers..addOne"></a>
 
@@ -7070,7 +6659,7 @@ This module contains the API for accessing SDK extensions.
   - [~asOffset(hex)](#module*Templating API* C formatting helpers..asOffset)
   - [~asDelimitedMacro(label)](#module*Templating API* C formatting helpers..asDelimitedMacro)
   - [~asHex(label)](#module*Templating API* C formatting helpers..asHex) ⇒
-  - [~asUnderlyingTypeHelper(dataType, context, packageId)](#module*Templating API* C formatting helpers..asUnderlyingTypeHelper) ⇒
+  - [~asUnderlyingTypeHelper(dataType, context, packageIds)](#module*Templating API* C formatting helpers..asUnderlyingTypeHelper) ⇒
   - [~asUnderlyingType(value)](#module*Templating API* C formatting helpers..asUnderlyingType) ⇒
   - [~asType(label)](#module*Templating API* C formatting helpers..asType) ⇒
   - [~asSymbol(label)](#module*Templating API* C formatting helpers..asSymbol) ⇒
@@ -7083,8 +6672,8 @@ This module contains the API for accessing SDK extensions.
   - [~asUnderscoreUppercase(str)](#module*Templating API* C formatting helpers..asUnderscoreUppercase) ⇒
   - [~asCliType(size, isSigned)](#module*Templating API* C formatting helpers..asCliType) ⇒
   - [~as_zcl_cli_type(str, optional, isSigned)](#module*Templating API* C formatting helpers..as_zcl_cli_type)
-  - [~dataTypeForBitmap(db, bitmap_name, packageId)](#module*Templating API* C formatting helpers..dataTypeForBitmap)
-  - [~dataTypeForEnum(db, enum_name, packageId)](#module*Templating API* C formatting helpers..dataTypeForEnum)
+  - [~dataTypeForBitmap(db, bitmap_name, packageIds)](#module*Templating API* C formatting helpers..dataTypeForBitmap)
+  - [~dataTypeForEnum(db, enum_name, packageIds)](#module*Templating API* C formatting helpers..dataTypeForEnum)
   - [~addOne(number)](#module*Templating API* C formatting helpers..addOne)
   - [~is_number_greater_than(num1, num2)](#module*Templating API* C formatting helpers..is_number_greater_than) ⇒
   - [~cluster_extension(options)](#module*Templating API* C formatting helpers..cluster_extension) ⇒
@@ -7137,7 +6726,7 @@ otherwise it is assumed decimal and converted to hex.
 
 <a name="module_Templating API_ C formatting helpers..asUnderlyingTypeHelper"></a>
 
-### Templating API: C formatting helpers~asUnderlyingTypeHelper(dataType, context, packageId) ⇒
+### Templating API: C formatting helpers~asUnderlyingTypeHelper(dataType, context, packageIds) ⇒
 
 This function is a helper function for asUnderlyingType and assists in
 returning the correct C type for the given data type
@@ -7145,11 +6734,11 @@ returning the correct C type for the given data type
 **Kind**: inner method of [<code>Templating API: C formatting helpers</code>](#module*Templating API* C formatting helpers)  
 **Returns**: The appropriate C type for the given data type
 
-| Param     | Type            |
-| --------- | --------------- |
-| dataType  | <code>\*</code> |
-| context   | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| dataType   | <code>\*</code> |
+| context    | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_Templating API_ C formatting helpers..asUnderlyingType"></a>
 
@@ -7306,7 +6895,7 @@ Returns the cli type representation.
 
 <a name="module_Templating API_ C formatting helpers..dataTypeForBitmap"></a>
 
-### Templating API: C formatting helpers~dataTypeForBitmap(db, bitmap_name, packageId)
+### Templating API: C formatting helpers~dataTypeForBitmap(db, bitmap_name, packageIds)
 
 Returns the type of bitmap based on the bitmap's name
 
@@ -7316,21 +6905,21 @@ Returns the type of bitmap based on the bitmap's name
 | ----------- | --------------- |
 | db          | <code>\*</code> |
 | bitmap_name | <code>\*</code> |
-| packageId   | <code>\*</code> |
+| packageIds  | <code>\*</code> |
 
 <a name="module_Templating API_ C formatting helpers..dataTypeForEnum"></a>
 
-### Templating API: C formatting helpers~dataTypeForEnum(db, enum_name, packageId)
+### Templating API: C formatting helpers~dataTypeForEnum(db, enum_name, packageIds)
 
 Returns the type of enum
 
 **Kind**: inner method of [<code>Templating API: C formatting helpers</code>](#module*Templating API* C formatting helpers)
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| enum_name | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| enum_name  | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_Templating API_ C formatting helpers..addOne"></a>
 
@@ -9724,7 +9313,6 @@ This module contains the API for templating. For more detailed instructions, rea
   - [~hbInstance()](#module*JS API* generator logic..hbInstance) ⇒
   - [~makeSynchronizablePromise(promise)](#module*JS API* generator logic..makeSynchronizablePromise)
   - [~collectBlocks(resultArray, options, context)](#module*JS API* generator logic..collectBlocks) ⇒
-  - [~ensureZclPackageId(context)](#module*JS API* generator logic..ensureZclPackageId) ⇒
   - [~ensureZclPackageIds(context)](#module*JS API* generator logic..ensureZclPackageIds) ⇒
   - [~ensureTemplatePackageId(context)](#module*JS API* generator logic..ensureTemplatePackageId) ⇒
   - [~ensureEndpointTypeIds(context)](#module*JS API* generator logic..ensureEndpointTypeIds) ⇒
@@ -10086,19 +9674,6 @@ executing promises for each, and collecting them into the outgoing string.
 | resultArray | <code>\*</code> |                                          |
 | options     | <code>\*</code> | Options passed from a block helper.      |
 | context     | <code>\*</code> | The context from within this was called. |
-
-<a name="module_JS API_ generator logic..ensureZclPackageId"></a>
-
-### JS API: generator logic~ensureZclPackageId(context) ⇒
-
-Returns the promise that resolves with the ZCL properties package id.
-
-**Kind**: inner method of [<code>JS API: generator logic</code>](#module*JS API* generator logic)  
-**Returns**: promise that resolves with the package id.
-
-| Param   | Type            |
-| ------- | --------------- |
-| context | <code>\*</code> |
 
 <a name="module_JS API_ generator logic..ensureZclPackageIds"></a>
 
@@ -10292,7 +9867,6 @@ Function wrapper that can be used when a helper is deprecated.
   - [~hbInstance()](#module*JS API* generator logic..hbInstance) ⇒
   - [~makeSynchronizablePromise(promise)](#module*JS API* generator logic..makeSynchronizablePromise)
   - [~collectBlocks(resultArray, options, context)](#module*JS API* generator logic..collectBlocks) ⇒
-  - [~ensureZclPackageId(context)](#module*JS API* generator logic..ensureZclPackageId) ⇒
   - [~ensureZclPackageIds(context)](#module*JS API* generator logic..ensureZclPackageIds) ⇒
   - [~ensureTemplatePackageId(context)](#module*JS API* generator logic..ensureTemplatePackageId) ⇒
   - [~ensureEndpointTypeIds(context)](#module*JS API* generator logic..ensureEndpointTypeIds) ⇒
@@ -10654,19 +10228,6 @@ executing promises for each, and collecting them into the outgoing string.
 | resultArray | <code>\*</code> |                                          |
 | options     | <code>\*</code> | Options passed from a block helper.      |
 | context     | <code>\*</code> | The context from within this was called. |
-
-<a name="module_JS API_ generator logic..ensureZclPackageId"></a>
-
-### JS API: generator logic~ensureZclPackageId(context) ⇒
-
-Returns the promise that resolves with the ZCL properties package id.
-
-**Kind**: inner method of [<code>JS API: generator logic</code>](#module*JS API* generator logic)  
-**Returns**: promise that resolves with the package id.
-
-| Param   | Type            |
-| ------- | --------------- |
-| context | <code>\*</code> |
 
 <a name="module_JS API_ generator logic..ensureZclPackageIds"></a>
 
@@ -11890,7 +11451,7 @@ scripting functionality.
 
 - [JS API: type related utilities](#module*JS API* type related utilities)
   - [~typeSize(db, zclPackageId, type)](#module*JS API* type related utilities..typeSize)
-  - [~typeSizeAttribute(db, zclPackageId, at, [defaultValue])](#module*JS API* type related utilities..typeSizeAttribute) ⇒
+  - [~typeSizeAttribute(db, zclPackageIds, at, [defaultValue])](#module*JS API* type related utilities..typeSizeAttribute) ⇒
   - [~longTypeDefaultValue(size, type, value)](#module*JS API* type related utilities..longTypeDefaultValue) ⇒
   - [~convertToCliType(str)](#module*JS API* type related utilities..convertToCliType) ⇒
   - [~isString(type)](#module*JS API* type related utilities..isString) ⇒
@@ -11916,7 +11477,7 @@ This function resolves with the size of a given type.
 
 <a name="module_JS API_ type related utilities..typeSizeAttribute"></a>
 
-### JS API: type related utilities~typeSizeAttribute(db, zclPackageId, at, [defaultValue]) ⇒
+### JS API: type related utilities~typeSizeAttribute(db, zclPackageIds, at, [defaultValue]) ⇒
 
 Returns the size of a real attribute, taking type size and defaults
 into consideration, so that strings are properly sized.
@@ -11927,7 +11488,7 @@ into consideration, so that strings are properly sized.
 | Param          | Type            | Default       |
 | -------------- | --------------- | ------------- |
 | db             | <code>\*</code> |               |
-| zclPackageId   | <code>\*</code> |               |
+| zclPackageIds  | <code>\*</code> |               |
 | at             | <code>\*</code> |               |
 | [defaultValue] | <code>\*</code> | <code></code> |
 
@@ -12320,17 +11881,17 @@ This module provides the API to access various zcl utilities.
   - [~attributeComparator(a, b)](#module*REST API* various zcl utilities..attributeComparator) ⇒
   - [~commandComparator(a, b)](#module*REST API* various zcl utilities..commandComparator) ⇒
   - [~sortStructsByDependency(structs)](#module*REST API* various zcl utilities..sortStructsByDependency) ⇒
-  - [~calculateBytes(res, options)](#module*REST API* various zcl utilities..calculateBytes)
+  - [~calculateBytes(res, options, db, packageIds, isStructType)](#module*REST API* various zcl utilities..calculateBytes)
   - [~optionsHashOrDefault(options, optionsKey, defaultValue)](#module*REST API* various zcl utilities..optionsHashOrDefault)
-  - [~dataTypeCharacterFormatter(db, packageId, type, options, resType)](#module*REST API* various zcl utilities..dataTypeCharacterFormatter)
-  - [~isEnum(db, enum_name, packageId)](#module*REST API* various zcl utilities..isEnum) ⇒
-  - [~isStruct(db, struct_name, packageId)](#module*REST API* various zcl utilities..isStruct) ⇒
+  - [~dataTypeCharacterFormatter(db, packageIds, type, options, resType)](#module*REST API* various zcl utilities..dataTypeCharacterFormatter)
+  - [~isEnum(db, enum_name, packageIds)](#module*REST API* various zcl utilities..isEnum) ⇒
+  - [~isStruct(db, struct_name, packageIds)](#module*REST API* various zcl utilities..isStruct) ⇒
   - [~isEvent(db, event_name, packageId)](#module*REST API* various zcl utilities..isEvent) ⇒
-  - [~isBitmap(db, bitmap_name, packageId)](#module*REST API* various zcl utilities..isBitmap) ⇒
+  - [~isBitmap(db, bitmap_name, packageIds)](#module*REST API* various zcl utilities..isBitmap) ⇒
   - [~defaultMessageForTypeConversion(fromType, toType, noWarning)](#module*REST API* various zcl utilities..defaultMessageForTypeConversion)
-  - [~dataTypeHelper(type, options, packageId, db, resolvedType, overridable)](#module*REST API* various zcl utilities..dataTypeHelper) ⇒
-  - [~asUnderlyingZclTypeWithPackageId(type, options, packageId, currentInstance)](#module*REST API* various zcl utilities..asUnderlyingZclTypeWithPackageId)
-  - [~determineType(db, packageId, type)](#module*REST API* various zcl utilities..determineType)
+  - [~dataTypeHelper(type, options, packageIds, db, resolvedType, overridable)](#module*REST API* various zcl utilities..dataTypeHelper) ⇒
+  - [~asUnderlyingZclTypeWithPackageId(type, options, packageIds, currentInstance)](#module*REST API* various zcl utilities..asUnderlyingZclTypeWithPackageId)
+  - [~determineType(db, type, packageIds)](#module*REST API* various zcl utilities..determineType)
 
 <a name="module_REST API_ various zcl utilities..clusterComparator"></a>
 
@@ -12393,7 +11954,7 @@ It uses the DFS-based topological sort algorithm.
 
 <a name="module_REST API_ various zcl utilities..calculateBytes"></a>
 
-### REST API: various zcl utilities~calculateBytes(res, options)
+### REST API: various zcl utilities~calculateBytes(res, options, db, packageIds, isStructType)
 
 This function calculates the number of bytes in the data type and based on
 that returns the option specified in the template.
@@ -12412,10 +11973,13 @@ will return 's'
 
 **Kind**: inner method of [<code>REST API: various zcl utilities</code>](#module*REST API* various zcl utilities)
 
-| Param   | Type            |
-| ------- | --------------- |
-| res     | <code>\*</code> |
-| options | <code>\*</code> |
+| Param        | Type            |
+| ------------ | --------------- |
+| res          | <code>\*</code> |
+| options      | <code>\*</code> |
+| db           | <code>\*</code> |
+| packageIds   | <code>\*</code> |
+| isStructType | <code>\*</code> |
 
 <a name="module_REST API_ various zcl utilities..optionsHashOrDefault"></a>
 
@@ -12431,36 +11995,36 @@ will return 's'
 
 <a name="module_REST API_ various zcl utilities..dataTypeCharacterFormatter"></a>
 
-### REST API: various zcl utilities~dataTypeCharacterFormatter(db, packageId, type, options, resType)
+### REST API: various zcl utilities~dataTypeCharacterFormatter(db, packageIds, type, options, resType)
 
 **Kind**: inner method of [<code>REST API: various zcl utilities</code>](#module*REST API* various zcl utilities)
 
-| Param     | Type            | Description                                |
-| --------- | --------------- | ------------------------------------------ |
-| db        | <code>\*</code> |                                            |
-| packageId | <code>\*</code> |                                            |
-| type      | <code>\*</code> |                                            |
-| options   | <code>\*</code> |                                            |
-| resType   | <code>\*</code> | Character associated to a zcl/c data type. |
+| Param      | Type            | Description                                |
+| ---------- | --------------- | ------------------------------------------ |
+| db         | <code>\*</code> |                                            |
+| packageIds | <code>\*</code> |                                            |
+| type       | <code>\*</code> |                                            |
+| options    | <code>\*</code> |                                            |
+| resType    | <code>\*</code> | Character associated to a zcl/c data type. |
 
 <a name="module_REST API_ various zcl utilities..isEnum"></a>
 
-### REST API: various zcl utilities~isEnum(db, enum_name, packageId) ⇒
+### REST API: various zcl utilities~isEnum(db, enum_name, packageIds) ⇒
 
 Local function that checks if an enum by the name exists
 
 **Kind**: inner method of [<code>REST API: various zcl utilities</code>](#module*REST API* various zcl utilities)  
 **Returns**: Promise of content.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| enum_name | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| enum_name  | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="module_REST API_ various zcl utilities..isStruct"></a>
 
-### REST API: various zcl utilities~isStruct(db, struct_name, packageId) ⇒
+### REST API: various zcl utilities~isStruct(db, struct_name, packageIds) ⇒
 
 Local function that checks if a struct by the name exists
 
@@ -12471,7 +12035,7 @@ Local function that checks if a struct by the name exists
 | ----------- | --------------- |
 | db          | <code>\*</code> |
 | struct_name | <code>\*</code> |
-| packageId   | <code>\*</code> |
+| packageIds  | <code>\*</code> |
 
 <a name="module_REST API_ various zcl utilities..isEvent"></a>
 
@@ -12490,7 +12054,7 @@ Function that checks if a given thing is an avent.
 
 <a name="module_REST API_ various zcl utilities..isBitmap"></a>
 
-### REST API: various zcl utilities~isBitmap(db, bitmap_name, packageId) ⇒
+### REST API: various zcl utilities~isBitmap(db, bitmap_name, packageIds) ⇒
 
 Local function that checks if a bitmap by the name exists
 
@@ -12501,7 +12065,7 @@ Local function that checks if a bitmap by the name exists
 | ----------- | --------------- |
 | db          | <code>\*</code> |
 | bitmap_name | <code>\*</code> |
-| packageId   | <code>\*</code> |
+| packageIds  | <code>\*</code> |
 
 <a name="module_REST API_ various zcl utilities..defaultMessageForTypeConversion"></a>
 
@@ -12517,7 +12081,7 @@ Local function that checks if a bitmap by the name exists
 
 <a name="module_REST API_ various zcl utilities..dataTypeHelper"></a>
 
-### REST API: various zcl utilities~dataTypeHelper(type, options, packageId, db, resolvedType, overridable) ⇒
+### REST API: various zcl utilities~dataTypeHelper(type, options, packageIds, db, resolvedType, overridable) ⇒
 
 **Kind**: inner method of [<code>REST API: various zcl utilities</code>](#module*REST API* various zcl utilities)  
 **Returns**: the data type associated with the resolvedType
@@ -12526,14 +12090,14 @@ Local function that checks if a bitmap by the name exists
 | ------------ | --------------- |
 | type         | <code>\*</code> |
 | options      | <code>\*</code> |
-| packageId    | <code>\*</code> |
+| packageIds   | <code>\*</code> |
 | db           | <code>\*</code> |
 | resolvedType | <code>\*</code> |
 | overridable  | <code>\*</code> |
 
 <a name="module_REST API_ various zcl utilities..asUnderlyingZclTypeWithPackageId"></a>
 
-### REST API: various zcl utilities~asUnderlyingZclTypeWithPackageId(type, options, packageId, currentInstance)
+### REST API: various zcl utilities~asUnderlyingZclTypeWithPackageId(type, options, packageIds, currentInstance)
 
 **Kind**: inner method of [<code>REST API: various zcl utilities</code>](#module*REST API* various zcl utilities)
 
@@ -12541,12 +12105,12 @@ Local function that checks if a bitmap by the name exists
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | type            |                                                                                                                                                                                                                                                                                                                                                                                                     |
 | options         |                                                                                                                                                                                                                                                                                                                                                                                                     |
-| packageId       |                                                                                                                                                                                                                                                                                                                                                                                                     |
+| packageIds      |                                                                                                                                                                                                                                                                                                                                                                                                     |
 | currentInstance | Note: If the options has zclCharFormatter set to true then the function will return the user defined data associated with the zcl data type and not the actual data type. It can also be used to calculate the size of the data types This is a utility function which is called from other helper functions using ut current instance. See comments in asUnderlyingZclType for usage instructions. |
 
 <a name="module_REST API_ various zcl utilities..determineType"></a>
 
-### REST API: various zcl utilities~determineType(db, packageId, type)
+### REST API: various zcl utilities~determineType(db, type, packageIds)
 
 Returns a promise that resolves into an object containing:
 type:
@@ -12555,11 +12119,11 @@ Base type for struct is a null.
 
 **Kind**: inner method of [<code>REST API: various zcl utilities</code>](#module*REST API* various zcl utilities)
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| type      | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| type       | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="renderer_api"></a>
 
@@ -13075,15 +12639,15 @@ limitations under the License.
 **Kind**: global constant  
 <a name="selectAllDiscriminators"></a>
 
-## selectAllDiscriminators(db, packageId) ⇒
+## selectAllDiscriminators(db, packageIds) ⇒
 
 **Kind**: global function  
 **Returns**: all the data type discriminator information
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
 
 <a name="selectDataTypeById"></a>
 
@@ -13102,7 +12666,7 @@ with its actual type from disciminator table.
 
 <a name="selectDataTypeByName"></a>
 
-## selectDataTypeByName(db, name, packageId) ⇒
+## selectDataTypeByName(db, name, packageIds) ⇒
 
 Gathers the data type information of an entry based on data type name along
 with its actual type from disciminator table.
@@ -13110,11 +12674,11 @@ with its actual type from disciminator table.
 **Kind**: global function  
 **Returns**: Data type information
 
-| Param     |
-| --------- |
-| db        |
-| name      |
-| packageId |
+| Param      |
+| ---------- |
+| db         |
+| name       |
+| packageIds |
 
 <a name="selectAllDataTypes"></a>
 
@@ -13132,7 +12696,7 @@ Gathers All the data types
 
 <a name="selectSizeFromType"></a>
 
-## selectSizeFromType(db, packageId, value) ⇒
+## selectSizeFromType(db, packageIds, value) ⇒
 
 Return the size of the given value whether it be a reference to it in the data
 type table in the form of a number or be it the name of the type in the form
@@ -13141,26 +12705,26 @@ if string.
 **Kind**: global function  
 **Returns**: The size of the given value
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-| value     | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |
+| value      | <code>\*</code> |
 
 <a name="selectNumberByName"></a>
 
-## selectNumberByName(db, name, packageId) ⇒
+## selectNumberByName(db, name, packageIds) ⇒
 
 Select an number matched by name.
 
 **Kind**: global function  
 **Returns**: number or undefined
 
-| Param     |
-| --------- |
-| db        |
-| name      |
-| packageId |
+| Param      |
+| ---------- |
+| db         |
+| name       |
+| packageIds |
 
 <a name="selectNumberById"></a>
 
@@ -13220,18 +12784,18 @@ Select String by ID.
 
 <a name="selectStringByName"></a>
 
-## selectStringByName(db, name, packageId) ⇒
+## selectStringByName(db, name, packageIds) ⇒
 
 Select String by name.
 
 **Kind**: global function  
 **Returns**: String
 
-| Param     |
-| --------- |
-| db        |
-| name      |
-| packageId |
+| Param      |
+| ---------- |
+| db         |
+| name       |
+| packageIds |
 
 <a name="attributeDefault"></a>
 
@@ -13570,7 +13134,7 @@ Attribute collection works like this:
 **Kind**: global function  
 <a name="collectAttributeSizes"></a>
 
-## collectAttributeSizes(endpointTypes) ⇒
+## collectAttributeSizes(db, zclPackageIds, endpointTypes) ⇒
 
 This function goes over all the attributes and populates sizes.
 
@@ -13579,11 +13143,13 @@ This function goes over all the attributes and populates sizes.
 
 | Param         | Type            |
 | ------------- | --------------- |
+| db            | <code>\*</code> |
+| zclPackageIds | <code>\*</code> |
 | endpointTypes | <code>\*</code> |
 
 <a name="collectAttributeTypeInfo"></a>
 
-## collectAttributeTypeInfo(endpointTypes) ⇒
+## collectAttributeTypeInfo(db, zclPackageIds, endpointTypes) ⇒
 
 This function goes over all attributes and populates atomic types.
 
@@ -13592,6 +13158,8 @@ This function goes over all attributes and populates atomic types.
 
 | Param         | Type            |
 | ------------- | --------------- |
+| db            | <code>\*</code> |
+| zclPackageIds | <code>\*</code> |
 | endpointTypes | <code>\*</code> |
 
 <a name="endpoint_config"></a>
@@ -13969,34 +13537,6 @@ Session at this point is blank, and has no packages.
 | state     | <code>\*</code> |
 | sessionId | <code>\*</code> |
 
-<a name="readDataFromFile"></a>
-
-## readDataFromFile(filePath) ⇒
-
-Reads the data from the file and resolves with the state object if all is good.
-
-**Kind**: global function  
-**Returns**: Promise of file reading.
-
-| Param    | Type            |
-| -------- | --------------- |
-| filePath | <code>\*</code> |
-
-<a name="importDataFromFile"></a>
-
-## importDataFromFile(db, filePath) ⇒
-
-Writes the data from the file into a new session.
-NOTE: This function does NOT initialize session packages.
-
-**Kind**: global function  
-**Returns**: a promise that resolves with the import result object that contains: sessionId, errors, warnings.
-
-| Param    | Type            |
-| -------- | --------------- |
-| db       | <code>\*</code> |
-| filePath | <code>\*</code> |
-
 <a name="importSessionKeyValues"></a>
 
 ## importSessionKeyValues(db, sessionId, keyValuePairs)
@@ -14040,6 +13580,34 @@ Parses JSON file and creates a state object out of it, which is passed further d
 | -------- | --------------- |
 | filePath | <code>\*</code> |
 | data     | <code>\*</code> |
+
+<a name="readDataFromFile"></a>
+
+## readDataFromFile(filePath) ⇒
+
+Reads the data from the file and resolves with the state object if all is good.
+
+**Kind**: global function  
+**Returns**: Promise of file reading.
+
+| Param    | Type            |
+| -------- | --------------- |
+| filePath | <code>\*</code> |
+
+<a name="importDataFromFile"></a>
+
+## importDataFromFile(db, filePath) ⇒
+
+Writes the data from the file into a new session.
+NOTE: This function does NOT initialize session packages.
+
+**Kind**: global function  
+**Returns**: a promise that resolves with the import result object that contains: sessionId, errors, warnings.
+
+| Param    | Type            |
+| -------- | --------------- |
+| db       | <code>\*</code> |
+| filePath | <code>\*</code> |
 
 <a name="initSessionTimers"></a>
 
@@ -14854,144 +14422,6 @@ and orchestrates the promise chain.
 | db    | <code>\*</code> |                     |
 | ctx   | <code>\*</code> | Context of loading. |
 
-<a name="recordToplevelPackage"></a>
-
-## recordToplevelPackage(db, metadataFile, crc) ⇒
-
-Records the toplevel package information and resolves into packageId
-
-**Kind**: global function  
-**Returns**: packageId
-
-| Param        | Type            |
-| ------------ | --------------- |
-| db           | <code>\*</code> |
-| metadataFile | <code>\*</code> |
-| crc          | <code>\*</code> |
-
-<a name="recordVersion"></a>
-
-## recordVersion(db, ctx)
-
-Records the version into the database.
-
-**Kind**: global function
-
-| Param | Type            |
-| ----- | --------------- |
-| db    | <code>\*</code> |
-| ctx   | <code>\*</code> |
-
-<a name="loadZclMetafiles"></a>
-
-## loadZclMetafiles(db, metadataFile) ⇒
-
-Toplevel function that loads the zcl file and passes it off to the correct zcl loader.
-
-**Kind**: global function  
-**Returns**: Array of loaded packageIds.
-
-| Param        | Type            | Description    |
-| ------------ | --------------- | -------------- |
-| db           | <code>\*</code> |                |
-| metadataFile | <code>\*</code> | array of paths |
-
-<a name="loadZcl"></a>
-
-## loadZcl(db, metadataFile) ⇒
-
-Loads individual zcl.json metafile.
-
-**Kind**: global function  
-**Returns**: Context object that contains .db and .packageId
-
-| Param        | Type            |
-| ------------ | --------------- |
-| db           | <code>\*</code> |
-| metadataFile | <code>\*</code> |
-
-<a name="loadIndividualFile"></a>
-
-## loadIndividualFile(db, filePath, sessionId)
-
-Load individual custom XML files.
-
-**Kind**: global function
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| sessionId | <code>\*</code> |
-
-<a name="bindValidationScript"></a>
-
-## bindValidationScript(db, basePackageId)
-
-This function creates a validator function with signatuee fn(stringToValidateOn)
-
-**Kind**: global function
-
-| Param         | Type            |
-| ------------- | --------------- |
-| db            | <code>\*</code> |
-| basePackageId | <code>\*</code> |
-
-<a name="getSchemaAndValidationScript"></a>
-
-## getSchemaAndValidationScript(db, basePackageId)
-
-Returns an object with zclSchema and zclValidation elements.
-
-**Kind**: global function
-
-| Param         | Type            |
-| ------------- | --------------- |
-| db            | <code>\*</code> |
-| basePackageId | <code>\*</code> |
-
-<a name="qualifyZclFile"></a>
-
-## qualifyZclFile(db, info, parentPackageId) ⇒
-
-Promises to qualify whether zcl file needs to be reloaded.
-If yes, the it will resolve with {filePath, data, packageId}
-If not, then it will resolve with {error}
-
-**Kind**: global function  
-**Returns**: Promise that resolves int he object of data.
-
-| Param           | Type            |
-| --------------- | --------------- |
-| db              | <code>\*</code> |
-| info            | <code>\*</code> |
-| parentPackageId | <code>\*</code> |
-
-<a name="processZclPostLoading"></a>
-
-## processZclPostLoading(db) ⇒
-
-Promises to perform a post loading step.
-
-**Kind**: global function  
-**Returns**: Promise to deal with the post-loading cleanup.
-
-| Param | Type            |
-| ----- | --------------- |
-| db    | <code>\*</code> |
-
-<a name="getDiscriminatorMap"></a>
-
-## getDiscriminatorMap(db, packageId) ⇒
-
-**Kind**: global function  
-**Returns**: data type discriminator map
-
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| packageId | <code>\*</code> |
-
 <a name="collectDataFromJsonFile"></a>
 
 ## collectDataFromJsonFile(ctx) ⇒
@@ -15272,20 +14702,21 @@ Prepare Data Types for database table insertion.
 
 <a name="processDataType"></a>
 
-## processDataType(db, filePath, packageId, data, dataType) ⇒
+## processDataType(db, filePath, packageId, knownPackages, data, dataType) ⇒
 
 Processes Data Type.
 
 **Kind**: global function  
 **Returns**: Promise of inserted Data Types into the Data Type table.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
-| dataType  | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
+| dataType      | <code>\*</code> |
 
 <a name="prepareNumber"></a>
 
@@ -15303,19 +14734,20 @@ Prepare numbers for database table insertion.
 
 <a name="processNumber"></a>
 
-## processNumber(db, filePath, packageId, data) ⇒
+## processNumber(db, filePath, packageId, knownPackages, data) ⇒
 
 Processes Numbers.
 
 **Kind**: global function  
 **Returns**: Promise of inserted numbers into the number table.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="prepareString"></a>
 
@@ -15333,19 +14765,20 @@ Prepare strings for database table insertion.
 
 <a name="processString"></a>
 
-## processString(db, filePath, packageId, data) ⇒
+## processString(db, filePath, packageId, knownPackages, data) ⇒
 
 Processes Strings.
 
 **Kind**: global function  
 **Returns**: Promise of inserted strings into the String table.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="prepareEnumOrBitmapAtomic"></a>
 
@@ -15363,19 +14796,20 @@ Prepare enums or bitmaps for database table insertion.
 
 <a name="processEnumAtomic"></a>
 
-## processEnumAtomic(db, filePath, packageId, data) ⇒
+## processEnumAtomic(db, filePath, packageId, knownPackages, data) ⇒
 
 Processes the enums.
 
 **Kind**: global function  
 **Returns**: A promise of inserted enums.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="prepareEnumOrBitmap"></a>
 
@@ -15393,83 +14827,88 @@ Prepare enums or bitmaps for database table insertion.
 
 <a name="processEnum"></a>
 
-## processEnum(db, filePath, packageId, data) ⇒
+## processEnum(db, filePath, packageId, knownPackages, data) ⇒
 
 Processes the enums.
 
 **Kind**: global function  
 **Returns**: A promise of inserted enums.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="processEnumItems"></a>
 
-## processEnumItems(db, filePath, packageId, data) ⇒
+## processEnumItems(db, filePath, packageId, knownPackages, data) ⇒
 
 Processes the enum Items.
 
 **Kind**: global function  
 **Returns**: A promise of inserted enum items.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="processBitmapAtomic"></a>
 
-## processBitmapAtomic(db, filePath, packageId, data) ⇒
+## processBitmapAtomic(db, filePath, packageId, knownPackages, data) ⇒
 
 Processes the bitmaps.
 
 **Kind**: global function  
 **Returns**: A promise of inserted bitmaps.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="processBitmap"></a>
 
-## processBitmap(db, filePath, packageId, data) ⇒
+## processBitmap(db, filePath, packageId, knownPackages, data) ⇒
 
 Processes the bitmaps.
 
 **Kind**: global function  
 **Returns**: A promise of inserted bitmaps.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="processBitmapFields"></a>
 
-## processBitmapFields(db, filePath, packageId, data) ⇒
+## processBitmapFields(db, filePath, packageId, knownPackages, data) ⇒
 
 Processes the bitmap fields.
 
 **Kind**: global function  
 **Returns**: A promise of inserted bitmap fields.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="prepareStruct"></a>
 
@@ -15487,35 +14926,36 @@ Prepare structs for database table insertion.
 
 <a name="processStruct"></a>
 
-## processStruct(db, filePath, packageId, data) ⇒
+## processStruct(db, filePath, packageId, knownPackages, data) ⇒
 
 Processes the structs.
 
 **Kind**: global function  
 **Returns**: A promise of inserted structs.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| filePath      | <code>\*</code> |
+| packageId     | <code>\*</code> |
+| knownPackages | <code>\*</code> |
+| data          | <code>\*</code> |
 
 <a name="processStructItems"></a>
 
-## processStructItems(db, filePath, packageId, data) ⇒
+## processStructItems(db, filePath, packageIds, data) ⇒
 
 Processes the struct Items.
 
 **Kind**: global function  
 **Returns**: A promise of inserted struct items.
 
-| Param     | Type            |
-| --------- | --------------- |
-| db        | <code>\*</code> |
-| filePath  | <code>\*</code> |
-| packageId | <code>\*</code> |
-| data      | <code>\*</code> |
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| filePath   | <code>\*</code> |
+| packageIds | <code>\*</code> |
+| data       | <code>\*</code> |
 
 <a name="prepareDeviceType"></a>
 
@@ -15772,3 +15212,141 @@ and orchestrates the promise chain.
 | ----- | --------------- | ----------------------- |
 | db    | <code>\*</code> |                         |
 | ctx   | <code>\*</code> | The context of loading. |
+
+<a name="recordToplevelPackage"></a>
+
+## recordToplevelPackage(db, metadataFile, crc) ⇒
+
+Records the toplevel package information and resolves into packageId
+
+**Kind**: global function  
+**Returns**: packageId
+
+| Param        | Type            |
+| ------------ | --------------- |
+| db           | <code>\*</code> |
+| metadataFile | <code>\*</code> |
+| crc          | <code>\*</code> |
+
+<a name="recordVersion"></a>
+
+## recordVersion(db, ctx)
+
+Records the version into the database.
+
+**Kind**: global function
+
+| Param | Type            |
+| ----- | --------------- |
+| db    | <code>\*</code> |
+| ctx   | <code>\*</code> |
+
+<a name="loadZclMetafiles"></a>
+
+## loadZclMetafiles(db, metadataFile) ⇒
+
+Toplevel function that loads the zcl file and passes it off to the correct zcl loader.
+
+**Kind**: global function  
+**Returns**: Array of loaded packageIds.
+
+| Param        | Type            | Description    |
+| ------------ | --------------- | -------------- |
+| db           | <code>\*</code> |                |
+| metadataFile | <code>\*</code> | array of paths |
+
+<a name="loadZcl"></a>
+
+## loadZcl(db, metadataFile) ⇒
+
+Loads individual zcl.json metafile.
+
+**Kind**: global function  
+**Returns**: Context object that contains .db and .packageId
+
+| Param        | Type            |
+| ------------ | --------------- |
+| db           | <code>\*</code> |
+| metadataFile | <code>\*</code> |
+
+<a name="loadIndividualFile"></a>
+
+## loadIndividualFile(db, filePath, sessionId)
+
+Load individual custom XML files.
+
+**Kind**: global function
+
+| Param     | Type            |
+| --------- | --------------- |
+| db        | <code>\*</code> |
+| filePath  | <code>\*</code> |
+| sessionId | <code>\*</code> |
+
+<a name="bindValidationScript"></a>
+
+## bindValidationScript(db, basePackageId)
+
+This function creates a validator function with signatuee fn(stringToValidateOn)
+
+**Kind**: global function
+
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| basePackageId | <code>\*</code> |
+
+<a name="getSchemaAndValidationScript"></a>
+
+## getSchemaAndValidationScript(db, basePackageId)
+
+Returns an object with zclSchema and zclValidation elements.
+
+**Kind**: global function
+
+| Param         | Type            |
+| ------------- | --------------- |
+| db            | <code>\*</code> |
+| basePackageId | <code>\*</code> |
+
+<a name="qualifyZclFile"></a>
+
+## qualifyZclFile(db, info, parentPackageId) ⇒
+
+Promises to qualify whether zcl file needs to be reloaded.
+If yes, the it will resolve with {filePath, data, packageId}
+If not, then it will resolve with {error}
+
+**Kind**: global function  
+**Returns**: Promise that resolves int he object of data.
+
+| Param           | Type            |
+| --------------- | --------------- |
+| db              | <code>\*</code> |
+| info            | <code>\*</code> |
+| parentPackageId | <code>\*</code> |
+
+<a name="processZclPostLoading"></a>
+
+## processZclPostLoading(db) ⇒
+
+Promises to perform a post loading step.
+
+**Kind**: global function  
+**Returns**: Promise to deal with the post-loading cleanup.
+
+| Param | Type            |
+| ----- | --------------- |
+| db    | <code>\*</code> |
+
+<a name="getDiscriminatorMap"></a>
+
+## getDiscriminatorMap(db, packageIds) ⇒
+
+**Kind**: global function  
+**Returns**: data type discriminator map
+
+| Param      | Type            |
+| ---------- | --------------- |
+| db         | <code>\*</code> |
+| packageIds | <code>\*</code> |

--- a/docs/template-tutorial.md
+++ b/docs/template-tutorial.md
@@ -92,7 +92,7 @@ Whichever helpers get executed they all contain `global` inside their context th
 - `db`: connection to the database being used
 - `sessionId`: session id for the user data being used
 - `genTemplatePackageId`: toplevel package id for gen-template.json file, used for querying options and other
-- `zclPackageId`: populated after you call `templateUtil.ensureZclPackageId()` the first time, used for querying the ZCL static data.
+- `zclPackageId`: populated after you call `templateUtil.ensureZclPackageIds()` the first time, used for querying the ZCL static data.
 
 Whenever a context switches, the switch will preserve this `global` object inside the context for helpers to access.
 

--- a/src-electron/db/db-api.js
+++ b/src-electron/db/db-api.js
@@ -567,6 +567,15 @@ function fromDbBool(value) {
   return value == 1
 }
 
+/**
+ *
+ * @param {*} value
+ * @returns Given value in the form of string
+ */
+function toInClause(value) {
+  return value ? value.toString() : value
+}
+
 exports.dbBeginTransaction = dbBeginTransaction
 exports.dbCommit = dbCommit
 exports.dbRollback = dbRollback
@@ -585,3 +594,4 @@ exports.loadSchema = loadSchema
 exports.initDatabaseAndLoadSchema = initDatabaseAndLoadSchema
 exports.toDbBool = toDbBool
 exports.fromDbBool = fromDbBool
+exports.toInClause = toInClause

--- a/src-electron/db/query-access.js
+++ b/src-electron/db/query-access.js
@@ -23,38 +23,41 @@
 const dbApi = require('./db-api.js')
 const dbMapping = require('./db-mapping.js')
 
-async function selectAccessOperations(db, packageId) {
+async function selectAccessOperations(db, packageIds) {
   return dbApi
     .dbAll(
       db,
       `
-SELECT NAME, DESCRIPTION FROM OPERATION WHERE PACKAGE_REF = ? ORDER BY NAME
-`,
-      [packageId]
+SELECT NAME, DESCRIPTION FROM OPERATION WHERE PACKAGE_REF IN (${dbApi.toInClause(
+        packageIds
+      )}) ORDER BY NAME
+`
     )
     .then((rows) => rows.map(dbMapping.map.accessOperation))
 }
 
-async function selectAccessRoles(db, packageId) {
+async function selectAccessRoles(db, packageIds) {
   return dbApi
     .dbAll(
       db,
       `
-SELECT NAME, DESCRIPTION, LEVEL FROM ROLE WHERE PACKAGE_REF = ? ORDER BY NAME
-    `,
-      [packageId]
+SELECT NAME, DESCRIPTION, LEVEL FROM ROLE WHERE PACKAGE_REF IN (${dbApi.toInClause(
+        packageIds
+      )}) ORDER BY NAME
+    `
     )
     .then((rows) => rows.map(dbMapping.map.accessRole))
 }
 
-async function selectAccessModifiers(db, packageId) {
+async function selectAccessModifiers(db, packageIds) {
   return dbApi
     .dbAll(
       db,
       `
-SELECT NAME, DESCRIPTION FROM ACCESS_MODIFIER WHERE PACKAGE_REF = ? ORDER BY NAME
-    `,
-      [packageId]
+SELECT NAME, DESCRIPTION FROM ACCESS_MODIFIER WHERE PACKAGE_REF IN (${dbApi.toInClause(
+        packageIds
+      )}) ORDER BY NAME
+    `
     )
     .then((rows) => rows.map(dbMapping.map.accessModifier))
 }
@@ -67,7 +70,7 @@ SELECT NAME, DESCRIPTION FROM ACCESS_MODIFIER WHERE PACKAGE_REF = ? ORDER BY NAM
  * @param {*} type
  * @returns array of {operation/role/accessModifier} objects.
  */
-async function selectDefaultAccess(db, packageId, type) {
+async function selectDefaultAccess(db, packageIds, type) {
   return dbApi
     .dbAll(
       db,
@@ -88,10 +91,10 @@ LEFT JOIN ROLE
 ON A.ROLE_REF = ROLE.ROLE_ID
 LEFT JOIN ACCESS_MODIFIER
 ON A.ACCESS_MODIFIER_REF = ACCESS_MODIFIER.ACCESS_MODIFIER_ID
-WHERE DA.PACKAGE_REF = ? AND DA.ENTITY_TYPE = ?
+WHERE DA.PACKAGE_REF IN (${dbApi.toInClause(packageIds)}) AND DA.ENTITY_TYPE = ?
 ORDER BY OPERATION.NAME, ROLE.NAME, ACCESS_MODIFIER.NAME
 `,
-      [packageId, type]
+      [type]
     )
     .then((rows) => rows.map(dbMapping.map.access))
 }

--- a/src-electron/db/query-attribute.js
+++ b/src-electron/db/query-attribute.js
@@ -578,7 +578,7 @@ async function selectReportableAttributeDetailsFromEnabledClustersAndEndpoints(
 
 async function selectAttributeByCode(
   db,
-  packageId,
+  packageIds,
   clusterCode,
   attributeCode,
   manufacturerCode
@@ -586,14 +586,14 @@ async function selectAttributeByCode(
   if (clusterCode == null) {
     return selectGlobalAttributeByCode(
       db,
-      packageId,
+      packageIds,
       attributeCode,
       manufacturerCode
     )
   } else {
     return selectNonGlobalAttributeByCode(
       db,
-      packageId,
+      packageIds,
       clusterCode,
       attributeCode,
       manufacturerCode
@@ -603,13 +603,13 @@ async function selectAttributeByCode(
 
 async function selectNonGlobalAttributeByCode(
   db,
-  packageId,
+  packageIds,
   clusterCode,
   attributeCode,
   manufacturerCode
 ) {
   let manufacturerCondition
-  let arg = [packageId, attributeCode, clusterCode]
+  let arg = [attributeCode, clusterCode]
 
   if (manufacturerCode == null || manufacturerCode == 0) {
     manufacturerCondition = 'C.MANUFACTURER_CODE IS NULL'
@@ -648,7 +648,7 @@ SELECT
 FROM ATTRIBUTE AS A
 INNER JOIN CLUSTER AS C
 ON C.CLUSTER_ID = A.CLUSTER_REF
-WHERE A.PACKAGE_REF = ?
+WHERE A.PACKAGE_REF IN (${packageIds})
   AND A.CODE = ?
   AND C.CODE = ?
   AND ${manufacturerCondition}`,
@@ -659,12 +659,12 @@ WHERE A.PACKAGE_REF = ?
 
 async function selectGlobalAttributeByCode(
   db,
-  packageId,
+  packageIds,
   attributeCode,
   manufacturerCode
 ) {
   let manufacturerCondition
-  let arg = [packageId, attributeCode]
+  let arg = [attributeCode]
 
   if (manufacturerCode == null || manufacturerCode == 0) {
     manufacturerCondition = 'A.MANUFACTURER_CODE IS NULL'
@@ -701,7 +701,7 @@ SELECT
   A.ARRAY_TYPE,
   A.MUST_USE_TIMED_WRITE
 FROM ATTRIBUTE AS A
-WHERE A.PACKAGE_REF = ?
+WHERE A.PACKAGE_REF IN (${packageIds})
   AND A.CODE = ?
   AND ${manufacturerCondition}`,
       arg

--- a/src-electron/db/query-bitmap.js
+++ b/src-electron/db/query-bitmap.js
@@ -48,7 +48,7 @@ WHERE PACKAGE_REF = ? ORDER BY NAME`,
   return rows.map(dbMapping.map.bitmap)
 }
 
-async function selectBitmapByName(db, packageId, name) {
+async function selectBitmapByName(db, packageIds, name) {
   return dbApi
     .dbGet(
       db,
@@ -59,8 +59,10 @@ SELECT
   BITMAP.SIZE AS SIZE
 FROM BITMAP
 INNER JOIN DATA_TYPE ON BITMAP.BITMAP_ID = DATA_TYPE.DATA_TYPE_ID
-WHERE (DATA_TYPE.NAME = ? OR DATA_TYPE.NAME = ?) AND DATA_TYPE.PACKAGE_REF = ?`,
-      [name, name.toLowerCase(), packageId]
+WHERE (DATA_TYPE.NAME = ? OR DATA_TYPE.NAME = ?) AND DATA_TYPE.PACKAGE_REF IN (${dbApi.toInClause(
+        packageIds
+      )})`,
+      [name, name.toLowerCase()]
     )
     .then(dbMapping.map.bitmap)
 }

--- a/src-electron/db/query-data-type-discriminator.js
+++ b/src-electron/db/query-data-type-discriminator.js
@@ -25,10 +25,10 @@ const dbMapping = require('./db-mapping')
 /**
  *
  * @param {*} db
- * @param {*} packageId
+ * @param {*} packageIds
  * @returns all the data type discriminator information
  */
-async function selectAllDiscriminators(db, packageId) {
+async function selectAllDiscriminators(db, packageIds) {
   return dbApi
     .dbAll(
       db,
@@ -39,8 +39,8 @@ async function selectAllDiscriminators(db, packageId) {
     FROM
       DISCRIMINATOR
     WHERE
-      PACKAGE_REF = ?`,
-      [packageId]
+      PACKAGE_REF IN (${dbApi.toInClause(packageIds)})
+      `
     )
     .then((rows) => rows.map(dbMapping.map.discriminator))
 }

--- a/src-electron/db/query-data-type.js
+++ b/src-electron/db/query-data-type.js
@@ -62,10 +62,10 @@ async function selectDataTypeById(db, id) {
  * with its actual type from disciminator table.
  * @param db
  * @param name
- * @param packageId
+ * @param packageIds
  * @returns Data type information
  */
-async function selectDataTypeByName(db, name, packageId) {
+async function selectDataTypeByName(db, name, packageIds) {
   let smallCaseName = name.toLowerCase()
   return dbApi
     .dbGet(
@@ -85,8 +85,10 @@ async function selectDataTypeByName(db, name, packageId) {
   ON
     DATA_TYPE.DISCRIMINATOR_REF = DISCRIMINATOR.DISCRIMINATOR_ID
   WHERE
-    (DATA_TYPE.NAME = ? OR DATA_TYPE.NAME = ?) AND DATA_TYPE.PACKAGE_REF = ?`,
-      [name, smallCaseName, packageId]
+    (DATA_TYPE.NAME = ? OR DATA_TYPE.NAME = ?) AND DATA_TYPE.PACKAGE_REF IN (${dbApi.toInClause(
+      packageIds
+    )})`,
+      [name, smallCaseName]
     )
     .then(dbMapping.map.dataType)
 }
@@ -126,17 +128,17 @@ async function selectAllDataTypes(db, packageId) {
  * type table in the form of a number or be it the name of the type in the form
  * if string.
  * @param {*} db
- * @param {*} packageId
+ * @param {*} packageIds
  * @param {*} value
  * @returns The size of the given value
  */
-async function selectSizeFromType(db, packageId, value) {
+async function selectSizeFromType(db, packageIds, value) {
   // Step 1: Extracting the data type based on type id or type name
   let dataType = null
   if (typeof value === 'number') {
     dataType = await queryZcl.selectDataTypeById(db, value)
   } else if (typeof value === 'string') {
-    dataType = await queryZcl.selectDataTypeByName(db, value, packageId)
+    dataType = await queryZcl.selectDataTypeByName(db, value, packageIds)
   }
 
   // Step 2: Find the size based on the type of data
@@ -145,19 +147,19 @@ async function selectSizeFromType(db, packageId, value) {
       dataType &&
       dataType.discriminatorName.toLowerCase() == dbEnum.zclType.bitmap
     ) {
-      let bt = await queryZcl.selectBitmapByName(db, packageId, dataType.name)
+      let bt = await queryZcl.selectBitmapByName(db, packageIds, dataType.name)
       return bt.size
     } else if (
       dataType &&
       dataType.discriminatorName.toLowerCase() == dbEnum.zclType.enum
     ) {
-      let et = await queryZcl.selectEnumByName(db, dataType.name, packageId)
+      let et = await queryZcl.selectEnumByName(db, dataType.name, packageIds)
       return et.size
     } else if (
       dataType &&
       dataType.discriminatorName.toLowerCase() == dbEnum.zclType.number
     ) {
-      let nt = await queryZcl.selectNumberByName(db, packageId, dataType.name)
+      let nt = await queryZcl.selectNumberByName(db, packageIds, dataType.name)
       return nt.size
     } else if (
       dataType &&

--- a/src-electron/db/query-enum.js
+++ b/src-electron/db/query-enum.js
@@ -82,7 +82,7 @@ INNER JOIN
 ON
   DT.DATA_TYPE_ID = DATA_TYPE_CLUSTER.DATA_TYPE_REF
 WHERE
-  DT.PACKAGE_REF IN (${packageIds})
+  DT.PACKAGE_REF IN (${dbApi.toInClause(packageIds)})
   AND DATA_TYPE_CLUSTER.CLUSTER_REF = ?
 ORDER BY DT.NAME`,
       [clusterId]
@@ -181,10 +181,10 @@ WHERE
  *
  * @param {*} db
  * @param {*} name
- * @param {*} packageId
+ * @param {*} packageIds
  * @returns enum or undefined
  */
-async function selectEnumByName(db, name, packageId) {
+async function selectEnumByName(db, name, packageIds) {
   return dbApi
     .dbGet(
       db,
@@ -200,9 +200,11 @@ INNER JOIN
 ON
   ENUM.ENUM_ID = DATA_TYPE.DATA_TYPE_ID
 WHERE
-  (DATA_TYPE.NAME = ? OR DATA_TYPE.NAME = ?)AND PACKAGE_REF = ?
+  (DATA_TYPE.NAME = ? OR DATA_TYPE.NAME = ?)AND PACKAGE_REF IN (${dbApi.toInClause(
+    packageIds
+  )})
 ORDER BY NAME`,
-      [name, name.toLowerCase(), packageId]
+      [name, name.toLowerCase()]
     )
     .then(dbMapping.map.enum)
 }

--- a/src-electron/db/query-event.js
+++ b/src-electron/db/query-event.js
@@ -88,7 +88,7 @@ INNER JOIN
 ON
   E.CLUSTER_REF = C.CLUSTER_ID
 WHERE
-  E.PACKAGE_REF in (${packageIds})
+  E.PACKAGE_REF in (${dbApi.toInClause(packageIds)})
 ORDER BY
   C.CODE, E.CODE`,
       []
@@ -115,7 +115,7 @@ INNER JOIN
 ON
   EVENT_FIELD.EVENT_REF = EVENT.EVENT_ID
 WHERE
-  EVENT.PACKAGE_REF IN (${packageIds})
+  EVENT.PACKAGE_REF IN (${dbApi.toInClause(packageIds)})
 ORDER BY
   EF.FIELD_IDENTIFIER
 `

--- a/src-electron/db/query-impexp.js
+++ b/src-electron/db/query-impexp.js
@@ -190,7 +190,9 @@ async function importEndpointType(db, sessionId, packageIds, endpointType) {
     let deviceTypeId = await dbApi
       .dbAll(
         db,
-        `SELECT DEVICE_TYPE_ID,PACKAGE_REF FROM DEVICE_TYPE WHERE CODE = ? AND PROFILE_ID = ? AND NAME = ? AND PACKAGE_REF IN (${packageIds})`,
+        `SELECT DEVICE_TYPE_ID,PACKAGE_REF FROM DEVICE_TYPE WHERE CODE = ? AND PROFILE_ID = ? AND NAME = ? AND PACKAGE_REF IN (${dbApi.toInClause(
+          packageIds
+        )})`,
         [
           parseInt(endpointType.deviceTypeCode),
           parseInt(endpointType.deviceTypeProfileId),
@@ -214,7 +216,9 @@ async function importEndpointType(db, sessionId, packageIds, endpointType) {
     let deviceTypeId = await dbApi
       .dbAll(
         db,
-        `SELECT DEVICE_TYPE_ID,PACKAGE_REF FROM DEVICE_TYPE WHERE CODE = ? AND PROFILE_ID = ? AND PACKAGE_REF IN (${packageIds})`,
+        `SELECT DEVICE_TYPE_ID,PACKAGE_REF FROM DEVICE_TYPE WHERE CODE = ? AND PROFILE_ID = ? AND PACKAGE_REF IN (${dbApi.toInClause(
+          packageIds
+        )})`,
         [
           parseInt(endpointType.deviceTypeCode),
           parseInt(endpointType.deviceTypeProfileId),
@@ -332,7 +336,9 @@ async function importClusterForEndpointType(
   let matchedPackageId = await dbApi
     .dbAll(
       db,
-      `SELECT CLUSTER_ID, PACKAGE_REF FROM CLUSTER WHERE PACKAGE_REF IN (${packageIds}) AND CODE = ? AND ${
+      `SELECT CLUSTER_ID, PACKAGE_REF FROM CLUSTER WHERE PACKAGE_REF IN (${dbApi.toInClause(
+        packageIds
+      )}) AND CODE = ? AND ${
         cluster.mfgCode == null
           ? 'MANUFACTURER_CODE IS NULL'
           : 'MANUFACTURER_CODE = ?'
@@ -451,7 +457,7 @@ ON
   E.CLUSTER_REF = ETC.CLUSTER_REF
 WHERE
   E.CODE = ?
-  AND E.PACKAGE_REF IN (${packageIds})
+  AND E.PACKAGE_REF IN (${dbApi.toInClause(packageIds)})
   AND E.SIDE = ETC.SIDE
   AND ETC.ENDPOINT_TYPE_CLUSTER_ID = ?
   AND ${
@@ -574,19 +580,19 @@ async function importAttributeForEndpointType(
   attribute
 ) {
   let selectAttributeQuery = `
-SELECT 
+SELECT
   A.ATTRIBUTE_ID,
   A.REPORTING_POLICY,
   A.STORAGE_POLICY
-FROM 
+FROM
   ATTRIBUTE AS A
 INNER JOIN
   ENDPOINT_TYPE_CLUSTER AS ETC
 ON
   ETC.CLUSTER_REF = A.CLUSTER_REF OR A.CLUSTER_REF IS NULL
-WHERE 
+WHERE
   A.CODE = ?
-  AND A.PACKAGE_REF IN (${packageIds})
+  AND A.PACKAGE_REF IN (${dbApi.toInClause(packageIds)})
   AND A.SIDE = ETC.SIDE
   AND ETC.ENDPOINT_TYPE_CLUSTER_ID = ?
   AND ${
@@ -737,7 +743,7 @@ async function importCommandForEndpointType(
       FROM COMMAND, ENDPOINT_TYPE_CLUSTER WHERE
         COMMAND.CODE = ?
         AND COMMAND.SOURCE = ?
-        AND COMMAND.PACKAGE_REF IN (${packageIds})
+        AND COMMAND.PACKAGE_REF IN (${dbApi.toInClause(packageIds)})
         AND ENDPOINT_TYPE_CLUSTER.ENDPOINT_TYPE_CLUSTER_ID = ?
         AND COMMAND.CLUSTER_REF = ENDPOINT_TYPE_CLUSTER.CLUSTER_REF
         AND ${

--- a/src-electron/db/query-number.js
+++ b/src-electron/db/query-number.js
@@ -27,10 +27,10 @@ const dbMapping = require('./db-mapping')
  *
  * @param db
  * @param name
- * @param packageId
+ * @param packageIds
  * @returns number or undefined
  */
-async function selectNumberByName(db, packageId, name) {
+async function selectNumberByName(db, packageIds, name) {
   return dbApi
     .dbGet(
       db,
@@ -42,8 +42,8 @@ async function selectNumberByName(db, packageId, name) {
     NUMBER.SIZE AS SIZE
   FROM NUMBER
   INNER JOIN DATA_TYPE ON NUMBER.NUMBER_ID = DATA_TYPE.DATA_TYPE_ID
-  WHERE NAME = ? AND PACKAGE_REF = ?`,
-      [name, packageId]
+  WHERE NAME = ? AND PACKAGE_REF IN (${dbApi.toInClause(packageIds)})`,
+      [name]
     )
     .then(dbMapping.map.number)
 }

--- a/src-electron/db/query-string.js
+++ b/src-electron/db/query-string.js
@@ -81,10 +81,10 @@ async function selectStringById(db, id) {
  *
  * @param db
  * @param name
- * @param packageId
+ * @param packageIds
  * @returns String
  */
-async function selectStringByName(db, name, packageId) {
+async function selectStringByName(db, name, packageIds) {
   return dbApi
     .dbGet(
       db,
@@ -98,13 +98,13 @@ async function selectStringByName(db, name, packageId) {
    FROM
      STRING
    INNER JOIN
-     DATA_TYPE 
+     DATA_TYPE
    ON
      STRING.STRING_ID = DATA_TYPE.DATA_TYPE_ID
    WHERE
      DATA_TYPE.NAME = ?
-     AND DATA_TYPE.PACKAGE_REF = ?`,
-      [name, packageId]
+     AND DATA_TYPE.PACKAGE_REF IN (${dbApi.toInClause(packageIds)})`,
+      [name]
     )
     .then(dbMapping.map.string)
 }

--- a/src-electron/db/query-struct.js
+++ b/src-electron/db/query-struct.js
@@ -69,7 +69,7 @@ WHERE
     .then(dbMapping.map.struct)
 }
 
-async function selectStructByName(db, name, packageId) {
+async function selectStructByName(db, name, packageIds) {
   return dbApi
     .dbGet(
       db,
@@ -85,10 +85,10 @@ INNER JOIN
   DATA_TYPE ON STRUCT.STRUCT_ID = DATA_TYPE.DATA_TYPE_ID
 WHERE
   NAME = ?
-  AND PACKAGE_REF = ?
+  AND PACKAGE_REF IN (${dbApi.toInClause(packageIds)})
 ORDER BY
   NAME`,
-      [name, packageId]
+      [name]
     )
     .then(dbMapping.map.struct)
 }

--- a/src-electron/generator/helper-access.js
+++ b/src-electron/generator/helper-access.js
@@ -26,10 +26,10 @@ const dbEnum = require('../../src-shared/db-enum')
  */
 
 async function collectDefaultAccessList(ctx, entityType) {
-  let packageId = await templateUtil.ensureZclPackageId(ctx)
+  let packageIds = await templateUtil.ensureZclPackageIds(ctx)
   let defaultAccess = await queryAccess.selectDefaultAccess(
     ctx.global.db,
-    packageId,
+    packageIds,
     entityType
   )
   return defaultAccess
@@ -90,7 +90,7 @@ async function collectAccesslist(ctx, options) {
  * @param {*} options
  */
 async function access_aggregate(options) {
-  let packageId = await templateUtil.ensureZclPackageId(this)
+  let packageIds = await templateUtil.ensureZclPackageIds(this)
   let accessList = await collectAccesslist(this, options)
   let ignoreEmpty
   if ('ignoreEmpty' in options.hash) {
@@ -101,13 +101,13 @@ async function access_aggregate(options) {
 
   let allOps = await queryAccess.selectAccessOperations(
     this.global.db,
-    packageId
+    packageIds
   )
   let allMods = await queryAccess.selectAccessModifiers(
     this.global.db,
-    packageId
+    packageIds
   )
-  let allRoles = await queryAccess.selectAccessRoles(this.global.db, packageId)
+  let allRoles = await queryAccess.selectAccessRoles(this.global.db, packageIds)
   let roleLevels = {}
   allRoles.forEach((r) => {
     roleLevels[r.name] = r.level

--- a/src-electron/generator/helper-attribute.js
+++ b/src-electron/generator/helper-attribute.js
@@ -38,10 +38,10 @@ async function attributeDefault(options) {
   // when used at the cluster level, 'this' is a cluster
   let code = parseInt(options.hash.code)
 
-  let packageId = await templateUtil.ensureZclPackageId(this)
+  let packageIds = await templateUtil.ensureZclPackageIds(this)
   let attr = await queryAttribute.selectAttributeByCode(
     this.global.db,
-    packageId,
+    packageIds,
     this.id,
     code,
     this.mfgCode
@@ -50,7 +50,7 @@ async function attributeDefault(options) {
     // Check if it's global attribute
     attr = await queryAttribute.selectAttributeByCode(
       this.global.db,
-      packageId,
+      packageIds,
       null,
       code,
       this.mfgCode

--- a/src-electron/generator/helper-c.js
+++ b/src-electron/generator/helper-c.js
@@ -78,10 +78,10 @@ function asHex(rawValue, padding, nullValue) {
  * returning the correct C type for the given data type
  * @param {*} dataType
  * @param {*} context
- * @param {*} packageId
+ * @param {*} packageIds
  * @returns The appropriate C type for the given data type
  */
-async function asUnderlyingTypeHelper(dataType, context, packageId) {
+async function asUnderlyingTypeHelper(dataType, context, packageIds) {
   try {
     if (
       dataType &&
@@ -89,7 +89,7 @@ async function asUnderlyingTypeHelper(dataType, context, packageId) {
     ) {
       let bt = await queryZcl.selectBitmapByName(
         context.global.db,
-        packageId,
+        packageIds,
         dataType.name
       )
       return context.global.overridable.bitmapType(bt.size)
@@ -100,7 +100,7 @@ async function asUnderlyingTypeHelper(dataType, context, packageId) {
       let et = await queryZcl.selectEnumByName(
         context.global.db,
         dataType.name,
-        packageId
+        packageIds
       )
       return context.global.overridable.enumType(et.size, et.name)
     } else if (
@@ -109,7 +109,7 @@ async function asUnderlyingTypeHelper(dataType, context, packageId) {
     ) {
       let nt = await queryZcl.selectNumberByName(
         context.global.db,
-        packageId,
+        packageIds,
         dataType.name
       )
       return context.global.overridable.numberType(
@@ -144,7 +144,7 @@ async function asUnderlyingTypeHelper(dataType, context, packageId) {
  */
 async function asUnderlyingType(value) {
   let dataType = null
-  let packageId = await templateUtil.ensureZclPackageId(this)
+  let packageIds = await templateUtil.ensureZclPackageIds(this)
 
   // Step 1: Extracting the data type based on id or name
   if (typeof value === 'number') {
@@ -153,7 +153,7 @@ async function asUnderlyingType(value) {
     dataType = await queryZcl.selectDataTypeByName(
       this.global.db,
       value,
-      packageId
+      packageIds
     )
   }
 
@@ -172,7 +172,7 @@ async function asUnderlyingType(value) {
 
   // Step 3: Detecting the type of the data type and returning the appropriate c
   // type through overridable
-  return asUnderlyingTypeHelper(dataType, this, packageId)
+  return asUnderlyingTypeHelper(dataType, this, packageIds)
 }
 
 /**
@@ -239,9 +239,9 @@ async function asBytes(value, type) {
     return value
   } else {
     return templateUtil
-      .ensureZclPackageId(this)
-      .then((packageId) =>
-        queryZcl.selectSizeFromType(this.global.db, packageId, type)
+      .ensureZclPackageIds(this)
+      .then((packageIds) =>
+        queryZcl.selectSizeFromType(this.global.db, packageIds, type)
       )
       .then((x) => {
         if (x == null) {
@@ -367,10 +367,10 @@ function as_zcl_cli_type(str, optional, isSigned) {
  *
  * @param {*} db
  * @param {*} bitmap_name
- * @param {*} packageId
+ * @param {*} packageIds
  */
-function dataTypeForBitmap(db, bitmap_name, packageId) {
-  return queryZcl.selectBitmapByName(db, packageId, bitmap_name).then((bm) => {
+function dataTypeForBitmap(db, bitmap_name, packageIds) {
+  return queryZcl.selectBitmapByName(db, packageIds, bitmap_name).then((bm) => {
     if (bm == null) {
       return `!!Invalid bitmap: ${bitmap_name}`
     } else {
@@ -384,10 +384,10 @@ function dataTypeForBitmap(db, bitmap_name, packageId) {
  *
  * @param {*} db
  * @param {*} enum_name
- * @param {*} packageId
+ * @param {*} packageIds
  */
-function dataTypeForEnum(db, enum_name, packageId) {
-  return queryZcl.selectEnumByName(db, enum_name, packageId).then((e) => {
+function dataTypeForEnum(db, enum_name, packageIds) {
+  return queryZcl.selectEnumByName(db, enum_name, packageIds).then((e) => {
     if (e == null) {
       return `!!Invalid enum: ${enum_name}`
     } else {

--- a/src-electron/generator/helper-command.js
+++ b/src-electron/generator/helper-command.js
@@ -37,14 +37,8 @@ async function if_command_arguments_exist(
   argument_return,
   no_argument_return
 ) {
-  let packageId = await templateUtil.ensureZclPackageId(this)
-
   let promise = queryCommand
-    .selectCommandArgumentsCountByCommandId(
-      this.global.db,
-      commandId,
-      packageId
-    )
+    .selectCommandArgumentsCountByCommandId(this.global.db, commandId)
     .then((res) => {
       if (res > 0) {
         return argument_return
@@ -72,11 +66,9 @@ async function if_command_arguments_exist(
  *
  */
 async function if_command_args_exist(commandId, options) {
-  let packageId = await templateUtil.ensureZclPackageId(this)
   let res = await queryCommand.selectCommandArgumentsCountByCommandId(
     this.global.db,
-    commandId,
-    packageId
+    commandId
   )
   if (res > 0) {
     return options.fn(this)

--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -885,11 +885,13 @@ async function collectAttributes(endpointTypes, options) {
 /**
  * This function goes over all the attributes and populates sizes.
  *
+ * @param {*} db
+ * @param {*} zclPackageIds
  * @param {*} endpointTypes
  * @returns promise that resolves with the passed endpointTypes, after populating the attribute type sizes.
  *
  */
-async function collectAttributeSizes(db, zclPackageId, endpointTypes) {
+async function collectAttributeSizes(db, zclPackageIds, endpointTypes) {
   let ps = []
   endpointTypes.forEach((ept) => {
     ept.clusters.forEach((cl) => {
@@ -898,7 +900,7 @@ async function collectAttributeSizes(db, zclPackageId, endpointTypes) {
           types
             .typeSizeAttribute(
               db,
-              zclPackageId,
+              zclPackageIds,
               at,
               `ERROR: ${at.name}, invalid size, ${at.type}`
             )
@@ -915,17 +917,19 @@ async function collectAttributeSizes(db, zclPackageId, endpointTypes) {
 
 /**
  * This function goes over all attributes and populates atomic types.
+ * @param {*} db
+ * @param {*} zclPackageIds
  * @param {*} endpointTypes
  * @returns promise that resolves with the passed endpointTypes, after populating the attribute atomic types.
  *
  */
-async function collectAttributeTypeInfo(db, zclPackageId, endpointTypes) {
+async function collectAttributeTypeInfo(db, zclPackageIds, endpointTypes) {
   let ps = []
   endpointTypes.forEach((ept) => {
     ept.clusters.forEach((cl) => {
       cl.attributes.forEach((at) => {
         ps.push(
-          zclUtil.determineType(db, at.type, zclPackageId).then((typeInfo) => {
+          zclUtil.determineType(db, at.type, zclPackageIds).then((typeInfo) => {
             at.typeInfo = typeInfo
           })
         )
@@ -964,7 +968,7 @@ function endpoint_config(options) {
     spaceForDefaultValue: options.hash.spaceForDefaultValue,
   }
   let promise = templateUtil
-    .ensureZclPackageId(newContext)
+    .ensureZclPackageIds(newContext)
     .then(() => queryEndpoint.selectAllEndpoints(db, sessionId))
     .then((endpoints) => {
       newContext.endpoints = endpoints
@@ -1043,10 +1047,10 @@ function endpoint_config(options) {
       return Promise.all(promises).then(() => endpointTypes)
     })
     .then((endpointTypes) =>
-      collectAttributeTypeInfo(db, this.global.zclPackageId, endpointTypes)
+      collectAttributeTypeInfo(db, this.global.zclPackageIds, endpointTypes)
     )
     .then((endpointTypes) =>
-      collectAttributeSizes(db, this.global.zclPackageId, endpointTypes)
+      collectAttributeSizes(db, this.global.zclPackageIds, endpointTypes)
     )
     .then((endpointTypes) =>
       collectAttributes(endpointTypes, collectAttributesOptions)

--- a/src-electron/generator/helper-tokens.js
+++ b/src-electron/generator/helper-tokens.js
@@ -54,7 +54,7 @@ function token_cluster_create(config) {
   map of clusters is required in order to gather all attributes (singletons and
   non-singletons) from all endpoint clusters.
 */
-function tokens_context(options) {
+async function tokens_context(options) {
   let context = {
     global: this.global,
     endpoints: {},
@@ -66,7 +66,7 @@ function tokens_context(options) {
     token_id: 0xb000,
   }
   let promises = []
-
+  let packageIds = await templateUtil.ensureZclPackageIds(this)
   // Loop through all the endpoints
   this.endpoints.forEach((endpoint) => {
     // Endpoint
@@ -155,7 +155,7 @@ function tokens_context(options) {
                   types
                     .typeSizeAttribute(
                       this.global.db,
-                      this.global.zclPackageId,
+                      packageIds,
                       attribute,
                       `ERROR: ${attribute.name}, invalid size, ${attribute.type}`
                     )

--- a/src-electron/generator/helper-zigbee-zcl.js
+++ b/src-electron/generator/helper-zigbee-zcl.js
@@ -48,18 +48,18 @@ async function zcl_command_argument_type_to_cli_data_type_util(
   context,
   options
 ) {
-  const packageId = await templateUtil.ensureZclPackageId(context)
+  const packageIds = await templateUtil.ensureZclPackageIds(context)
   let arrayExtension = 'isArray' in context && context.isArray ? 'OPT' : ''
   let dataType = await queryZcl.selectDataTypeByName(
     context.global.db,
     type,
-    packageId
+    packageIds
   )
   if (dataType) {
     if (dataType.discriminatorName.toLowerCase() == dbEnum.zclType.bitmap) {
       let bitmap = await queryZcl.selectBitmapByName(
         context.global.db,
-        packageId,
+        packageIds,
         dataType.name
       )
       let bitmapSize = await get_cli_size(bitmap.size, type, allowZclTypes)
@@ -70,7 +70,7 @@ async function zcl_command_argument_type_to_cli_data_type_util(
       let en = await queryZcl.selectEnumByName(
         context.global.db,
         dataType.name,
-        packageId
+        packageIds
       )
       let enumSize = await get_cli_size(en.size, type, allowZclTypes)
       return cliPrefix + '_UINT' + enumSize + arrayExtension
@@ -79,7 +79,7 @@ async function zcl_command_argument_type_to_cli_data_type_util(
     ) {
       let number = await queryZcl.selectNumberByName(
         context.global.db,
-        packageId,
+        packageIds,
         dataType.name
       )
       let numSize = await get_cli_size(number.size, type, allowZclTypes)

--- a/src-electron/generator/matter/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src-electron/generator/matter/app/zap-templates/common/ClusterTestGeneration.js
@@ -1179,18 +1179,18 @@ async function asTestType(type, isList) {
     return 'list';
   }
 
-  const pkgId = await templateUtil.ensureZclPackageId(this);
+  const pkgIds = await templateUtil.ensureZclPackageIds(this);
   const db = this.global.db;
 
-  const isEnum = await zclHelper.isEnum(db, type, pkgId);
+  const isEnum = await zclHelper.isEnum(db, type, pkgIds);
   if (isEnum != 'unknown') {
-    const enumObj = await queryEnum.selectEnumByName(db, type, pkgId);
+    const enumObj = await queryEnum.selectEnumByName(db, type, pkgIds);
     return 'enum' + 8 * enumObj.size;
   }
 
-  const isBitmap = await zclHelper.isBitmap(db, type, pkgId);
+  const isBitmap = await zclHelper.isBitmap(db, type, pkgIds);
   if (isBitmap != 'unknown') {
-    const bitmapObj = await queryBitmap.selectBitmapByName(db, pkgId, type);
+    const bitmapObj = await queryBitmap.selectBitmapByName(db, pkgIds, type);
     return 'bitmap' + 8 * bitmapObj.size;
   }
 

--- a/src-electron/generator/matter/app/zap-templates/common/attributes/Accessors.js
+++ b/src-electron/generator/matter/app/zap-templates/common/attributes/Accessors.js
@@ -109,8 +109,8 @@ async function accessorTraitType(type) {
 
 async function typeAsDelimitedMacro(type) {
   const { db } = this.global;
-  const pkgId = await templateUtil.ensureZclPackageId(this);
-  const typeInfo = await zclUtil.determineType(db, type, pkgId);
+  const pkgIds = await templateUtil.ensureZclPackageIds(this);
+  const typeInfo = await zclUtil.determineType(db, type, pkgIds);
   return cHelper.asDelimitedMacro.call(this, typeInfo.atomicType);
 }
 

--- a/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
@@ -305,7 +305,7 @@ async function asNativeType(type) {
   }
 
   const promise = templateUtil
-    .ensureZclPackageId(this)
+    .ensureZclPackageIds(this)
     .then(fn.bind(this))
     .catch((err) => {
       console.log(err);
@@ -527,7 +527,9 @@ async function zapTypeToClusterObjectType(type, isDecodable, options) {
     );
   }
 
-  let typeStr = await templateUtil.ensureZclPackageId(this).then(fn.bind(this));
+  let typeStr = await templateUtil
+    .ensureZclPackageIds(this)
+    .then(fn.bind(this));
   if ((this.isArray || this.entryType) && !options.hash.forceNotList) {
     passByReference = true;
     // If we did not have a namespace provided, we can assume we're inside
@@ -638,7 +640,7 @@ async function _zapTypeToPythonClusterObjectType(type, options) {
     }
   }
 
-  let promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this));
+  let promise = templateUtil.ensureZclPackageIds(this).then(fn.bind(this));
   if ((this.isArray || this.entryType) && !options.hash.forceNotList) {
     promise = promise.then((typeStr) => `typing.List[${typeStr}]`);
   }
@@ -724,7 +726,7 @@ async function _getPythonFieldDefault(type, options) {
     }
   }
 
-  let promise = templateUtil.ensureZclPackageId(this).then(fn.bind(this));
+  let promise = templateUtil.ensureZclPackageIds(this).then(fn.bind(this));
   if ((this.isArray || this.entryType) && !options.hash.forceNotList) {
     promise = promise.then((typeStr) => `field(default_factory=lambda: [])`);
   }
@@ -801,10 +803,10 @@ function hasProperty(obj, prop) {
 
 async function zcl_events_fields_by_event_name(name, options) {
   const { db, sessionId } = this.global;
-  const packageId = await templateUtil.ensureZclPackageId(this);
+  const packageIds = await templateUtil.ensureZclPackageIds(this);
 
   const promise = queryEvents
-    .selectAllEvents(db, packageId)
+    .selectAllEvents(db, packageIds)
     .then((events) => events.find((event) => event.name == name))
     .then((evt) => queryEvents.selectEventFieldsByEventId(db, evt.id))
     .then((fields) =>
@@ -820,11 +822,11 @@ async function zcl_events_fields_by_event_name(name, options) {
 // Must be used inside zcl_clusters
 async function zcl_commands_that_need_timed_invoke(options) {
   const { db } = this.global;
-  let packageId = await templateUtil.ensureZclPackageId(this);
+  let packageIds = await templateUtil.ensureZclPackageIds(this);
   let commands = await queryCommand.selectCommandsByClusterId(
     db,
     this.id,
-    packageId
+    packageIds
   );
   commands = commands.filter((cmd) => cmd.mustUseTimedInvoke);
   return templateUtil.collectBlocks(commands, options, this);
@@ -833,8 +835,8 @@ async function zcl_commands_that_need_timed_invoke(options) {
 // Allows conditioning generation on whether the given type is a fabric-scoped
 // struct.
 async function if_is_fabric_scoped_struct(type, options) {
-  let packageId = await templateUtil.ensureZclPackageId(this);
-  let st = await zclQuery.selectStructByName(this.global.db, type, packageId);
+  let packageIds = await templateUtil.ensureZclPackageIds(this);
+  let st = await zclQuery.selectStructByName(this.global.db, type, packageIds);
 
   if (st) {
     // TODO: Should know whether a struct is fabric-scoped without sniffing its

--- a/src-electron/generator/matter/app/zap-templates/templates/chip/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/chip/helper.js
@@ -545,10 +545,14 @@ async function chip_endpoint_clusters(options) {
  * @returns Promise of content.
  */
 async function if_is_strongly_typed_bitmap(type, options) {
-  let packageId = await templateUtil.ensureZclPackageId(this);
+  let packageIds = await templateUtil.ensureZclPackageIds(this);
   let bitmap;
   if (type && typeof type === 'string') {
-    bitmap = await queryZcl.selectBitmapByName(this.global.db, packageId, type);
+    bitmap = await queryZcl.selectBitmapByName(
+      this.global.db,
+      packageIds,
+      type
+    );
   } else {
     bitmap = await queryZcl.selectBitmapById(this.global.db, type);
   }
@@ -556,7 +560,7 @@ async function if_is_strongly_typed_bitmap(type, options) {
   if (bitmap) {
     let a = await queryZcl.selectAtomicType(
       this.global.db,
-      packageId,
+      packageIds,
       bitmap.name
     );
     if (a) {
@@ -589,14 +593,14 @@ async function if_is_strongly_typed_chip_enum(type, options) {
   if (type.toLowerCase() == 'vendor_id') {
     return options.fn(this);
   } else {
-    let packageId = await templateUtil.ensureZclPackageId(this);
+    let packageIds = await templateUtil.ensureZclPackageIds(this);
     let enumRes;
     // Retrieving the enum from the enum table
     if (type && typeof type === 'string') {
       enumRes = await queryZcl.selectEnumByName(
         this.global.db,
         type,
-        packageId
+        packageIds
       );
     } else {
       enumRes = await queryZcl.selectEnumById(this.global.db, type);
@@ -607,7 +611,7 @@ async function if_is_strongly_typed_chip_enum(type, options) {
     if (enumRes) {
       let a = await queryZcl.selectAtomicType(
         this.global.db,
-        packageId,
+        packageIds,
         enumRes.name
       );
       if (a) {
@@ -630,8 +634,8 @@ async function if_chip_enum(type, options) {
     return options.fn(this);
   }
 
-  let pkgId = await templateUtil.ensureZclPackageId(this);
-  let checkResult = await zclHelper.isEnum(this.global.db, type, pkgId);
+  let pkgIds = await templateUtil.ensureZclPackageIds(this);
+  let checkResult = await zclHelper.isEnum(this.global.db, type, pkgIds);
   let result;
   if (checkResult != 'unknown') {
     result = options.fn(this);
@@ -656,8 +660,8 @@ async function if_chip_complex(options) {
     return options.fn(this);
   }
 
-  let pkgId = await templateUtil.ensureZclPackageId(this);
-  let checkResult = await zclHelper.isStruct(this.global.db, this.type, pkgId);
+  let pkgIds = await templateUtil.ensureZclPackageIds(this);
+  let checkResult = await zclHelper.isStruct(this.global.db, this.type, pkgIds);
   let result;
   if (checkResult != 'unknown') {
     result = options.fn(this);

--- a/src-electron/generator/matter/chip-tool/templates/helper.js
+++ b/src-electron/generator/matter/chip-tool/templates/helper.js
@@ -64,7 +64,7 @@ function asTypeMinValue(type) {
   }
 
   const promise = templateUtil
-    .ensureZclPackageId(this)
+    .ensureZclPackageIds(this)
     .then(fn.bind(this))
     .catch((err) => {
       console.log(err);
@@ -103,7 +103,7 @@ function asTypeMaxValue(type) {
   }
 
   const promise = templateUtil
-    .ensureZclPackageId(this)
+    .ensureZclPackageIds(this)
     .then(fn.bind(this))
     .catch((err) => {
       console.log(err);
@@ -113,11 +113,11 @@ function asTypeMaxValue(type) {
 }
 
 async function structs_with_cluster_name(options) {
-  const packageId = await templateUtil.ensureZclPackageId(this);
+  const packageIds = await templateUtil.ensureZclPackageIds(this);
 
   const structs = await zclQuery.selectAllStructsWithItems(
     this.global.db,
-    packageId
+    packageIds
   );
 
   let blocks = [];

--- a/src-electron/generator/matter/controller/java/templates/helper.js
+++ b/src-electron/generator/matter/controller/java/templates/helper.js
@@ -132,7 +132,7 @@ function asJniSignatureBasic(type, useBoxedTypes) {
   }
 
   const promise = templateUtil
-    .ensureZclPackageId(this)
+    .ensureZclPackageIds(this)
     .then(fn.bind(this))
     .catch((err) => {
       console.log(err);
@@ -194,13 +194,13 @@ async function asUnderlyingBasicType(type) {
 }
 
 async function asJavaType(type, zclType, cluster, options) {
-  let pkgId = await templateUtil.ensureZclPackageId(this);
+  let pkgIds = await templateUtil.ensureZclPackageIds(this);
   if (zclType == null) {
     const options = { hash: {} };
     zclType = await zclHelper.asUnderlyingZclType.call(this, type, options);
   }
   let isStruct = await zclHelper
-    .isStruct(this.global.db, type, pkgId)
+    .isStruct(this.global.db, type, pkgIds)
     .then((zclType) => zclType != 'unknown');
 
   let classType = '';
@@ -258,12 +258,12 @@ async function asJniClassName(type, zclType, cluster, options) {
 }
 
 async function asJniHelper(type, zclType, cluster, options) {
-  let pkgId = await templateUtil.ensureZclPackageId(this);
+  let pkgIds = await templateUtil.ensureZclPackageIds(this);
   if (zclType == null) {
     zclType = await zclHelper.asUnderlyingZclType.call(this, type, options);
   }
   let isStruct = await zclHelper
-    .isStruct(this.global.db, type, pkgId)
+    .isStruct(this.global.db, type, pkgIds)
     .then((zclType) => zclType != 'unknown');
 
   if (this.isOptional) {

--- a/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
+++ b/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
@@ -124,16 +124,16 @@ function asObjectiveCNumberType(label, type, asLowerCased) {
   }
 
   const promise = templateUtil
-    .ensureZclPackageId(this)
+    .ensureZclPackageIds(this)
     .then(fn.bind(this))
     .catch((err) => console.log(err));
   return templateUtil.templatePromise(this.global, promise);
 }
 
 async function asObjectiveCClass(type, cluster, options) {
-  let pkgId = await templateUtil.ensureZclPackageId(this);
+  let pkgIds = await templateUtil.ensureZclPackageIds(this);
   let isStruct = await zclHelper
-    .isStruct(this.global.db, type, pkgId)
+    .isStruct(this.global.db, type, pkgIds)
     .then((zclType) => zclType != 'unknown');
 
   if (

--- a/src-electron/rest/static-zcl.js
+++ b/src-electron/rest/static-zcl.js
@@ -157,10 +157,9 @@ function parseForZclData(db, entity, id, packageIdArray) {
         db,
         id,
         packageIdArray,
-        zclEntityQuery(
-          queryZcl.selectAllStructsWithItemCount,
-          queryZcl.selectStructById
-        )
+        zclEntityQuery(queryZcl.selectAllStructsWithItemCount, [
+          queryZcl.selectStructById,
+        ])
       )
     case 'deviceType':
       return reduceAndConcatenateZclEntity(

--- a/src-electron/util/types.js
+++ b/src-electron/util/types.js
@@ -33,7 +33,7 @@ const env = require('./env')
  * @param {*} type
  */
 async function typeSize(db, zclPackageId, type) {
-  return queryZcl.selectSizeFromType(db, zclPackageId, type)
+  return queryZcl.selectSizeFromType(db, [zclPackageId], type)
 }
 
 /**
@@ -41,12 +41,12 @@ async function typeSize(db, zclPackageId, type) {
  * into consideration, so that strings are properly sized.
  *
  * @param {*} db
- * @param {*} zclPackageId
+ * @param {*} zclPackageIds
  * @param {*} at
  * @param {*} [defaultValue=null]
  * @returns Promise that resolves into the size of the attribute.
  */
-async function typeSizeAttribute(db, zclPackageId, at, defaultValue = null) {
+async function typeSizeAttribute(db, zclPackageIds, at, defaultValue = null) {
   let sizeType
   if (at.typeInfo) {
     if (!at.typeInfo.atomicType && !at.typeInfo.size) {
@@ -59,7 +59,7 @@ async function typeSizeAttribute(db, zclPackageId, at, defaultValue = null) {
     }
   }
   sizeType = at.type
-  let size = await queryZcl.selectSizeFromType(db, zclPackageId, sizeType)
+  let size = await queryZcl.selectSizeFromType(db, zclPackageIds, sizeType)
 
   if (size) {
     return size

--- a/src-electron/zcl/zcl-loader-dotdot.js
+++ b/src-electron/zcl/zcl-loader-dotdot.js
@@ -883,7 +883,7 @@ async function processEnums(db, filePath, packageId, data) {
   let typeMap = await zclLoader.getDiscriminatorMap(db, packageId)
   return queryLoader.insertEnum(
     db,
-    packageId,
+    [packageId],
     data.map((x) => prepareEnumsOrBitmaps(x, typeMap.get(dbEnum.zclType.enum)))
   )
 }
@@ -918,7 +918,7 @@ async function processEnumItems(db, filePath, packageId, data) {
       })
     }
   })
-  return queryLoader.insertEnumItems(db, packageId, enumItems)
+  return queryLoader.insertEnumItems(db, packageId, [packageId], enumItems)
 }
 
 /**
@@ -935,7 +935,7 @@ async function processBitmaps(db, filePath, packageId, data) {
   let typeMap = await zclLoader.getDiscriminatorMap(db, packageId)
   return queryLoader.insertBitmap(
     db,
-    packageId,
+    [packageId],
     data.map((x) =>
       prepareEnumsOrBitmaps(x, typeMap.get(dbEnum.zclType.bitmap))
     )
@@ -972,7 +972,12 @@ async function processBitmapFields(db, filePath, packageId, data) {
       })
     }
   })
-  return queryLoader.insertBitmapFields(db, packageId, bitmapFields)
+  return queryLoader.insertBitmapFields(
+    db,
+    packageId,
+    [packageId],
+    bitmapFields
+  )
 }
 
 /**
@@ -1004,7 +1009,7 @@ async function processStruct(db, filePath, packageId, data) {
   let typeMap = await zclLoader.getDiscriminatorMap(db, packageId)
   return queryLoader.insertStruct(
     db,
-    packageId,
+    [packageId],
     data.map((x) => prepareStruct2(x, typeMap.get(dbEnum.zclType.struct)))
   )
 }
@@ -1050,7 +1055,7 @@ async function processStructItems(db, filePath, packageId, data) {
       })
     }
   })
-  return queryLoader.insertStructItems(db, packageId, structItems)
+  return queryLoader.insertStructItems(db, [packageId], structItems)
 }
 
 /**

--- a/src-electron/zcl/zcl-loader.js
+++ b/src-electron/zcl/zcl-loader.js
@@ -294,12 +294,12 @@ async function processZclPostLoading(db, packageId) {
 /**
  *
  * @param {*} db
- * @param {*} packageId
+ * @param {*} packageIds
  * @returns data type discriminator map
  */
-async function getDiscriminatorMap(db, packageId) {
+async function getDiscriminatorMap(db, packageIds) {
   let typeMap = new Map()
-  let discriminators = await queryZcl.selectAllDiscriminators(db, packageId)
+  let discriminators = await queryZcl.selectAllDiscriminators(db, packageIds)
   discriminators.forEach((d) => {
     typeMap.set(d.name.toLowerCase(), d.id)
   })

--- a/test/gen-meta.test.js
+++ b/test/gen-meta.test.js
@@ -87,10 +87,9 @@ test(
     expect(access[0].role).toBeNull()
     expect(access[0].accessModifier).toBe('fabric-sensitive')
 
-    const structs = await queryZcl.selectAllStructsWithItemCount(
-      db,
-      zclContext.packageId
-    )
+    const structs = await queryZcl.selectAllStructsWithItemCount(db, [
+      zclContext.packageId,
+    ])
     for (const s of structs) {
       let clusters = await queryZcl.selectStructClusters(db, s.id)
       if (s.name == 'SimpleStruct') {

--- a/test/gen-template/zigbee/gen-templates.json
+++ b/test/gen-template/zigbee/gen-templates.json
@@ -198,6 +198,11 @@
       "output": "zap-command.h"
     },
     {
+      "path": "zap-command-ver-2.zapt",
+      "name": "ZCL command APIs version 2",
+      "output": "zap-command-ver-2.h"
+    },
+    {
       "path": "zap-outgoing-command.zapt",
       "name": "ZCL outgoing command",
       "output": "zap-outgoing-command.out"

--- a/test/gen-template/zigbee/zap-command-ver-2.zapt
+++ b/test/gen-template/zigbee/zap-command-ver-2.zapt
@@ -1,0 +1,250 @@
+{{#zcl_global_commands}}
+{{#if (is_str_equal source "either")}}
+/** @brief Command description for {{label}}
+*
+* Command: {{label}}
+* @param clusterId EmberAfClusterId*/
+{{#zcl_command_arguments}}
+// @param {{name}} {{as_underlying_zcl_type type}}
+{{#if isArray}}// @param {{name}}Len uint16_t {{/if}}
+{{/zcl_command_arguments}}
+#define emberAfFillCommandGlobalServerToClient{{name}}(clusterId, \
+{{#zcl_command_arguments}}
+  {{#if isArray}}
+  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+  {{else}}
+  {{name}}{{#not_last}},{{/not_last~}}
+  {{/if~}}
+{{/zcl_command_arguments}}) \
+emberAfFillExternalBuffer((ZCL_GLOBAL_COMMAND \
+                           | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT {{#is_command_default_response_disabled .}} | ZCL_DISABLE_DEFAULT_RESPONSE_MASK{{/is_command_default_response_disabled}}), \
+                           clusterId, \
+                           ZCL_{{as_delimited_macro label}}_COMMAND_ID, \
+                           "{{#zcl_command_arguments}}{{as_underlying_zcl_type type array="b" one_byte="u" two_byte="v" three_byte="x" four_byte="w" short_string="s" long_string="l" ten_byte="A" eleven_byte="B" twelve_byte="C" thirten_byte="D" fourteen_byte="E" fifteen_byte="F" sixteen_byte="G" struct="b" defaul="b" zclCharFormatter="true"}}{{/zcl_command_arguments}}"{{#if_command_args_exist this.id}},{{/if_command_args_exist}} \
+                           {{#zcl_command_arguments}}
+							  {{#if isArray}}
+							  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+							  {{else}}
+							  {{name}}{{#not_last}},{{/not_last~}}
+							  {{/if~}}
+						   {{/zcl_command_arguments}});
+
+/** @brief Command description for {{label}}
+*
+* Command: {{label}}
+* @param clusterId EmberAfClusterId*/
+{{#zcl_command_arguments}}
+// @param {{name}} {{as_underlying_zcl_type type}}
+{{#if isArray}}// @param {{name}}Len uint16_t {{/if}}
+{{/zcl_command_arguments}}
+#define emberAfFillCommandGlobalClientToServer{{name}}(clusterId, \
+{{#zcl_command_arguments}}
+  {{#if isArray}}
+  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+  {{else}}
+  {{name}}{{#not_last}},{{/not_last~}}
+  {{/if~}}
+{{/zcl_command_arguments}}) \
+emberAfFillExternalBuffer((ZCL_GLOBAL_COMMAND \
+                           | ZCL_FRAME_CONTROL_CLIENT_TO_SERVER{{#is_command_default_response_disabled .}} | ZCL_DISABLE_DEFAULT_RESPONSE_MASK{{/is_command_default_response_disabled}}), \
+                           clusterId, \
+                           ZCL_{{as_delimited_macro label}}_COMMAND_ID, \
+                           "{{#zcl_command_arguments}}{{as_underlying_zcl_type type array="b" one_byte="u" two_byte="v" three_byte="x" four_byte="w" short_string="s" long_string="l" ten_byte="A" eleven_byte="B" twelve_byte="C" thirten_byte="D" fourteen_byte="E" fifteen_byte="F" sixteen_byte="G" struct="b" defaul="b" zclCharFormatter="true"}}{{/zcl_command_arguments}}"{{#if_command_args_exist this.id}},{{/if_command_args_exist}} \
+                           {{#zcl_command_arguments}}
+							  {{#if isArray}}
+							  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+							  {{else}}
+							  {{name}}{{#not_last}},{{/not_last~}}
+							  {{/if~}}
+						   {{/zcl_command_arguments}});
+{{else}}
+
+/** @brief Command description for {{label}}
+*
+* Command: {{label}}
+* @param clusterId EmberAfClusterId*/
+{{#zcl_command_arguments}}
+// @param {{name}} {{as_underlying_zcl_type type}}
+{{#if isArray}}// @param {{name}}Len uint16_t {{/if}}
+{{/zcl_command_arguments}}
+{{#if (is_client source)}}
+#define emberAfFillCommandGlobalClientToServer{{name}}(clusterId, \
+{{#zcl_command_arguments}}
+  {{#if isArray}}
+  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+  {{else}}
+  {{name}}{{#not_last}},{{/not_last~}}
+  {{/if~}}
+{{/zcl_command_arguments}}) \
+emberAfFillExternalBuffer((ZCL_GLOBAL_COMMAND \
+                           | ZCL_FRAME_CONTROL_CLIENT_TO_SERVER{{#is_command_default_response_disabled .}} | ZCL_DISABLE_DEFAULT_RESPONSE_MASK{{/is_command_default_response_disabled}}), \
+                           clusterId, \
+                           ZCL_{{as_delimited_macro label}}_COMMAND_ID, \
+                           "{{#zcl_command_arguments}}{{as_underlying_zcl_type type array="b" one_byte="u" two_byte="v" three_byte="x" four_byte="w" short_string="s" long_string="l" ten_byte="A" eleven_byte="B" twelve_byte="C" thirten_byte="D" fourteen_byte="E" fifteen_byte="F" sixteen_byte="G" struct="b" defaul="b" zclCharFormatter="true"}}{{/zcl_command_arguments}}"{{#if_command_args_exist this.id}},{{/if_command_args_exist}} \
+                           {{#zcl_command_arguments}}
+							  {{#if isArray}}
+							  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+							  {{else}}
+							  {{name}}{{#not_last}},{{/not_last~}}
+							  {{/if~}}
+						   {{/zcl_command_arguments}});
+
+{{else}}
+#define emberAfFillCommandGlobalServerToClient{{name}}(clusterId, \
+{{#zcl_command_arguments}}
+  {{#if isArray}}
+  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+  {{else}}
+  {{name}}{{#not_last}},{{/not_last~}}
+  {{/if~}}
+{{/zcl_command_arguments}}) \
+emberAfFillExternalBuffer((ZCL_GLOBAL_COMMAND \
+                           | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT{{#is_command_default_response_disabled .}} | ZCL_DISABLE_DEFAULT_RESPONSE_MASK{{/is_command_default_response_disabled}}), \
+                           clusterId, \
+                           ZCL_{{as_delimited_macro label}}_COMMAND_ID, \
+                           "{{#zcl_command_arguments}}{{as_underlying_zcl_type type array="b" one_byte="u" two_byte="v" three_byte="x" four_byte="w" short_string="s" long_string="l" ten_byte="A" eleven_byte="B" twelve_byte="C" thirten_byte="D" fourteen_byte="E" fifteen_byte="F" sixteen_byte="G" struct="b" defaul="b" zclCharFormatter="true"}}{{/zcl_command_arguments}}"{{#if_command_args_exist this.id}},{{/if_command_args_exist}} \
+                           {{#zcl_command_arguments}}
+							  {{#if isArray}}
+							  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+							  {{else}}
+							  {{name}}{{#not_last}},{{/not_last~}}
+							  {{/if~}}
+						   {{/zcl_command_arguments}});
+
+{{/if}}
+
+{{/if}}
+{{/zcl_global_commands}}
+/** @} END Global Commands */
+
+
+// Cluster Specific Commands
+
+{{#zcl_clusters}}
+{{#zcl_commands}}
+{{#if (is_str_equal source "either")}}
+/** @brief {{description}}
+* Cluster: {{../label}}, {{../caption}}
+* Command: {{name}}*/
+{{#zcl_command_arguments}}
+// @param {{name}} {{as_underlying_zcl_type type}}
+{{#if isArray}}// @param {{name}}Len uint16_t {{/if}}
+{{/zcl_command_arguments}}
+#define emberAfFillCommand{{as_camel_cased ../define false}}ServerToClient{{name}}( \
+{{#zcl_command_arguments}}
+  {{#if isArray}}
+  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+  {{else}}
+  {{name}}{{#not_last}},{{/not_last~}}
+  {{/if~}}
+{{/zcl_command_arguments}}) \
+emberAfFillExternal{{#if_mfg_specific_cluster ../id}}ManufacturerSpecific{{/if_mfg_specific_cluster}}Buffer((ZCL_CLUSTER_SPECIFIC_COMMAND{{#if_mfg_specific_cluster ../id}} | ZCL_MANUFACTURER_SPECIFIC_MASK{{/if_mfg_specific_cluster}} \
+                           | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT{{#is_command_default_response_disabled .}} | ZCL_DISABLE_DEFAULT_RESPONSE_MASK{{/is_command_default_response_disabled}}), \
+                           ZCL_{{as_delimited_macro ../define}}_ID, {{backslash}}{{new_line 1}}
+                           {{~#if_mfg_specific_cluster ../id~}}
+                           {{../manufacturerCode}}, \
+                           {{/if_mfg_specific_cluster}}
+                           ZCL_{{as_delimited_macro name}}_COMMAND_ID, \
+                           "{{#zcl_command_arguments}}{{as_underlying_zcl_type type array="b" one_byte="u" two_byte="v" three_byte="x" four_byte="w" short_string="s" long_string="l" ten_byte="A" eleven_byte="B" twelve_byte="C" thirten_byte="D" fourteen_byte="E" fifteen_byte="F" sixteen_byte="G" struct="b" defaul="b" zclCharFormatter="true"}}{{/zcl_command_arguments}}"{{#if_command_args_exist this.id}},{{/if_command_args_exist}} \
+                           {{#zcl_command_arguments}}
+							  {{#if isArray}}
+							  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+							  {{else}}
+							  {{name}}{{#not_last}},{{/not_last~}}
+							  {{/if~}}
+						   {{/zcl_command_arguments}});
+
+/** @brief {{description}}
+* Cluster: {{../label}}, {{../caption}}
+* Command: {{name}}*/
+{{#zcl_command_arguments}}
+// @param {{name}} {{as_underlying_zcl_type type}}
+{{#if isArray}}// @param {{name}}Len uint16_t {{/if}}
+{{/zcl_command_arguments}}
+#define emberAfFillCommand{{as_camel_cased ../define false}}ClientToServer{{name}}( \
+{{#zcl_command_arguments}}
+  {{#if isArray}}
+  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+  {{else}}
+  {{name}}{{#not_last}},{{/not_last~}}
+  {{/if~}}
+{{/zcl_command_arguments}}) \
+emberAfFillExternal{{#if_mfg_specific_cluster ../id}}ManufacturerSpecific{{/if_mfg_specific_cluster}}Buffer((ZCL_CLUSTER_SPECIFIC_COMMAND{{#if_mfg_specific_cluster ../id}} | ZCL_MANUFACTURER_SPECIFIC_MASK{{/if_mfg_specific_cluster}} \
+                           | ZCL_FRAME_CONTROL_CLIENT_TO_SERVER{{#is_command_default_response_disabled .}} | ZCL_DISABLE_DEFAULT_RESPONSE_MASK{{/is_command_default_response_disabled}}), \
+                           ZCL_{{as_delimited_macro ../define}}_ID, {{backslash}}{{new_line 1}}
+                           {{~#if_mfg_specific_cluster ../id~}}
+                           {{../manufacturerCode}}, \
+                           {{/if_mfg_specific_cluster}}
+                           ZCL_{{as_delimited_macro name}}_COMMAND_ID, \
+                           "{{#zcl_command_arguments}}{{as_underlying_zcl_type type array="b" one_byte="u" two_byte="v" three_byte="x" four_byte="w" short_string="s" long_string="l" ten_byte="A" eleven_byte="B" twelve_byte="C" thirten_byte="D" fourteen_byte="E" fifteen_byte="F" sixteen_byte="G" struct="b" defaul="b" zclCharFormatter="true"}}{{/zcl_command_arguments}}"{{#if_command_args_exist this.id}},{{/if_command_args_exist}} \
+                           {{#zcl_command_arguments}}
+							  {{#if isArray}}
+							  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+							  {{else}}
+							  {{name}}{{#not_last}},{{/not_last~}}
+							  {{/if~}}
+						   {{/zcl_command_arguments}});
+{{else}}
+
+/** @brief {{description}}
+* Cluster: {{../label}}, {{../caption}}
+* Command: {{name}}*/
+{{#zcl_command_arguments}}
+// @param {{name}} {{as_underlying_zcl_type type}}
+{{#if isArray}}// @param {{name}}Len uint16_t {{/if}}
+{{/zcl_command_arguments}}
+{{#if (is_client source)}}
+#define emberAfFillCommand{{as_camel_cased ../define false}}{{name}}( \
+{{#zcl_command_arguments}}
+  {{#if isArray}}
+  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+  {{else}}
+  {{name}}{{#not_last}},{{/not_last~}}
+  {{/if~}}
+{{/zcl_command_arguments}}) \
+emberAfFillExternal{{#if_mfg_specific_cluster ../id}}ManufacturerSpecific{{/if_mfg_specific_cluster}}Buffer((ZCL_CLUSTER_SPECIFIC_COMMAND{{#if_mfg_specific_cluster ../id}} | ZCL_MANUFACTURER_SPECIFIC_MASK{{/if_mfg_specific_cluster}} \
+                           | ZCL_FRAME_CONTROL_CLIENT_TO_SERVER{{#is_command_default_response_disabled .}} | ZCL_DISABLE_DEFAULT_RESPONSE_MASK{{/is_command_default_response_disabled}}), \
+                           ZCL_{{as_delimited_macro ../define}}_ID, {{backslash}}{{new_line 1}}
+                           {{~#if_mfg_specific_cluster ../id~}}
+                           {{../manufacturerCode}}, \
+                           {{/if_mfg_specific_cluster}}
+                           ZCL_{{as_delimited_macro name}}_COMMAND_ID, \
+                           "{{#zcl_command_arguments}}{{as_underlying_zcl_type type array="b" one_byte="u" two_byte="v" three_byte="x" four_byte="w" short_string="s" long_string="l" ten_byte="A" eleven_byte="B" twelve_byte="C" thirten_byte="D" fourteen_byte="E" fifteen_byte="F" sixteen_byte="G" struct="b" defaul="b" zclCharFormatter="true"}}{{/zcl_command_arguments}}"{{#if_command_args_exist this.id}},{{/if_command_args_exist}} \
+                           {{#zcl_command_arguments}}
+							  {{#if isArray}}
+							  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+							  {{else}}
+							  {{name}}{{#not_last}},{{/not_last~}}
+							  {{/if~}}
+						   {{/zcl_command_arguments}});
+
+{{else}}
+#define emberAfFillCommand{{as_camel_cased ../define false}}{{name}}( \
+{{#zcl_command_arguments}}
+  {{#if isArray}}
+  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+  {{else}}
+  {{name}}{{#not_last}},{{/not_last~}}
+  {{/if~}}
+{{/zcl_command_arguments}}) \
+emberAfFillExternal{{#if_mfg_specific_cluster ../id}}ManufacturerSpecific{{/if_mfg_specific_cluster}}Buffer((ZCL_CLUSTER_SPECIFIC_COMMAND{{#if_mfg_specific_cluster ../id}} | ZCL_MANUFACTURER_SPECIFIC_MASK{{/if_mfg_specific_cluster}} \
+                           | ZCL_FRAME_CONTROL_SERVER_TO_CLIENT{{#is_command_default_response_disabled .}} | ZCL_DISABLE_DEFAULT_RESPONSE_MASK{{/is_command_default_response_disabled}}), \
+                           ZCL_{{as_delimited_macro ../define}}_ID, {{backslash}}{{new_line 1}}
+                           {{~#if_mfg_specific_cluster ../id~}}
+                           {{../manufacturerCode}}, \
+                           {{/if_mfg_specific_cluster}}
+                           ZCL_{{as_delimited_macro name}}_COMMAND_ID, \
+                           "{{#zcl_command_arguments}}{{as_underlying_zcl_type type array="b" one_byte="u" two_byte="v" three_byte="x" four_byte="w" short_string="s" long_string="l" ten_byte="A" eleven_byte="B" twelve_byte="C" thirten_byte="D" fourteen_byte="E" fifteen_byte="F" sixteen_byte="G" struct="b" defaul="b" zclCharFormatter="true"}}{{/zcl_command_arguments}}"{{#if_command_args_exist this.id}},{{/if_command_args_exist}} \
+                           {{#zcl_command_arguments}}
+							  {{#if isArray}}
+							  {{name}}, {{name}}Len{{#not_last}},{{/not_last~}}
+							  {{else}}
+							  {{name}}{{#not_last}},{{/not_last~}}
+							  {{/if~}}
+						   {{/zcl_command_arguments}});
+
+{{/if}}
+
+{{/if}}
+{{/zcl_commands}}
+{{/zcl_clusters}}

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -74,6 +74,7 @@ test(
     let globalCtx = {
       db: zclContext.db,
       zclPackageId: zclContext.packageId,
+      zclPackageIds: [zclContext.packageId],
     }
     ctx = {
       global: globalCtx,

--- a/test/resource/custom-cluster/custom-dut.xml
+++ b/test/resource/custom-cluster/custom-dut.xml
@@ -1,0 +1,296 @@
+<configurator>
+
+  <enum name="CustomStatus" type="ENUM8" description="Status Codes">
+    <item name="A"                      value="0x00" />
+    <item name="B"                      value="0x01" />
+    <item name="C"               value="0x70" />
+    <item name="D" value="0x71" />
+    <item name="E" value="0x72" />
+    <item name="F"            value="0x73" />
+    <item name="G"           value="0x74" />
+    <item name="H"               value="0x7E" />
+    <item name="I"      value="0x7F" />
+    <item name="J"            value="0x80" />
+    <item name="K"        value="0x81" />
+    <item name="L"        value="0x82" />
+    <item name="M"  value="0x83" />
+    <item name="N"  value="0x84" />
+    <item name="O"                value="0x85" />
+    <item name="P"        value="0x86" />
+    <item name="Q"                value="0x87" />
+    <item name="R"                    value="0x88" />
+    <item name="S"           value="0x89" />
+    <item name="T"             value="0x8A" />
+    <item name="U"                    value="0x8B" />
+    <item name="V"       value="0x8C" />
+    <item name="W"            value="0x8D" />
+    <item name="X"             value="0x8E" />
+    <item name="Y"                   value="0x8F" />
+    <item name="Z"   value="0x90" />
+    <item name="AA"          value="0x91" />
+    <item name="AB"                 value="0x92" />
+    <item name="AC"                value="0x93" />
+    <item name="AD"                      value="0x94" />
+    <item name="AE"                        value="0x95" />
+    <item name="AF"                value="0x96" />
+    <item name="AG"                value="0x97" />
+    <item name="AH"           value="0x98" />
+    <item name="AI"           value="0x99" />
+    <item name="AJ"             value="0xC0" />
+    <item name="AK"             value="0xC1" />
+    <item name="AL"            value="0xC2" />
+  </enum>
+
+  <enum name="CustomType" type="ENUM8">
+    <item name="T1"       value="0x00" />
+    <item name="T2"     value="0x01" />
+    <item name="T3"        value="0x02" />
+  </enum>
+
+  <enum name="CustomLevel" type="ENUM8">
+    <item name="L1"        value="0x00" />
+    <item name="L2"      value="0x01" />
+    <item name="L3"  value="0x02" />
+    <item name="L4"         value="0x03" />
+    <item name="L5"        value="0x04" />
+    <item name="L6"      value="0x05" />
+  </enum>
+
+  <enum name="CustomArea" type="ENUM8">
+    <item name="A1"        value="0x00" />
+  </enum>
+
+  <enum name="CustomType2" type="ENUM16">
+    <item name="T21"        value="0x0000" />
+  </enum>
+
+  <struct name="CustomStruct">
+    <item name="S1"       type="UTC_TIME" />
+    <item name="S2"      type="CustomType2" />
+    <item name="S3"      type="CustomLevel"  />
+    <item name="S4"       type="CustomArea" />
+  </struct>
+
+  <enum name="CustomId" type="ENUM8">
+    <item name="I1"             value="0x00" />
+    <item name="I2"            value="0x01" />
+    <item name="I3"            value="0x02" />
+    <item name="I4"        value="0x03" />
+  </enum>
+
+  <enum name="CustomColor" type="ENUM8">
+    <item name="C1"      value="0x0"/>
+    <item name="C2"    value="0x1"/>
+    <item name="C3"    value="0x2"/>
+    <item name="C4"     value="0x3"/>
+    <item name="C5"      value="0x4"/>
+  </enum>
+
+  <cluster manufacturerCode="0x10e0">
+    <name>Custom Cluster</name>
+    <domain>SE</domain>
+    <description>A Custom Cluster
+    </description>
+
+    <!-- Cluster Id must be within the mfg spec range 0xfc00 - 0xffff -->
+    <code>0xFCa7</code>
+    <define>CUSTOM_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+
+    <attribute manufacturerCode="0x10e0" side="server" code="0x0001" define="A1"
+      type="INT8U" min="0x00" max="0x01" writable="true"
+      default="0x01" optional="false">A1</attribute>
+
+    <attribute manufacturerCode="0x10e0" side="server" code="0x0100" define="A2"
+        type="INT32U" min="0x00" max="0xFFFFFFFE" writable="false"
+        default="576" optional="false">A2</attribute>
+
+    <attribute  manufacturerCode="0x10e0" side="server" code="0x0101" define="A3"
+        type="INT16U" min="0x00" max="0xFFFE" writable="false"
+        default="24" optional="true">A3</attribute>
+
+    <attribute  manufacturerCode="0x10e0" side="server" code="0x0102" define="A4"
+        type="INT16U" min="0x00" max="0xFFFE" writable="false"
+        default="192" optional="true">A4</attribute>
+
+    <attribute  manufacturerCode="0x10e0" side="server" code="0x0103" define="A5"
+        type="INT8U" min="0x00" max="0xFE" writable="false"
+        default="1" optional="true">A5</attribute>
+
+    <attribute manufacturerCode="0x10e0" side="server" code="0x0200" define="A6"
+      type="INT8U" writable="true" default="0x01" optional="true">A6</attribute>
+
+    <attribute  manufacturerCode="0x10e0" side="server" code="0x0300" define="A7"
+      type="INT8U" min="0x0" writable="false"
+      default="0" optional="true">A7</attribute>
+
+    <attribute manufacturerCode="0x10e0" side="server" code="0x0301" define="A8"
+      type="INT16U" min="0" writable="false"
+      default="0" optional="true">A8</attribute>
+
+    <!-- COMMANDS -->
+    <!-- Client Commands -->
+    <command source="client" code="0x00"
+      name="C1"
+      optional="false">
+      <description>
+        C1
+      </description>
+      <arg name="arg1" type="INT16U" />
+    </command>
+
+    <command source="client" code="0x01"
+      name="C2"
+      optional="false">
+      <description>
+        C2
+      </description>
+      <arg name="arg1" type="INT16U" />
+    </command>
+
+    <command source="client" code="0x02"
+      name="C3"
+      optional="true">
+      <description>
+        C3
+      </description>
+      <arg name="arg1" type="INT16U" />
+    </command>
+
+    <command source="client" code="0x03"
+      name="C4"
+      optional="false">
+      <description>
+        C4
+      </description>
+      <arg name="arg1" type="INT16U" />
+      <arg name="arg2" type="INT16U" />
+      <arg name="arg3" type="INT16U" />
+    </command>
+
+    <command source="client" code="0x04"
+      name="C5"
+      optional="true" >
+      <description>
+        C5
+      </description>
+      <arg name="arg1" type="INT16U" />
+      <arg name="arg2" type="UTC_TIME" />
+      <arg name="arg3" type="CustomType" />
+      <arg name="arg4" type="INT16U" />
+      <arg name="arg5" type="INT16U" />
+    </command>
+
+    <command source="client" code="0x05"
+      name="C6"
+      optional="false" >
+      <description>
+        C6
+      </description>
+      <arg name="arg1" type="INT16U" />
+    </command>
+
+    <command source="client" code="0x06" name="C7" optional="true" >
+      <description>
+        C7
+      </description>
+      <arg name="arg1" type="INT16U" />
+      <arg name="arg2" type="INT16U" />
+      <arg name="arg3" type="INT16U" />
+    </command>
+
+    <command source="client" code="0x07"
+      name="C8"
+      optional="false">
+      <description>
+        C8
+      </description>
+      <arg name="arg1" type="INT16U" />
+      <arg name="arg2" type="INT8U" />
+    </command>
+
+    <command source="client" code="0x08"
+      name="C9"
+      optional="false">
+      <description>
+        C9
+      </description>
+      <arg name="arg1" type="INT16U" />
+    </command>
+
+    <command source="client" code="0x09"
+      name="C10"
+      optional="false">
+      <description>
+        C10
+      </description>
+      <arg name="arg1" type="INT16U" />
+      <arg name="arg2" type="CustomId"/>
+    </command>
+
+    <command source="client" code="0x0A"
+      name="C11"
+      optional="true">
+      <description>
+        C11
+      </description>
+      <arg name="arg1" type="INT16U"/>
+      <arg name="arg2" type="CustomId" />
+      <arg name="arg3" type="INT32S" />
+    </command>
+
+
+    <!-- Server commands -->
+    <command source="server" code="0x00"
+      name="C12"
+      optional="false">
+      <description>
+        C12
+      </description>
+      <arg name="arg1" type="INT32U" />
+      <arg name="arg2" type="OCTET_STRING" />
+    </command>
+
+    <command source="server" code="0x01"
+      name="C13"
+      optional="false" >
+      <description>
+        C13
+      </description>
+      <arg name="arg1" type="INT32U" />
+      <arg name="arg" type="CustomStatus" />
+    </command>
+
+    <command source="server" code="0x02" name="C14"
+      optional="false" >
+      <description>
+        C14
+      </description>
+      <arg name="arg1" type="INT32U" />
+      <arg name="arg2" type="UTC_TIME" />
+      <arg name="arg3" type="INT16U" />
+      <arg name="arg4" type="CustomLevel" />
+      <arg name="arg5" type="OCTET_STRING" />
+    </command>
+
+    <command source="server" code="0x03" name="C15"
+      optional="false" >
+      <description>
+        C15
+      </description>
+      <arg name="arg1" type="INT32U" />
+      <arg name="arg2" type="CustomStruct" />
+    </command>
+
+    <command source="server" code="0x04" name="C16"
+      optional="false" >
+      <description>
+        C16
+      </description>
+      <arg name="arg1" type="INT32U" />
+      <arg name="arg2" type="CustomId" />
+      <arg name="arg3" type="INT32S" />
+    </command>
+  </cluster>
+</configurator>

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -78,7 +78,7 @@ exports.timeout = {
 
 exports.testTemplate = {
   zigbee: './test/gen-template/zigbee/gen-templates.json',
-  zigbeeCount: 27,
+  zigbeeCount: 28,
   matter: './test/gen-template/matter/gen-test.json',
   matterCount: 7,
   matter2: './test/gen-template/matter2/templates.json',
@@ -97,6 +97,7 @@ exports.testZclMetafile = path.join(__dirname, './resource/meta/zcl.json')
 exports.testServer = testServer
 
 exports.testCustomXml = './test/resource/custom-cluster/test-custom.xml'
+exports.testCustomXml2 = './test/resource/custom-cluster/custom-dut.xml'
 exports.customClusterXml =
   './test/resource/custom-cluster/custom-bead-cluster.xml'
 exports.badTestCustomXml = './test/resource/custom-cluster/bad-test-custom.xml'

--- a/test/zcl-loader-consecutive.test.js
+++ b/test/zcl-loader-consecutive.test.js
@@ -122,7 +122,7 @@ test(
       x = await queryZcl.selectAllEnumItems(db, jsonPackageId)
       expect(x.length).toEqual(testUtil.totalEnumItemCount)
 
-      x = await queryZcl.selectAllStructsWithItemCount(db, jsonPackageId)
+      x = await queryZcl.selectAllStructsWithItemCount(db, [jsonPackageId])
       expect(x.length).toEqual(54)
 
       x = await queryZcl.selectAllBitmaps(db, jsonPackageId)
@@ -175,7 +175,7 @@ test(
       x = await queryZcl.selectAllEnumItems(db, dotdotPackageId)
       expect(x.length).toEqual(testUtil.totalDotDotEnumItems)
 
-      x = await queryZcl.selectAllStructsWithItemCount(db, dotdotPackageId)
+      x = await queryZcl.selectAllStructsWithItemCount(db, [dotdotPackageId])
       expect(x.length).toEqual(20)
 
       x = await queryZcl.selectAllAtomics(db, dotdotPackageId)

--- a/test/zcl-loader.test.js
+++ b/test/zcl-loader.test.js
@@ -174,7 +174,7 @@ test(
       expect(attributes.length).toBeGreaterThan(40)
       let ps = []
       attributes.forEach((a) => {
-        ps.push(types.typeSizeAttribute(db, packageId, a))
+        ps.push(types.typeSizeAttribute(db, [packageId], a))
       })
 
       x = await dbApi.dbAll(
@@ -233,7 +233,7 @@ test(
       expect(x.length).toEqual(testUtil.totalDotDotEnums)
       x = await testQuery.selectCountFrom(db, 'ENUM_ITEM')
       expect(x).toEqual(testUtil.totalDotDotEnumItems)
-      x = await queryZcl.selectAllStructsWithItemCount(db, packageId)
+      x = await queryZcl.selectAllStructsWithItemCount(db, [packageId])
       expect(x.length).toEqual(20)
       x = await testQuery.selectCountFrom(db, 'STRUCT_ITEM')
       expect(x).toEqual(63)

--- a/test/zcl-properties-loader.test.js
+++ b/test/zcl-properties-loader.test.js
@@ -60,7 +60,7 @@ test(
       expect(x.length).toEqual(17)
       x = await queryZcl.selectAllEnums(db, packageId)
       expect(x.length).toEqual(208)
-      x = await queryZcl.selectAllStructsWithItemCount(db, packageId)
+      x = await queryZcl.selectAllStructsWithItemCount(db, [packageId])
       expect(x.length).toEqual(50)
       x = await queryZcl.selectAllBitmaps(db, packageId)
       expect(x.length).toEqual(128)


### PR DESCRIPTION
This needs to go side by side with a CHIP repo PR because zap code outside the zap repo is still using packageId instead of packageIds
Switching to use templateUtil.ensureZclPackageIds instead of templateUtil.ensureZclPackageId to handle the custom xml generation which is not being accounted for currently when loading custom xml from the UI