### PR TITLE
trigger on push/pr for all branches.

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,9 +5,7 @@ name: Cypress UI tests - Zigbee data
 
 on:
   push:
-    branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/mattercypress.yml
+++ b/.github/workflows/mattercypress.yml
@@ -5,9 +5,7 @@ name: Cypress UI tests - Matter data
 
 on:
   push:
-    branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,8 @@ name: Build and release packages
 
 on:
   push:
-    branches: [master]
   pull_request:
-    branches: [master]
   workflow_dispatch:
-    branches: [master]
 
 env:
   ZAP_TEST_TIMEOUT: 3600000

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,8 +2,6 @@ name: SonarCloud scan
 on:
   push:
     branches:
-      - master
-      - zigbee_shared_cluster_logic
   pull_request_target:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -5,9 +5,7 @@ name: Generation and back-end tests
 
 on:
   push:
-    branches: [master]
   pull_request:
-    branches: [master]
 
 env:
   ZAP_TEST_TIMEOUT: 3600000


### PR DESCRIPTION
When internal PR depend on a specific branch, the build should be kicked off automatically during branch creation instead of requiring a manual kick off. Many users do not know it is required.