### PR TITLE
Cleaning up Matter zap code and adding functionality to existing zap helpers and creating new ones to remove state in Matter's zap code:

### DIFF
--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -179,6 +179,7 @@ exports.map = {
       argIsNullable: x.ARG_IS_NULLABLE,
       responseRef: x.RESPONSE_REF,
       responseName: x.RESPONSE_NAME,
+      hasSpecificResponse: x.RESPONSE_REF ? 1 : 0,
       isIncoming: x.INCOMING,
       isOutgoing: x.OUTGOING,
       isDefaultResponseEnabled: x.IS_DEFAULT_RESPONSE_ENABLED,

--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -104,16 +104,21 @@ exports.map = {
       reportableChange: x.REPORTABLE_CHANGE,
       reportableChangeLength: x.REPORTABLE_CHANGE_LENGTH,
       isWritable: dbApi.fromDbBool(x.IS_WRITABLE),
+      isWritableAttribute: dbApi.fromDbBool(x.IS_WRITABLE),
       isNullable: dbApi.fromDbBool(x.IS_NULLABLE),
       defaultValue: x.DEFAULT_VALUE,
       isOptional: dbApi.fromDbBool(x.IS_OPTIONAL),
       isReportable:
         x.REPORTING_POLICY == dbEnums.reportingPolicy.mandatory ||
         x.REPORTING_POLICY == dbEnums.reportingPolicy.suggested,
+      isReportableAttribute:
+        x.REPORTING_POLICY == dbEnums.reportingPolicy.mandatory ||
+        x.REPORTING_POLICY == dbEnums.reportingPolicy.suggested,
       reportingPolicy: x.REPORTING_POLICY,
       isSceneRequired: dbApi.fromDbBool(x.IS_SCENE_REQUIRED),
       entryType: x.ARRAY_TYPE,
       mustUseTimedWrite: dbApi.fromDbBool(x.MUST_USE_TIMED_WRITE),
+      isArray: x.IS_ARRAY,
     }
   },
 

--- a/src-electron/db/query-attribute.js
+++ b/src-electron/db/query-attribute.js
@@ -183,7 +183,7 @@ async function selectAllAttributeDetailsFromEnabledClusters(
 ) {
   let sideFilter = ''
   if (side) {
-    sideFilter = " AND ATTRIBUTE.SIDE = 'server'"
+    sideFilter = ` AND ATTRIBUTE.SIDE = '${side}' `
   }
   let endpointTypeClusterRef = endpointsAndClusters
     .map((ep) => ep.endpointTypeClusterRef)

--- a/src-electron/db/query-attribute.js
+++ b/src-electron/db/query-attribute.js
@@ -476,6 +476,8 @@ async function selectAttributeDetailsFromEnabledClusters(
       mfgAttributeCount: x.MANUFACTURING_SPECIFIC_ATTRIBUTE_COUNT,
       singletonAttributeSize: x.SINGLETON_ATTRIBUTE_SIZE,
       maxAttributeSize: x.MAX_ATTRIBUTE_SIZE,
+      isGlobalAttribute: x.IS_GLOBAL_ATTRIBUTE,
+      isArray: x.IS_ARRAY,
     }
   }
   return dbApi
