### PR TITLE
adding 'versionJson' to CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "post-import": "node src-script/zap-start.js convert --postImportScript test/resource/test-script.js test/resource/three-endpoint-device.zap -o test.zap",
     "analyze": "node src-script/zap-start.js analyze -z ./zcl-builtin/silabs/zcl.json -g ./test/gen-template/zigbee/gen-templates.json ./test/resource/three-endpoint-device.zap -o ./tmp",
     "version": "node src-script/zap-start.js --version",
+    "versionJson": "node src-script/zap-start.js --versionJson",
     "gen": "node src-script/zap-generate.js --genResultFile --stateDirectory ~/.zap/gen -z ./zcl-builtin/silabs/zcl.json -g ./test/gen-template/zigbee/gen-templates.json -i ./test/resource/three-endpoint-device.zap -o ./tmp",
     "gen2": "node src-script/zap-generate.js --genResultFile -z ./zcl-builtin/silabs/zcl.json -g ./test/gen-template/zigbee/gen-templates.json -i ./test/resource/generation-test-file-1.zap -o ./tmp",
     "gen3": "node src-script/zap-generate.js --genResultFile --stateDirectory ~/.zap/gen3 -z ./zcl-builtin/dotdot/library.xml -g ./test/gen-template/zigbee/gen-templates.json -i ./test/resource/generation-test-file-1.zap -o ./tmp",

--- a/src-electron/util/args.ts
+++ b/src-electron/util/args.ts
@@ -220,6 +220,16 @@ export function processCommandLineArguments(argv: string[]) {
         zapVersion.source ? '\nMode: source' : '\nMode: binary'
       }`
     )
+    .version(
+      '--versionJson',
+      JSON.stringify({
+        Version: zapVersion.version,
+        'Feature level': zapVersion.featureLevel,
+        Hash: zapVersion.hash,
+        Date: zapVersion.date,
+        Mode: zapVersion.source ? 'source' : 'binary',
+      }, null, 1)
+    )
     .help()
     .alias({
       help: ['h', '?'],


### PR DESCRIPTION
For ZAP commit tracking on Jenkins CI build page, this reduces parsing logic by directly using JSON output to store version info per build.