### PR TITLE
fix zap server startup error on windows

### DIFF
--- a/src-electron/server/ipc-server.ts
+++ b/src-electron/server/ipc-server.ts
@@ -48,9 +48,9 @@ const server: ipcTypes.Server = {
  * Returns the socket path for the IPC.
  */
 function socketPath() {
-  var defaultSocketPath =
+  let defaultSocketPath =
     process.platform == 'win32'
-      ? '\\\\.\\pipe\\' + 'zap-ipc' + '-sock'
+      ? 'zap-ipc-sock'
       : path.join(os.tmpdir(), 'zap-ipc' + '.sock')
   return defaultSocketPath
 }


### PR DESCRIPTION
fix JSON START/END message not sending on windows.

node-ipc was having a hard time creating the socket due to not recognizing the path as valid.

BUG: ZAPP-969