@@ -491,6 +493,22 @@ async function selectAttributeDetailsFromEnabledClusters(
     ATTRIBUTE.DEFINE,
     ATTRIBUTE.MANUFACTURER_CODE,
     ATTRIBUTE.IS_WRITABLE,
+    CASE
+      WHEN
+        ATTRIBUTE.CLUSTER_REF IS NULL
+      THEN
+        1
+      ELSE
+        0
+    END AS IS_GLOBAL_ATTRIBUTE,
+    CASE
+      WHEN
+        ATTRIBUTE.ARRAY_TYPE IS NOT NULL
+      THEN
+        1
+      ELSE
+        0
+    END AS IS_ARRAY,
     CLUSTER.CLUSTER_ID AS CLUSTER_ID,
     ENDPOINT_TYPE_CLUSTER.SIDE AS CLUSTER_SIDE,
     CLUSTER.NAME AS CLUSTER_NAME,

--- a/src-electron/db/query-command.js
+++ b/src-electron/db/query-command.js
@@ -571,6 +571,7 @@ async function selectAllIncomingOrOutgoingCommandsForCluster(
       isFabricScoped: dbApi.fromDbBool(x.IS_FABRIC_SCOPED),
       responseName: x.RESPONSE_NAME,
       responseRef: x.RESPONSE_REF,
+      hasSpecificResponse: x.RESPONSE_REF ? 1 : 0,
       incoming: x.INCOMING,
       outgoing: x.OUTGOING,
       mfgCommandCount: x.MANUFACTURING_SPECIFIC_COMMAND_COUNT,

--- a/src-electron/db/query-command.js
+++ b/src-electron/db/query-command.js
@@ -564,6 +564,7 @@ async function selectAllIncomingOrOutgoingCommandsForCluster(
       numberOfClusterSidesEnabled: x.NO_OF_CLUSTER_SIDES_ENABLED,
       id: x.COMMAND_ID,
       commandName: x.COMMAND_NAME,
+      name: x.COMMAND_NAME,
       commandSource: x.COMMAND_SOURCE,
       code: x.COMMAND_CODE,
       mustUseTimedInvoke: dbApi.fromDbBool(x.MUST_USE_TIMED_INVOKE),

--- a/src-electron/db/query-endpoint-type.js
+++ b/src-electron/db/query-endpoint-type.js
@@ -162,7 +162,17 @@ async function selectEndpointType(db, id) {
  * @param {*} endpointTypes
  * @returns Promise that resolves with the data that should go into the external form.
  */
-async function selectAllClustersDetailsFromEndpointTypes(db, endpointTypes) {
+async function selectAllClustersDetailsFromEndpointTypes(
+  db,
+  endpointTypes,
+  options = null
+) {
+  let side = null
+  let endpointClusterSideFilter = 'ENDPOINT_TYPE_CLUSTER.SIDE IS NOT ""'
+  if (options && options.hash.side) {
+    side = options.hash.side.toLowerCase()
+    endpointClusterSideFilter = "ENDPOINT_TYPE_CLUSTER.SIDE = '" + side + "'"
+  }
   let endpointTypeIds = endpointTypes.map((ep) => ep.endpointTypeId).toString()
   let mapFunction = (x) => {
     return {
@@ -204,7 +214,7 @@ ON
 WHERE
   ENDPOINT_TYPE_CLUSTER.ENDPOINT_TYPE_REF IN (${endpointTypeIds})
 AND
-  ENDPOINT_TYPE_CLUSTER.SIDE IS NOT "" AND ENDPOINT_TYPE_CLUSTER.ENABLED = 1
+  ${endpointClusterSideFilter} AND ENDPOINT_TYPE_CLUSTER.ENABLED = 1
 GROUP BY
   NAME, SIDE
 ${

--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -650,8 +650,10 @@ async function selectAttributesByClusterIdAndSideIncludingGlobal(
   db,
   clusterId,
   packageIds,
-  side
+  side,
+  hasIsOptional
 ) {
+  let optionalAttributeString = hasIsOptional ? 'IS_OPTIONAL,' : ''
   return dbApi
     .dbAll(
       db,
@@ -662,7 +664,14 @@ SELECT
   CODE,
   MANUFACTURER_CODE,
   NAME,
-  TYPE,
+  CASE
+    WHEN
+      ATTRIBUTE.ARRAY_TYPE IS NULL
+    THEN
+      ATTRIBUTE.TYPE
+    ELSE
+      ATTRIBUTE.ARRAY_TYPE
+  END AS TYPE,
   SIDE,
   DEFINE,
   MIN,
@@ -675,12 +684,20 @@ SELECT
   REPORTABLE_CHANGE_LENGTH,
   IS_WRITABLE,
   DEFAULT_VALUE,
-  IS_OPTIONAL,
+  ${optionalAttributeString}
   REPORTING_POLICY,
   IS_NULLABLE,
   IS_SCENE_REQUIRED,
   ARRAY_TYPE,
-  MUST_USE_TIMED_WRITE
+  MUST_USE_TIMED_WRITE,
+  CASE
+    WHEN
+      ATTRIBUTE.ARRAY_TYPE IS NOT NULL
+    THEN
+      1
+    ELSE
+      0
+  END AS IS_ARRAY
 FROM ATTRIBUTE
 WHERE
   SIDE = ?

--- a/src-electron/generator/helper-c.js
+++ b/src-electron/generator/helper-c.js
@@ -263,8 +263,39 @@ async function asBytes(value, type) {
  * @param {*} str
  * @returns a spaced out string in lowercase
  */
-function asCamelCased(label, firstLower = true) {
-  return string.toCamelCase(label, firstLower)
+function asCamelCased(label, firstLower = true, options = { hash: {} }) {
+  const preserveAcronyms = options && options.hash.preserveAcronyms
+  if (!preserveAcronyms) {
+    return string.toCamelCase(label, firstLower)
+  } else {
+    let tokens = label.replace(/[+()&]/g, '').split(/ |_|-|\//)
+
+    let str = tokens
+      .map((token) => {
+        let isAcronym = token == token.toUpperCase()
+        if (!isAcronym) {
+          let newToken = token[0].toUpperCase()
+          if (token.length > 1) {
+            newToken += token.substring(1)
+          }
+          return newToken
+        }
+
+        if (preserveAcronyms) {
+          return token
+        }
+
+        // if preserveAcronyms is false, then anything beyond the first letter becomes lower-case.
+        let newToken = token[0]
+        if (token.length > 1) {
+          newToken += token.substring(1).toLowerCase()
+        }
+        return newToken
+      })
+      .join('')
+
+    return str.replace(/[^A-Za-z0-9_]/g, '')
+  }
 }
 
 /**

--- a/src-electron/generator/helper-command.js
+++ b/src-electron/generator/helper-command.js
@@ -399,6 +399,34 @@ async function if_command_fixed_length(commandId, options) {
   return options.fn(this)
 }
 
+/**
+ * If helper which checks if a command has atleast one required command
+ * argument.
+ *
+ * example:
+ * {{#if_command_has_required_argument commandId}}
+ * command has a required argument
+ * {{else}}
+ * command does not have a required argument
+ * {{/if_command_has_required_argument}}
+ * @param {*} commandId
+ * @param {*} options
+ * @returns  content in the handlebar template based on the commandId
+ * having a required command argument or not as shown in the example.
+ */
+async function if_command_has_required_argument(commandId, options) {
+  let commandArgs = await queryCommand.selectCommandArgumentsByCommandId(
+    this.global.db,
+    commandId
+  )
+  for (let commandArg of commandArgs) {
+    if (!commandArg.isOptional) {
+      return options.fn(this)
+    }
+  }
+  return options.inverse(this)
+}
+
 // WARNING! WARNING! WARNING! WARNING! WARNING! WARNING!
 //
 // Note: these exports are public API. Templates that might have been created in the past and are
@@ -438,3 +466,4 @@ exports.if_command_arg_not_always_present_with_presentif =
 exports.if_command_arg_always_present_with_presentif =
   if_command_arg_always_present_with_presentif
 exports.if_command_args_exist = if_command_args_exist
+exports.if_command_has_required_argument = if_command_has_required_argument

--- a/src-electron/generator/helper-session.js
+++ b/src-electron/generator/helper-session.js
@@ -1480,6 +1480,30 @@ async function generated_attribute_min_max_index(
   return dataPtr
 }
 
+/**
+ * If helper that checks if there are clusters enabled
+ *
+ * @param {*} options
+ * @returns Promise of the resolved blocks iterating over cluster commands.
+ * Available options:
+ * - side: side="client/server" can be used to check if there are client or
+ * server side clusters are available
+ */
+async function if_has_user_clusters(options) {
+  let endpointTypes = await templateUtil.ensureEndpointTypeIds(this)
+  let clusters =
+    await queryEndpointType.selectAllClustersDetailsFromEndpointTypes(
+      this.global.db,
+      endpointTypes,
+      options
+    )
+  if (clusters.length > 0) {
+    return options.fn(this)
+  } else {
+    return options.inverse(this)
+  }
+}
+
 const dep = templateUtil.deprecatedHelper
 
 // WARNING! WARNING! WARNING! WARNING! WARNING! WARNING!
@@ -1575,3 +1599,4 @@ exports.is_command_default_response_enabled =
   is_command_default_response_enabled
 exports.is_command_default_response_disabled =
   is_command_default_response_disabled
+exports.if_has_user_clusters = if_has_user_clusters

--- a/src-electron/generator/helper-session.js
+++ b/src-electron/generator/helper-session.js
@@ -294,7 +294,8 @@ async function all_user_cluster_attribute_util(
       await queryAttribute.selectAllAttributeDetailsFromEnabledClusters(
         currentContext.global.db,
         endpointsAndClusters,
-        packageIds
+        packageIds,
+        side
       )
   } else if (isManufacturingSpecific) {
     endpointAttributes =

--- a/src-electron/generator/helper-session.js
+++ b/src-electron/generator/helper-session.js
@@ -442,11 +442,11 @@ async function all_cli_commands_for_user_enabled_clusters(options) {
  */
 async function all_user_clusters(options) {
   let endpointTypes = await templateUtil.ensureEndpointTypeIds(this)
-
   let clusters =
     await queryEndpointType.selectAllClustersDetailsFromEndpointTypes(
       this.global.db,
-      endpointTypes
+      endpointTypes,
+      options
     )
 
   return templateUtil.collectBlocks(clusters, options, this)

--- a/src-electron/generator/helper-zcl.js
+++ b/src-electron/generator/helper-zcl.js
@@ -2862,10 +2862,21 @@ async function as_underlying_java_type_for_zcl_type(
   }
 }
 
+/**
+ * See as_underlying_language_specific_zcl_type_util
+ * @param {*} type
+ * @param {*} options
+ * @returns Underlying language specific data type for a given zcl data type
+ */
+async function as_underlying_language_specific_zcl_type(type, options) {
+  return as_underlying_language_specific_zcl_type_util(type, options, this)
+}
+
 /*
  *
  * @param {*} type
  * @param {*} options
+ * @param {*} context
  * @returns the size of of the zcl type with cutsomizations through options
  * Available Options:
  * - language: Specify the language of return for eg c, python, etc
@@ -2878,12 +2889,16 @@ async function as_underlying_java_type_for_zcl_type(
  * - unSignedPostfix: Use this postfix instead of the postfix mentioned when it is a signed zcl type
  * - All other options passed to this helper are considered as overrides for
  * zcl types
- * for eg: (get_underlying_language_specific_zcl_type single="float") will return the zcl
+ * for eg: (as_underlying_language_specific_zcl_type single="float") will return the zcl
  * data type "float" for "single"
  * Note: "single" is an exception here
  *
  */
-async function get_underlying_language_specific_zcl_type(type, options) {
+async function as_underlying_language_specific_zcl_type_util(
+  type,
+  options,
+  context
+) {
   let hash = options.hash
   let prefix = hash && hash.prefix ? hash.prefix : ''
   let signedPrefix = hash && hash.signedPrefix ? hash.signedPrefix : ''
@@ -2897,9 +2912,9 @@ async function get_underlying_language_specific_zcl_type(type, options) {
   }
 
   // Get ZCL Data Type from the db
-  const packageIds = await templateUtil.ensureZclPackageIds(this)
+  const packageIds = await templateUtil.ensureZclPackageIds(context)
   let dataType = await queryZcl.selectDataTypeByName(
-    this.global.db,
+    context.global.db,
     type,
     packageIds
   )
@@ -2910,7 +2925,7 @@ async function get_underlying_language_specific_zcl_type(type, options) {
 
   if (dataType) {
     // Overwrite any type with the one coming from the template options
-    // Eg: {{get_underlying_language_specific_zcl_type type boolean='bool'}}
+    // Eg: {{as_underlying_language_specific_zcl_type type boolean='bool'}}
     // Here all types named 'boolean' will return 'bool'
     if (type in hash) {
       return hash[type]
@@ -2921,7 +2936,7 @@ async function get_underlying_language_specific_zcl_type(type, options) {
         type,
         dataType,
         packageIds,
-        this
+        context
       )
     } else if (hash.language == 'python') {
       // Language Specific: Python
@@ -2930,7 +2945,7 @@ async function get_underlying_language_specific_zcl_type(type, options) {
       return as_underlying_Objective_C_Class_type_for_zcl_type(
         type,
         dataType,
-        this,
+        context,
         options
       )
     } else if (hash.language == 'c++' || hash.language == 'objectiveC') {
@@ -2942,7 +2957,7 @@ async function get_underlying_language_specific_zcl_type(type, options) {
           return 'OctetString'
         } else if (characterStringTypes.includes(type.toUpperCase())) {
           return 'CharString'
-        } else if (this.isArray) {
+        } else if (context.isArray) {
           return 'List'
         }
       } else if (dataType.name.includes('float')) {
@@ -2956,7 +2971,7 @@ async function get_underlying_language_specific_zcl_type(type, options) {
           type,
           dataType,
           packageIds,
-          this
+          context
         )
         result = sizeAndSign.size
         isSigned = sizeAndSign.isSigned
@@ -3171,5 +3186,7 @@ exports.as_type_max_value = as_type_max_value
 exports.as_type_min_value = as_type_min_value
 exports.as_zcl_type_size = as_zcl_type_size
 exports.if_compare = if_compare
-exports.get_underlying_language_specific_zcl_type =
-  get_underlying_language_specific_zcl_type
+exports.as_underlying_language_specific_zcl_type =
+  as_underlying_language_specific_zcl_type
+exports.as_underlying_language_specific_zcl_type_util =
+  as_underlying_language_specific_zcl_type_util

--- a/src-electron/generator/matter/app/zap-templates/templates/chip/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/chip/helper.js
@@ -30,7 +30,7 @@ function throwErrorIfUndefined(item, errorMsg, conditions) {
     if (condition == undefined) {
       console.log(item);
       console.log(errorMsg);
-      throw error;
+      throw errorMsg;
     }
   });
 }

--- a/src-electron/generator/matter/controller/java/templates/helper.js
+++ b/src-electron/generator/matter/controller/java/templates/helper.js
@@ -218,7 +218,15 @@ async function asJavaType(type, zclType, cluster, options) {
       cluster
     )}Cluster${appHelper.asUpperCamelCase(type)}`;
   } else {
-    classType += asJavaBoxedType(type, zclType);
+    let boxedType = asJavaBoxedType(type, zclType);
+    if (boxedType == 'Object') {
+      boxedType = await zclHelper.as_underlying_language_specific_zcl_type_util(
+        type,
+        { hash: { language: 'java' } },
+        this
+      );
+    }
+    classType += boxedType;
   }
 
   if (!options.hash.underlyingType) {

--- a/src-electron/generator/matter/controller/java/templates/helper.js
+++ b/src-electron/generator/matter/controller/java/templates/helper.js
@@ -25,6 +25,7 @@ const appHelper = require('../../../app/zap-templates/templates/app/helper.js');
 const dbEnum = require('../../../../../../src-shared/db-enum');
 
 function convertBasicCTypeToJavaType(cType) {
+  let error = '';
   switch (cType) {
     case 'uint8_t':
     case 'int8_t':
@@ -49,6 +50,7 @@ function convertBasicCTypeToJavaType(cType) {
 }
 
 function convertBasicCTypeToJniType(cType) {
+  let error = '';
   switch (convertBasicCTypeToJavaType(cType)) {
     case 'int':
       return 'jint';
@@ -67,6 +69,7 @@ function convertBasicCTypeToJniType(cType) {
 }
 
 function convertBasicCTypeToJavaBoxedType(cType) {
+  let error = '';
   switch (convertBasicCTypeToJavaType(cType)) {
     case 'int':
       return 'Integer';
@@ -143,6 +146,7 @@ function asJniSignatureBasic(type, useBoxedTypes) {
 
 function convertCTypeToJniSignature(cType, useBoxedTypes) {
   let javaType;
+  let error = '';
   if (useBoxedTypes) {
     javaType = convertBasicCTypeToJavaBoxedType(cType);
   } else {

--- a/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
+++ b/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
@@ -78,6 +78,7 @@ async function asTypedExpressionFromObjectiveC(value, type) {
 
 function asObjectiveCNumberType(label, type, asLowerCased) {
   function fn(pkgId) {
+    let error = '';
     const options = { hash: {} };
     return zclHelper.asUnderlyingZclType
       .call(this, type, options)

--- a/test/gen-template/matter3/1.zapt
+++ b/test/gen-template/matter3/1.zapt
@@ -1,9 +1,9 @@
 {{#chip_client_clusters}}
         case app::Clusters::{{asUpperCamelCase name}}::Id: {
             using namespace app::Clusters::{{asUpperCamelCase name}};
-                {{#chip_server_cluster_attributes}}
+                {{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
                 case Attributes::{{asUpperCamelCase name}}::Id: {
                     using TypeInfo = Attributes::{{asUpperCamelCase name}}::TypeInfo;
                     {{>decode_value target="value" source="cppValue" cluster=(asUpperCamelCase parent.name) depth=0 earlyReturn="nullptr"}}
-                {{/chip_server_cluster_attributes}}
+                {{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
 {{/chip_client_clusters}}

--- a/test/gen-template/matter3/10.zapt
+++ b/test/gen-template/matter3/10.zapt
@@ -35,7 +35,7 @@ void CHIP{{chipCallback.name}}AttributeCallback::CallbackFn(void * context, {{ch
 {{/chip_server_global_responses}}
 
 {{#chip_client_clusters}}
-{{#chip_server_cluster_attributes}}
+{{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
 {{! TODO: Add support for struct-typed attributes }}
 {{#unless (isStrEqual chipCallback.name "Unsupported")}}
 
@@ -71,7 +71,7 @@ void CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallb
   {{/if_basic_global_response}}
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
 {{/chip_client_clusters}}
 
 {{/if}}

--- a/test/gen-template/matter3/11.zapt
+++ b/test/gen-template/matter3/11.zapt
@@ -15,7 +15,7 @@ public:
 {{/chip_server_global_responses}}
 
 {{#chip_client_clusters}}
-{{#chip_server_cluster_attributes}}
+{{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
 {{#unless (isStrEqual chipCallback.name "Unsupported")}}
 {{#if_basic_global_response}}
 {{else}}
@@ -27,7 +27,7 @@ class CHIP{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCall
 {{/if_basic_global_response}}
 
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
 {{/chip_client_clusters}}
 
 {{/if}}

--- a/test/gen-template/matter3/13.zapt
+++ b/test/gen-template/matter3/13.zapt
@@ -7,7 +7,7 @@
       }
 
   {{/chip_cluster_responses}}
-      {{#chip_server_cluster_attributes}}
+      {{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
       {{#if isArray}}
       {{#if isStruct}}
 
@@ -19,7 +19,7 @@
           CommandResponseInfo commandResponseInfo = new CommandResponseInfo("valueList", "List<{{> asJavaTypeForEntry isArray=false}}>");
       }
       {{/if}}
-      {{/chip_server_cluster_attributes}}
+      {{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
 
   {{/chip_client_clusters}}
 

--- a/test/gen-template/matter3/14.zapt
+++ b/test/gen-template/matter3/14.zapt
@@ -3,7 +3,7 @@
 
     {{#chip_client_clusters}}
        Map<String, InteractionInfo> read{{asUpperCamelCase name}}InteractionInfo = new LinkedHashMap<>();
-        {{#chip_server_cluster_attributes}}
+        {{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
         {{! TODO: Add support for struct-typed attributes }}
         {{#unless (isStrEqual chipCallback.name "Unsupported")}}
         Map<String, CommandParameterInfo> read{{asUpperCamelCase ../name}}{{asUpperCamelCase name}}CommandParams = new LinkedHashMap<String, CommandParameterInfo>();
@@ -26,7 +26,7 @@
         );
         read{{asUpperCamelCase ../name}}InteractionInfo.put("read{{asUpperCamelCase name}}Attribute", read{{asUpperCamelCase ../name}}{{asUpperCamelCase name}}AttributeInteractionInfo);
         {{/unless}}
-        {{/chip_server_cluster_attributes}}
+        {{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
         readAttributeMap.put("{{asLowerCamelCase name}}", read{{asUpperCamelCase name}}InteractionInfo);
         {{/chip_client_clusters}}
 

--- a/test/gen-template/matter3/15.zapt
+++ b/test/gen-template/matter3/15.zapt
@@ -2,7 +2,7 @@
 {{#if (chip_has_client_clusters)}}
     {{#chip_client_clusters}}
       Map<String, InteractionInfo> write{{asUpperCamelCase name}}InteractionInfo = new LinkedHashMap<>();
-        {{#chip_server_cluster_attributes}}
+        {{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
         {{! TODO: Add support for struct-typed attributes }}
         {{#unless (isStrEqual chipCallback.name "Unsupported")}}
         {{#if isWritableAttribute}}
@@ -24,7 +24,7 @@
         {{/unless}}
         {{/if}}
         {{/unless}}
-        {{/chip_server_cluster_attributes}}
+        {{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
         writeAttributeMap.put("{{asLowerCamelCase name}}", write{{asUpperCamelCase name}}InteractionInfo);
     {{/chip_client_clusters}}
 

--- a/test/gen-template/matter3/16.zapt
+++ b/test/gen-template/matter3/16.zapt
@@ -21,7 +21,7 @@
 {{/chip_cluster_commands}}
             },
             "attributes": {
-{{#chip_server_cluster_attributes}}
+{{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
                 {{asHex code 8}}: {
                     "attributeName": "{{asUpperCamelCase name}}",
                     "attributeId": {{asHex code 8}},
@@ -33,7 +33,7 @@
                     "writable": True,
                     {{/if}}
                 },
-{{/chip_server_cluster_attributes}}
+{{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
             },
     }
 {{/chip_client_clusters}}

--- a/test/gen-template/matter3/2.zapt
+++ b/test/gen-template/matter3/2.zapt
@@ -8,12 +8,12 @@ typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase nam
 
 {{! TODO: global response types?}}
 
-{{#chip_server_cluster_attributes}}
+{{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
 {{#if isArray}}
 typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallbackType)(void *, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo::DecodableType &);
 {{else}}
 typedef void (*CHIP{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallbackType)(void *, chip::app::Clusters::{{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::TypeInfo::DecodableArgType);
 {{/if}}
-{{/chip_server_cluster_attributes}}
+{{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
 {{/chip_client_clusters}}
 {{/if}}

--- a/test/gen-template/matter3/3.zapt
+++ b/test/gen-template/matter3/3.zapt
@@ -40,7 +40,7 @@
 
   {{/chip_cluster_responses}}
 
-  {{#chip_server_cluster_attributes}}
+  {{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
   {{#unless (isStrEqual chipCallback.name "Unsupported")}}
   {{#if_basic_global_response}}
   {{else}}
@@ -62,8 +62,8 @@
     {{/if}}
   {{/if_basic_global_response}}
   {{/unless}}
-  {{/chip_server_cluster_attributes}}
-  {{#chip_server_cluster_attributes}}
+  {{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
+  {{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
   {{! TODO: Add support for struct-typed attributes }}
   {{#unless (isStrEqual chipCallback.name "Unsupported")}}
 
@@ -99,8 +99,8 @@
     }
   {{/if}}
   {{/unless}}
-  {{/chip_server_cluster_attributes}}
-  {{#chip_server_cluster_attributes}}
+  {{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
+  {{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
   {{! TODO: Add support for struct-typed attributes }}
   {{#unless (isStrEqual chipCallback.name "Unsupported")}}
 
@@ -124,7 +124,7 @@
       {{/if_basic_global_response}}, int minInterval, int maxInterval);
   {{/if}}
   {{/unless}}
-  {{/chip_server_cluster_attributes}}
+  {{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
   }
   {{#not_last}}
 

--- a/test/gen-template/matter3/4.zapt
+++ b/test/gen-template/matter3/4.zapt
@@ -2,7 +2,7 @@
 {{#if (chip_has_client_clusters)}}
 
 {{#chip_client_clusters}}
-{{#chip_server_cluster_attributes}}
+{{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
 {{#unless (isStrEqual chipCallback.name "Unsupported")}}
 {{#if isWritableAttribute}}
 
@@ -22,6 +22,6 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase na
 }
 {{/if}}
 {{/unless}}
-{{/chip_server_cluster_attributes}}
+{{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
 {{/chip_client_clusters}}
 {{/if}}

--- a/test/gen-template/matter3/7.zapt
+++ b/test/gen-template/matter3/7.zapt
@@ -12,11 +12,11 @@
   public static String attributeIdToName(long clusterId, long attributeId) {
     {{#chip_client_clusters}}
     if (clusterId == {{code}}L) {
-      {{#chip_server_cluster_attributes}}
+      {{#all_user_cluster_attributes_irrespective_of_manufatucuring_specification name 'server'}}
       if (attributeId == {{code}}L) {
         return "{{asUpperCamelCase name}}";
       }
-      {{/chip_server_cluster_attributes}}
+      {{/all_user_cluster_attributes_irrespective_of_manufatucuring_specification}}
       return "";
     }
     {{/chip_client_clusters}}


### PR DESCRIPTION
- Adding more things to attribute maps in db-mapping.js query-attribute.js
- Cleaning up attribute apis/queries to include more data from the backend in query-attribute.js, query-zcl.js
- Updating selectAllClustersDetailsFromEndpointTypes in query-endpoint-type.js for more customization
- Updating asCamelCased in helper-c.js to account for preserving acronyms. The other API camel cased helper can be deprecated with this
- Creating get_underlying_language_specific_zcl_type to give the right data type for different zcl types based in different language specifications
- Minor error cleanup in helper.js files and also updating the zap test templates for matter code.
- Github: ZAP#682