### PR TITLE
Add an option to asUpperCamelCase to not turn uppercased acronyms int…

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
@@ -407,9 +407,28 @@ function asLowerCamelCase(label) {
   return str.replace(/[^A-Za-z0-9_]/g, '');
 }
 
-function asUpperCamelCase(label) {
-  let str = string.toCamelCase(label, false);
-  return str.replace(/[^A-Za-z0-9_]/g, '');
+function asUpperCamelCase(label, options) {
+  const preserveAcronyms = options && options.hash.preserveAcronyms;
+
+  let tokens = label.replace(/[+()&]/g, '').split(/ |_|-|\//);
+
+  let str = tokens
+    .map((token) => {
+      let isAcronym = token == token.toUpperCase();
+      if (!isAcronym) {
+        return token[0].toUpperCase() + token.substring(1);
+      }
+
+      if (preserveAcronyms) {
+        return token;
+      }
+
+      // if preserveAcronyms is false, then anything beyond the first letter becomes lower-case.
+      return token[0] + token.substring(1).toLowerCase();
+    })
+    .join('');
+
+  return str.replace(/[^A-Za-z0-9_ ]/g, '');
 }
 
 function chip_friendly_endpoint_type_name(options) {

--- a/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
+++ b/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
@@ -152,9 +152,9 @@ async function asObjectiveCClass(type, cluster, options) {
   }
 
   if (isStruct) {
-    return `MTR${appHelper.asUpperCamelCase(
-      cluster
-    )}Cluster${appHelper.asUpperCamelCase(type)}`;
+    return `MTR${appHelper.asUpperCamelCase(cluster, {
+      hash: { preserveAcronyms: true },
+    })}Cluster${appHelper.asUpperCamelCase(type)}`;
   }
 
   return 'NSNumber';
@@ -211,7 +211,9 @@ function commandHasRequiredField(command) {
  * "Enum" bits on the enum names while we're here.
  */
 function objCEnumName(clusterName, enumLabel) {
-  clusterName = appHelper.asUpperCamelCase(clusterName);
+  clusterName = appHelper.asUpperCamelCase(clusterName, {
+    hash: { preserveAcronyms: true },
+  });
   enumLabel = appHelper.asUpperCamelCase(enumLabel);
   // Some enum names have one or more copies of the cluster name at the
   // beginning.


### PR DESCRIPTION
…o lowercased

#### Problem

In some cases it may be useful to preserve the case of acronyms when `asUpperCamelCase` is called.

#### Changes
 * Add an option to `asUpperCamelCase` to not turn uppercased acronyms to lowercased.