### PR TITLE
Fixed discrepancy in zcl-builtin/dotdot files

### DIFF
--- a/zcl-builtin/dotdot/Basic.xml
+++ b/zcl-builtin/dotdot/Basic.xml
@@ -136,7 +136,7 @@ applicable to this document can be found in the LICENSE.md file.
           <type:enumeration value="21" name="MudRoom" />
           <type:enumeration value="22" name="Nursery" />
           <type:enumeration value="23" name="Pantry" />
-          <type:enumeration value="24" name="Office" />
+          <type:enumeration value="24" name="SecondaryOffice" />
           <type:enumeration value="25" name="Outside" />
           <type:enumeration value="26" name="Pool" />
           <type:enumeration value="27" name="Porch" />
@@ -157,7 +157,7 @@ applicable to this document can be found in the LICENSE.md file.
           <type:enumeration value="36" name="Patio" />
           <type:enumeration value="37" name="Driveway" />
           <type:enumeration value="38" name="SunRoom" />
-          <type:enumeration value="39" name="LivingRoom" />
+          <type:enumeration value="39" name="SecondaryLivingRoom" />
           <type:enumeration value="3A" name="Spa" />
           <type:enumeration value="3B" name="Whirlpool" />
           <type:enumeration value="3C" name="Shed" />

--- a/zcl-builtin/dotdot/ElectricalMeasurement.xml
+++ b/zcl-builtin/dotdot/ElectricalMeasurement.xml
@@ -214,7 +214,7 @@ applicable to this document can be found in the LICENSE.md file.
           <field name="ProfileIntervalPeriod" type="ProfileIntervalPeriod" />
           <field name="NumberOfIntervalsDelivered" type="uint8" />
           <field name="AttributeId" type="attribId" /> 
-          <field name="Intervals" type="unk" array="true" arrayLengthSize="0" />
+          <field name="Intervals" type="uint8" array="true" arrayLengthSize="0" />
         </fields>
       </command>
     </commands>

--- a/zcl-builtin/dotdot/Thermostat.xml
+++ b/zcl-builtin/dotdot/Thermostat.xml
@@ -178,7 +178,7 @@ applicable to this document can be found in the LICENSE.md file.
      	  <type:enumeration value="03" name="Wednesday" />
      	  <type:enumeration value="04" name="Thursday" />
      	  <type:enumeration value="05" name="Friday" />
-     	  <type:enumeration value="06" name="Sunday" />
+     	  <type:enumeration value="06" name="Saturday" />
       	</restriction>
       </attribute>
       <attribute id="0021" name="NumberOfWeeklyTransitions" type="uint8" max="255" />

--- a/zcl-builtin/dotdot/global.xml
+++ b/zcl-builtin/dotdot/global.xml
@@ -156,7 +156,7 @@ applicable to this document can be found in the LICENSE.md file.
 			<type:sequence>
 				<field name="AttributeIdentifier" type="attribId" />
 				<!-- TODO: Attribute Data Type -->
-				<field name="AccessControl" type="map8" />
+				<field name="AccessControl" type="bitmap8" />
 			</type:sequence>
 		</restriction>
 	</type:type>

--- a/zcl-builtin/dotdot/library.xml
+++ b/zcl-builtin/dotdot/library.xml
@@ -252,7 +252,7 @@ applicable to this document can be found in the LICENSE.md file.
     </restriction>
   </type:type>
   <!-- Misc -->
-  <type:type id="f0" short="eui64" name="IEEE address" discrete="true">
+  <type:type id="f0" short="EUI64" name="IEEE address" discrete="true">
     <restriction>
       <type:length value="8" />
     </restriction>
@@ -322,7 +322,7 @@ applicable to this document can be found in the LICENSE.md file.
       <type:enumeration name="clusterId" value="e8" />
       <type:enumeration name="attribId" value="e9" />
       <type:enumeration name="bacOID" value="ea" />
-      <type:enumeration name="eui64" value="f0" />
+      <type:enumeration name="EUI64" value="f0" />
       <type:enumeration name="key128" value="f1" />
       <type:enumeration name="unk" value="ff" />
     </restriction>


### PR DESCRIPTION
* Basic.xml                 - Fixed duplicate names in enums
* ElectricalMeasurement.xml - Fixed invalid type
* Thermostat.xml            - Fixed duplicate names in enum (there was two Sundays in a week ;))
* global.xml                - changed invalid 'map8' to 'bitmap8'
* library.xml               - changed eui64 to EUI64 to match other usage of this type