### PR TITLE
Fix default values for long strings.

### DIFF
--- a/src-electron/util/bin.ts
+++ b/src-electron/util/bin.ts
@@ -125,7 +125,9 @@ function hexToBinary(hex: string) {
 
   cleansedHex = cleansedHex.replace(/[^0-F]/g, '')
 
-  return parseInt(cleansedHex, 16).toString(2).padStart(cleansedHex.length*4, '0')
+  return parseInt(cleansedHex, 16)
+    .toString(2)
+    .padStart(cleansedHex.length * 4, '0')
 }
 
 /**
@@ -139,7 +141,11 @@ function hexToBinary(hex: string) {
  * @returns Object containing 'length' and 'content', where length
  * is number of bytes used and content is actual content in C format.
  */
-function stringToOneByteLengthPrefixCBytes(value: string, maxLength: number, pad = true) {
+function stringToOneByteLengthPrefixCBytes(
+  value: string,
+  maxLength: number,
+  pad = true
+) {
   let len = value.length
   let ret = `${len}, `
   for (let i = 0; i < len; i++) {
@@ -169,10 +175,14 @@ function stringToOneByteLengthPrefixCBytes(value: string, maxLength: number, pad
  * @returns Object containing 'length' and 'content', where length
  * is number of bytes used and content is actual content in C format.
  */
-function stringToTwoByteLengthPrefixCBytes(value: string, maxLength: number, pad = true) {
+function stringToTwoByteLengthPrefixCBytes(
+  value: string,
+  maxLength: number,
+  pad = true
+) {
   let len = value.length
-  let ret = `${(len >> 8) & 0xff}, `
-  ret = ret.concat(`${len & 0xff}, `)
+  let ret = `${len & 0xff}, `
+  ret = ret.concat(`${(len >> 8) & 0xff}, `)
   for (let i = 0; i < len; i++) {
     ret = ret.concat(`'${value[i]}', `)
   }

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -118,13 +118,13 @@ test(
 
     r = bin.stringToTwoByteLengthPrefixCBytes('Test string')
     expect(r.content).toContain(
-      "0, 11, 'T', 'e', 's', 't', ' ', 's', 't', 'r', 'i', 'n', 'g',"
+      "11, 0, 'T', 'e', 's', 't', ' ', 's', 't', 'r', 'i', 'n', 'g',"
     )
     expect(r.length).toBe(13)
 
     r = bin.stringToTwoByteLengthPrefixCBytes('x'.repeat(300), 400, false)
     expect(r.content).toContain(
-      "1, 44, 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x',"
+      "44, 1, 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x',"
     )
     expect(r.length).toBe(302)
 


### PR DESCRIPTION
Long strings store their length in 2 bytes at the front of the string, with the
bytes being a little-endian representation of the string length.

But the endpoint config output was spitting out the length as big-endian, not
little-endian.  This caused things to be pretty confused and led to buffer
overruns trying to read data that was not there.