### PR TITLE
Allow failures in non-strict autoloading, to accomodate for legacy files.

### DIFF
--- a/src-electron/importexport/import-json.js
+++ b/src-electron/importexport/import-json.js
@@ -114,7 +114,13 @@ async function importSinglePackage(db, pkg, zapFilePath, packageMatch) {
   // No perfect match.
   // We will attempt to simply load up the package as it is listed in the file.
   if (autoloading && !(packageMatch === dbEnum.packageMatch.ignore)) {
-    return await autoLoadPackage(db, pkg, absPath)
+    try {
+      return await autoLoadPackage(db, pkg, absPath)
+    } catch (err) {
+      if (dbEnum.packageMatch == dbEnum.packageMatch.strict) {
+        throw err
+      }
+    }
   }
 
   // Now we have to perform the guessing logic.


### PR DESCRIPTION
This fixes the problem where pre-check (zaptest) on the Zigbee stack failed with the old .zap files
that had incorrect package information inside them. While those files are in error, we
do promise backwards compatibility, and that includes backwards compatibility with 
zap files created prior to proper implementation of package recording.
