### PR TITLE
Fixing the command argument optional attribute loading and fixing the zcl cli helper to take that into account

### DIFF
--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -467,7 +467,10 @@ function prepareCluster(cluster, context, isExtension = false) {
               isArray: arg.$.array == 'true' ? 1 : 0,
               presentIf: arg.$.presentIf,
               isNullable: arg.$.isNullable == 'true' ? true : false,
-              isOptional: arg.$.optional == 'true' ? true : false,
+              isOptional:
+                arg.$.optional == 'true' || arg.$.optional == '1'
+                  ? true
+                  : false,
               countArg: arg.$.countArg,
               fieldIdentifier: lastFieldId,
               introducedIn: arg.$.introducedIn,


### PR DESCRIPTION
- Adding additional options to zcl_command_argument_type_to_cli_data_type_util function such that it can account for the the isOptional argument to return the precise CLI command argument
- The xml mentions optional=1 for the command arguments. Therefore accounting for that in the zcl-loader-silabs.js
- JIRA: EMZIGBEE-10318