### PR TITLE
Providing a mechanism in Overridable to prevent additional comments

### DIFF
--- a/apack.json
+++ b/apack.json
@@ -4,7 +4,7 @@
   "description": "Graphical configuration tool for application and libraries based on Zigbee Cluster Library.",
   "path": [".", "node_modules/.bin/", "ZAP.app/Contents/MacOS"],
   "requiredFeatureLevel": "apack.core:9",
-  "featureLevel": 85,
+  "featureLevel": 86,
   "uc.triggerExtension": "zap",
   "executable": {
     "zap:win32.x86_64": {

--- a/src-electron/generator/overridable.js
+++ b/src-electron/generator/overridable.js
@@ -56,9 +56,10 @@ function nonAtomicType(arg = { name: 'unknown', isStruct: false }) {
  *
  * @param {*} arg Object containing name and size
  */
-function atomicType(arg = { name: 'unknown', size: 0 }) {
+function atomicType(arg = { name: 'unknown', size: 0, no_warning: 0 }) {
   let name = arg.name
   let size = arg.size
+  let no_warning = arg.no_warning
   if (name.startsWith('int')) {
     let signed
     if (name.endsWith('s')) signed = true
@@ -91,9 +92,13 @@ function atomicType(arg = { name: 'unknown', size: 0 }) {
       case 'boolean':
         return 'uint8_t'
       case 'array':
-        return `/* TYPE WARNING: ${name} array defaults to */ uint8_t * `
+        return no_warning
+          ? `uint8_t *`
+          : `/* TYPE WARNING: ${name} array defaults to */ uint8_t * `
       default:
-        return `/* TYPE WARNING: ${name} defaults to */ uint8_t * `
+        return no_warning
+          ? `uint8_t *`
+          : `/* TYPE WARNING: ${name} defaults to */ uint8_t * `
     }
   }
 }

--- a/src-electron/util/zcl-util.js
+++ b/src-electron/util/zcl-util.js
@@ -525,6 +525,10 @@ function dataTypeHelper(
   resolvedType,
   overridable
 ) {
+  let no_warning = { no_warning: 0 }
+  if ('no_warning' in options.hash) {
+    no_warning = { no_warning: options.hash.no_warning }
+  }
   switch (resolvedType) {
     case dbEnum.zclType.array:
       if ('array' in options.hash) {
@@ -577,7 +581,7 @@ function dataTypeHelper(
     default:
       return queryZcl
         .selectAtomicType(db, packageIds, type)
-        .then((atomic) => overridable.atomicType(atomic))
+        .then((atomic) => overridable.atomicType({ ...atomic, ...no_warning }))
   }
 }
 


### PR DESCRIPTION
- adding no_warning option in overridable.atomicType so that /* TYPE WARNING: */ message does not get generated because if this helper is used within a comments section of the code then compiler will throw an error
- Bumping the feature level
- JIRA: ZAPP-991