### PR TITLE
Notification system (RENOP)

### DIFF
--- a/cypress/integration/devtools/devtools.spec.js
+++ b/cypress/integration/devtools/devtools.spec.js
@@ -16,9 +16,7 @@ describe('Testing visibility of devtools option', () => {
 
   it('check if devtools option gets visible', () => {
     cy.setZclProperties()
-    cy.get(
-      'a.q-btn > .q-btn__wrapper > .q-btn__content > .material-icons'
-    ).click()
+    cy.get('#preference > .q-btn__wrapper > .q-btn__content > .q-icon').click()
     cy.get('[aria-label="Enable development tools"] > .q-toggle__label').click()
     cy.get('.q-btn__wrapper').contains('Back').click()
     cy.get('.q-gutter-y-md > :nth-child(1)').should('contain', 'Dev Tools')

--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -568,6 +568,17 @@ exports.map = {
       value: x.VALUE,
     }
   },
+  notifications: (x) => {
+    if (x == null) return undefined
+    return {
+      ref: x.SESSION_REF,
+      type: x.NOTICE_TYPE,
+      message: x.NOTICE_MESSAGE,
+      severity: x.NOTICE_SEVERITY,
+      order: x.NOTICE_ORDER,
+      display: x.DISPLAY,
+    }
+  },
 }
 
 exports.reverseMap = {

--- a/src-electron/db/query-notification.js
+++ b/src-electron/db/query-notification.js
@@ -1,0 +1,84 @@
+'use strict'
+/**
+ *
+ *    Copyright (c) 2020 Silicon Labs
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/**
+ * This module provides notification related queries.
+ *
+ * @module DB API: session related queries.
+ */
+const dbApi = require('./db-api.js')
+const dbMapping = require('./db-mapping.js')
+/**
+ * Sets a notification in the SESSION_NOTICE table
+ *
+ * @export
+ * @param {*} db
+ * @param {*} type
+ * @param {*} status
+ * @param {*} sessionId
+ * @param {*} severity
+ */
+async function setNotification(db, type, status, sessionId, severity) {
+  return dbApi.dbUpdate(
+    db,
+    'INSERT INTO SESSION_NOTICE ( SESSION_REF, NOTICE_TYPE, NOTICE_MESSAGE, NOTICE_SEVERITY, DISPLAY) VALUES ( ?, ?, ?, ?, ?)',
+    [sessionId, type, status, severity, 1]
+  )
+}
+async function setAllNotificationDisplay(db, sessionId) {
+  return dbApi.dbUpdate(
+    db,
+    'UPDATE SESSION_NOTICE SET DISPLAY = ? WHERE SESSION_REF = ?',
+    [0, sessionId]
+  )
+}
+/**
+ * Deletes a notification from the SESSION_NOTICE table
+ *
+ * @export
+ * @param {*} db
+ * @param {*} upgrade
+ * @param {*} status
+ */
+async function deleteNotification(db, upgrade, status) {
+  return dbApi.dbUpdate(
+    db,
+    'DELETE FROM SESSION_NOTICE WHERE ( SESSION_REF, STATUS ) = ( ?, ? )',
+    [upgrade, status]
+  )
+}
+/**
+ * Retrieves a notification from the SESSION_NOTICE table
+ *
+ * @export
+ * @param {*} db
+ */
+async function getNotification(db, sessionId) {
+  let rows = []
+  rows = await dbApi.dbAll(
+    db,
+    'SELECT * FROM SESSION_NOTICE WHERE SESSION_REF = ?',
+    [sessionId]
+  )
+  return rows.map(dbMapping.map.notifications)
+}
+// exports
+exports.setNotification = setNotification
+exports.setAllNotificationDisplay = setAllNotificationDisplay
+exports.deleteNotification = deleteNotification
+exports.getNotification = getNotification
+//# sourceMappingURL=query-notification.js.map

--- a/src-electron/db/zap-schema.sql
+++ b/src-electron/db/zap-schema.sql
@@ -1117,4 +1117,17 @@ CREATE TABLE IF NOT EXISTS "SETTING" (
   "VALUE" text,
   UNIQUE(CATEGORY, KEY)
 );
+/*
+  Session Notification table
+*/
+
+ CREATE TABLE IF NOT EXISTS "SESSION_NOTICE" (
+   "SESSION_REF" integer,
+   "NOTICE_TYPE" text,
+   "NOTICE_MESSAGE" text,
+   "NOTICE_SEVERITY" integer,
+   "NOTICE_ORDER"  integer primary key autoincrement,
+   "DISPLAY" integer,
+   foreign key (SESSION_REF) references SESSION(SESSION_ID) on delete cascade
+ );
 /* EO SCHEMA */

--- a/src-electron/importexport/import-isc.js
+++ b/src-electron/importexport/import-isc.js
@@ -28,6 +28,7 @@ const util = require('../util/util')
 const dbEnum = require('../../src-shared/db-enum')
 const restApi = require('../../src-shared/rest-api')
 const env = require('../util/env')
+const notification = require('../db/query-notification.js')
 
 /**
  * Locates or adds an attribute, and returns it.
@@ -640,6 +641,13 @@ async function loadSessionKeyValues(db, sessionId, keyValues) {
 async function iscDataLoader(db, state, sessionId) {
   let endpointTypes = state.endpointTypes
   let promises = []
+  await notification.setNotification(
+    db,
+    'UPGRADE',
+    'ISC FILE UPGRADED TO ZAP FILE. PLEASE SAVE AS TO SAVE OFF NEWLY CREATED ZAP FILE.',
+    sessionId,
+    1
+  )
 
   // We don't have the package info inside ISC file, so we
   // do our best here.

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -28,6 +28,7 @@ const dbApi = require('../db/db-api.js')
 const queryAttribute = require('../db/query-attribute.js')
 const queryCommand = require('../db/query-command.js')
 const queryConfig = require('../db/query-config.js')
+const queryNotification = require('../db/query-notification.js')
 const queryEndpointType = require('../db/query-endpoint-type.js')
 const queryEndpoint = require('../db/query-endpoint.js')
 const querySession = require('../db/query-session.js')
@@ -53,6 +54,20 @@ function httpGetSessionKeyValues(db) {
       sessionId
     )
     response.status(StatusCodes.OK).json(sessionKeyValues)
+  }
+}
+
+/**
+ * HTTP GET: session get notifications
+ *
+ * @param {*} db
+ * @returns callback for the express uri registration
+ */
+function httpGetNotifications(db) {
+  return async (request, response) => {
+    let sessionId = request.zapSessionId
+    let notifications = await queryNotification.getNotification(db, sessionId)
+    response.status(StatusCodes.OK).json(notifications)
   }
 }
 
@@ -722,7 +737,7 @@ function httpDeleteSessionPackage(db) {
 
 /**
  * Creating a duplicate for endpoint
- * 
+ *
  * @param {*} db
  * @returns newly created endpoint id
  */
@@ -737,48 +752,67 @@ function httpPostDuplicateEndpoint(db) {
       endpointIdentifier,
       endpointTypeId
     )
-    res.status(StatusCodes.OK).json({id:id})
+    res.status(StatusCodes.OK).json({ id: id })
   }
 }
 
 /**
  * Creating a duplicate for endpoint-type and endpoint-type-attributes
- * 
+ *
  * @param {*} db
  * @returns newly created endpoint-type id
  */
 function httpPostDuplicateEndpointType(db) {
   return async (request, response) => {
     let { endpointTypeId } = request.body
-    let newId = await queryConfig.duplicateEndpointType(
-      db, endpointTypeId
-    )
+    let newId = await queryConfig.duplicateEndpointType(db, endpointTypeId)
 
     duplicateEndpointTypeClusters(db, endpointTypeId, newId)
 
     response.status(StatusCodes.OK).json({
-      id: newId
+      id: newId,
     })
   }
 }
 
 /**
  * duplicate all clusters and attributes of an old endpoint type, using oldEndpointType id and newly created endpointType id
- * 
+ *
  * @param {*} db
  * @param {*} oldEndpointTypeId
  * @param {*} newEndpointTypeId
  */
-async function duplicateEndpointTypeClusters(db, oldEndpointTypeId, newEndpointTypeId) {
-  let oldEndpointTypeClusters = await queryConfig.selectEndpointClusters(db, oldEndpointTypeId);
+async function duplicateEndpointTypeClusters(
+  db,
+  oldEndpointTypeId,
+  newEndpointTypeId
+) {
+  let oldEndpointTypeClusters = await queryConfig.selectEndpointClusters(
+    db,
+    oldEndpointTypeId
+  )
   oldEndpointTypeClusters.forEach(async (endpointTypeCluster) => {
-    let newEndpointTypeClusterId = await queryConfig.insertOrReplaceClusterState(db,newEndpointTypeId,endpointTypeCluster.clusterRef,endpointTypeCluster.side, endpointTypeCluster.enabled)
-    let oldAttributes = await queryAttribute.selectEndpointTypeAttributesByEndpointTypeRefAndClusterRef(db,oldEndpointTypeId,endpointTypeCluster.endpointTypeClusterId)
+    let newEndpointTypeClusterId =
+      await queryConfig.insertOrReplaceClusterState(
+        db,
+        newEndpointTypeId,
+        endpointTypeCluster.clusterRef,
+        endpointTypeCluster.side,
+        endpointTypeCluster.enabled
+      )
+    let oldAttributes =
+      await queryAttribute.selectEndpointTypeAttributesByEndpointTypeRefAndClusterRef(
+        db,
+        oldEndpointTypeId,
+        endpointTypeCluster.endpointTypeClusterId
+      )
     oldAttributes.forEach(async (attrubute) => {
-      await queryAttribute.duplicateEndpointTypeAttribute(db,
+      await queryAttribute.duplicateEndpointTypeAttribute(
+        db,
         newEndpointTypeId,
         newEndpointTypeClusterId,
-        attrubute)
+        attrubute
+      )
     })
   })
 }
@@ -826,6 +860,10 @@ exports.get = [
   {
     uri: restApi.uri.getAllSessionKeyValues,
     callback: httpGetSessionKeyValues,
+  },
+  {
+    uri: restApi.uri.notification,
+    callback: httpGetNotifications,
   },
   {
     uri: restApi.uri.initialState,

--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -90,6 +90,7 @@ exports.pathRelativity = {
 exports.wsCategory = {
   generic: 'generic',
   dirtyFlag: 'dirtyFlag',
+  upgrade: 'upgrade',
   validation: 'validation',
   sessionCreationError: 'sessionCreationError',
   componentUpdateStatus: 'componentUpdateStatus',

--- a/src-shared/rend-api.js
+++ b/src-shared/rend-api.js
@@ -23,6 +23,9 @@ exports.renderer_api = {
     dirtyFlag: {
       arg: 'dirtyState',
     },
+    notification: {
+      arg: 'notification',
+    },
     fileBrowse: {
       arg: 'browseObject',
     },
@@ -120,7 +123,11 @@ exports.id = {
   isDirty: 'isDirty',
 }
 
-exports.notifyKey = { dirtyFlag: 'dirtyFlag', fileBrowse: 'fileBrowse' }
+exports.notifyKey = {
+  dirtyFlag: 'dirtyFlag',
+  fileBrowse: 'fileBrowse',
+  notification: 'notification',
+}
 
 exports.jsonPrefix = 'rendererApiJson:'
 

--- a/src-shared/rest-api.js
+++ b/src-shared/rest-api.js
@@ -24,6 +24,7 @@ const uri = {
   endpoint: '/endpoint',
   endpointType: '/endpointType',
   initialState: '/initialState',
+  notification: '/notification',
   duplicateEndpoint: '/duplicateEndpoint',
   duplicateEndpointType: '/duplicateEndpointType',
   dirtyFlag: '/dirtyFlag',

--- a/src/layouts/ZclConfiguratorLayout.vue
+++ b/src/layouts/ZclConfiguratorLayout.vue
@@ -78,6 +78,14 @@ limitations under the License.
               </div></Transition
             >
           </q-btn>
+          <q-btn flat icon="warning" to="/notifications" id="Notifications">
+            <Transition name="bounce">
+              <div v-if="displayButton" class="text-align q-ml-xs">
+                Notifications
+              </div></Transition
+            >
+            <q-tooltip> Notifications </q-tooltip>
+          </q-btn>
         </q-toolbar>
         <q-dialog
           v-model="globalOptionsDialog"

--- a/src/layouts/ZclLayout.vue
+++ b/src/layouts/ZclLayout.vue
@@ -144,9 +144,9 @@ limitations under the License.
                     clickable
                     v-close-popup
                     @click="
-                    generationButtonText = file.category
-                    getGeneratedFile(file.category)
-                  "
+                      generationButtonText = file.category
+                      getGeneratedFile(file.category)
+                    "
                     :label="generationButtonText"
                   >
                     <q-item-section>
@@ -159,7 +159,7 @@ limitations under the License.
                 <template>
                   <div class="q-ma-md">
                     <q-scroll-area style="height: 70vh" ref="generationScroll">
-                    <pre class="q-ma-none container">{{
+                      <pre class="q-ma-none container">{{
                         generationData
                       }}</pre>
                       <q-scroll-observer @scroll="onScroll" />
@@ -222,7 +222,7 @@ export default {
         title: 'Select directory to generate into',
         mode: 'directory',
         defaultPath: currentPath,
-        buttonLabel: 'Generate'
+        buttonLabel: 'Generate',
       })
     },
     getGeneratedFiles() {

--- a/src/pages/Notifications.vue
+++ b/src/pages/Notifications.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="q-pa-md">
+    <q-toolbar class="shadow-2">
+      <q-btn icon="arrow_back" to="/" label="Back" data-test="go-back-button" />
+    </q-toolbar>
+    <q-table
+      title="Notifications"
+      :data="notis"
+      :columns="columns"
+      row-key="ref"
+    >
+      <template v-slot:header="props">
+        <q-tr :props="props">
+          <q-th v-for="col in props.cols" :key="col.name" :props="props">
+            {{ col.label }}
+          </q-th>
+        </q-tr>
+      </template>
+      <template v-slot:body="props">
+        <q-tr :props="props" class="table_body">
+          <q-td key="ref" :props="props">
+            <div>{{ props.row.ref }}</div>
+          </q-td>
+          <q-td key="type" :props="props">
+            <div>{{ props.row.type }}</div>
+          </q-td>
+          <q-td key="message" :props="props">
+            <div>{{ props.row.message }}</div>
+          </q-td>
+          <q-td key="severity" :props="props">
+            <div>{{ props.row.severity }}</div>
+          </q-td>
+        </q-tr>
+      </template>
+    </q-table>
+  </div>
+</template>
+
+<script>
+import restApi from '../../src-shared/rest-api.js'
+export default {
+  data() {
+    return {
+      columns: [
+        {
+          name: 'ref',
+          align: 'center',
+          label: 'ref',
+          field: 'ref',
+        },
+        { name: 'type', align: 'center', label: 'type', field: 'type' },
+        {
+          name: 'message',
+          align: 'center',
+          label: 'message',
+          field: 'message',
+        },
+        {
+          name: 'severity',
+          align: 'center',
+          label: 'severity',
+          field: 'severity',
+        },
+      ],
+      notis: [],
+    }
+  },
+  created() {
+    this.$serverGet(restApi.uri.notification)
+      .then((resp) => {
+        for (let i = 0; i < resp.data.length; i++) {
+          this.notis.push(resp.data[i])
+        }
+      })
+      .catch((err) => {
+        console.log(err)
+      })
+  },
+}
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -45,6 +45,11 @@ const routes = [
     path: '/about',
     component: () => import('pages/About.vue'),
   },
+  {
+    path: '/notifications',
+    name: 'notifications',
+    component: () => import('pages/Notifications.vue'),
+  },
 ]
 
 // Always leave this as last one


### PR DESCRIPTION
This is a Draft PR for the notification framework.

TODO:
1. **Decide how the querying of SESSION_NOTICE table will be implemented.**
_OPTIONS:_
A. Notifications should be able to be triggered at any moment. Therefore, it would make sense to have interval polling          which constantly checks for new notifications.  This is not in the PR but I have this working locally. Although this code is out of date, here is an example of how it might work https://github.com/project-chip/zap/commit/57d9486034af18b16d203a9e9c432212fdb6348e
B. If notifications are not able to be triggered at any moment and are specific for importing and exporting .zap files then there could be a function which queries the SESSION_NOTICE table after importing. This way there would be no need for polling. Basically, the notifications would only be queried when creating a session...
C. Both A and B

2. **Add notification page to the front end**
3. Test




