### PR TITLE
Fix FabricIndex handling in structs and events.

### DIFF
--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -370,7 +370,7 @@ async function selectStructsWithItemsImpl(db, packageIds, clusterId) {
       objectToActOn = {
         id: value.STRUCT_ID,
         name: value.STRUCT_NAME,
-        isFabricScoped: value.IS_FABRIC_SCOPED,
+        isFabricScoped: dbApi.fromDbBool(value.IS_FABRIC_SCOPED),
         label: value.STRUCT_NAME,
         struct_cluster_count: value.STRUCT_CLUSTER_COUNT,
         items: [],

--- a/src-electron/generator/helper-zcl.js
+++ b/src-electron/generator/helper-zcl.js
@@ -32,7 +32,6 @@ const octetStringTypes = ['OCTET_STRING', 'LONG_OCTET_STRING']
 const stringShortTypes = ['CHAR_STRING', 'OCTET_STRING']
 const stringLongTypes = ['LONG_CHAR_STRING', 'LONG_OCTET_STRING']
 
-const fabricIndexType = 'fabric_idx'
 /**
  * This module contains the API for templating. For more detailed instructions, read {@tutorial template-tutorial}
  *
@@ -135,7 +134,6 @@ async function zcl_structs(options) {
   structs = await zclUtil.sortStructsByDependency(structs)
   structs.forEach((st) => {
     st.struct_contains_array = false
-    st.struct_is_fabric_scoped = false
     st.struct_has_fabric_sensitive_fields = false
     st.has_no_clusters = st.struct_cluster_count < 1
     st.has_one_cluster = st.struct_cluster_count == 1
@@ -143,10 +141,6 @@ async function zcl_structs(options) {
     st.items.forEach((i) => {
       if (i.isArray) {
         st.struct_contains_array = true
-      }
-      if (i.type && i.type.toLowerCase() == fabricIndexType) {
-        st.struct_is_fabric_scoped = true
-        st.struct_fabric_idx_field = i.label
       }
       if (i.isFabricSensitive) {
         st.struct_has_fabric_sensitive_fields = true
@@ -548,17 +542,10 @@ async function zcl_events(options) {
   }
 
   let ps = events.map(async (ev) => {
-    ev.event_is_fabric_scoped = false
     ev.items = await queryEvent.selectEventFieldsByEventId(
       this.global.db,
       ev.id
     )
-    ev.items.forEach((i) => {
-      if (i.type && i.type.toLowerCase() == fabricIndexType && !i.isNullable) {
-        ev.event_is_fabric_scoped = true
-        ev.event_fabric_idx_field = i.name
-      }
-    })
   })
   await Promise.all(ps)
 

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -31,6 +31,10 @@ const dbEnum = require('../../src-shared/db-enum')
 const zclLoader = require('./zcl-loader')
 const _ = require('lodash')
 
+const fabricIndexFieldId = 0xfe
+const fabricIndexFieldName = 'FabricIndex'
+const fabricIndexType = 'fabric_idx'
+
 /**
  * Promises to read the JSON file and resolve all the data.
  * @param {*} ctx  Context containing information about the file
@@ -486,6 +490,22 @@ function prepareCluster(cluster, context, isExtension = false) {
           }
         })
       }
+      if (ev.isFabricSensitive) {
+        if (!ev.fields) {
+          ev.fields = []
+        }
+        ev.fields.push({
+          name: fabricIndexFieldName,
+          type: fabricIndexType,
+          isArray: false,
+          isNullable: false,
+          isOptional: false,
+          fieldIdentifier: fabricIndexFieldId,
+          introducedIn: null,
+          removedIn: null,
+        })
+      }
+
       // We only add event if it does not have removedIn
       if (ev.removedIn == null) ret.events.push(ev)
     })
@@ -1308,6 +1328,24 @@ async function processStructItems(db, filePath, packageId, data) {
           isOptional: item.$.optional == 'true' ? true : false,
           isFabricSensitive: item.$.isFabricSensitive == 'true' ? true : false,
         })
+      })
+    }
+
+    if (si.$.isFabricScoped == 'true') {
+      structItems.push({
+        structName: si.$.name,
+        structClusterCode: si.cluster ? parseInt(si.clusterCode) : null,
+        name: fabricIndexFieldName,
+        type: fabricIndexType,
+        fieldIdentifier: fabricIndexFieldId,
+        minLength: 0,
+        maxLength: null,
+        isWritable: false,
+        isArray: false,
+        isEnum: false,
+        isNullable: false,
+        isOptional: false,
+        isFabricSensitive: false,
       })
     }
   })

--- a/test/gen-meta.test.js
+++ b/test/gen-meta.test.js
@@ -229,9 +229,7 @@ test(
     expect(epc).toContain('Nest complex;// <- has nested array')
     expect(epc).toContain('// DoubleNest <- contains nested array')
     expect(epc).toContain('array;  // FABRIC SENSITIVE')
-    expect(epc).toContain(
-      '// Struct is fabric scroped, fabric index field label: fab_idx'
-    )
+    expect(epc).toContain('// Struct is fabric-scoped')
 
     epc = genResult.content['access.out']
     expect(epc).not.toBeNull()
@@ -242,7 +240,7 @@ test(
     expect(epc).toContain(
       '* Aggregates [3]: fScope=true/fSensitive=false/read=view/write=[operate - manage]/invoke=NONE'
     )
-    expect(epc).toContain('HelloEvent is a fabric scoped event, field: fabric')
+    expect(epc).toContain('HelloEvent is a fabric-sensitive event')
   },
   testUtil.timeout.medium()
 )

--- a/test/resource/meta/access.zapt
+++ b/test/resource/meta/access.zapt
@@ -35,8 +35,8 @@ Cluster: {{name}} [{{code}}]
   {{#default_access entity="event"}}
     * Default: {{operation}} / Role: {{role}} / Modifier: {{accessModifier}}
   {{/default_access}}
-  {{#if event_is_fabric_scoped}}
-    * {{name}} is a fabric scoped event, field: {{event_fabric_idx_field}}
+  {{#if isFabricSensitive}}
+    * {{name}} is a fabric-sensitive event
   {{/if}}
     * Items
   {{#zcl_event_fields}}

--- a/test/resource/meta/struct.zapt
+++ b/test/resource/meta/struct.zapt
@@ -7,8 +7,8 @@
 {{#if struct_contains_nested_array}}
 // {{label}} <- contains nested array
 {{/if}}
-{{#if struct_is_fabric_scoped}}
-// Struct is fabric scroped, fabric index field label: {{ struct_fabric_idx_field }}
+{{#if isFabricScoped}}
+// Struct is fabric-scoped
 {{/if}}
 {{#zcl_struct_items checkForDoubleNestedArray="true"}}
 {{#first}}

--- a/test/resource/meta/test1.xml
+++ b/test/resource/meta/test1.xml
@@ -24,9 +24,8 @@ limitations under the License.
     <define>TEST_1</define>
     <client tick="false" init="false">false</client>
     <server tick="false" init="false">true</server>
-    <struct name="FabricScopedStruct">
+    <struct name="FabricScopedStruct" isFabricScoped="true">
       <cluster code="0xABCD"/>
-      <item name="fab_idx" type="FABRIC_IDX"/>
     </struct>
     <attribute side="server" code="0x0000" define="AT1" type="LIST" entryType="FabricScopedStruct" writable="false" optional="true">
       <!-- Fabric scoped attributes are lists with a struct which contains a fabric_idx field. -->
@@ -76,7 +75,6 @@ limitations under the License.
       <field id="1" name="arg1" type="INT8U" isNullable="true"/>
       <field id="2" name="arg2" type="INT32U" array="true"/>
       <field id="3" name="arg3" type="CHAR_STRING"/>
-      <field id="4" name="fabric" type="fabric_idx"/>
     </event>
   </cluster>
 </configurator>

--- a/test/resource/meta/types.xml
+++ b/test/resource/meta/types.xml
@@ -152,8 +152,7 @@ limitations under the License.
     <item name="simple1" type="INT8U"/>
     <item name="complex" type="Nest" array="true"/>
   </struct>
-  <struct name="FabricScoped">
-    <item name="fab_idx" type="FABRIC_IDX"/>
+  <struct name="FabricScoped" isFabricScoped="true">
   </struct>
 
   <bitmap name="TestBitmap" type="INT8U">


### PR DESCRIPTION
1) Remove struct_is_fabric_scoped and event_is_fabric_scoped now that we have
   isFabricScoped/isFabricSensitive on those objects.  Add the relevant XML
   attributes instead of trying to guess based on fields.
2) Remove event_fabric_idx_field and struct_fabric_idx_field, since we are no
   longer guessing based on fields.
3) Synthesize the relevant struct item or event field with the right name, type,
   field id, per spec, if the struct is fabric-scoped or the event is
   fabric-sensitive.

This is a hard requirement for implementing Leave events properly for Matter:
those have a fabric_idx field but are _not_ fabric-scoped.