### PR TITLE
Switch to Matter-friendly package matching.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "genmatter1": "node src-script/zap-generate.js --genResultFile --stateDirectory ~/.zap/genmatter -z ./zcl-builtin/matter/zcl.json -g ./test/gen-template/matter/gen-test.json -i ./test/resource/matter-test.zap -o ./tmp/matter1",
     "genmatter2": "node src-script/zap-generate.js --genResultFile --stateDirectory ~/.zap/genmatter2 -z ./zcl-builtin/matter/zcl.json -g ./test/gen-template/matter/gen-test.json -i ./test/resource/matter-switch.zap -o ./tmp/matter2",
     "genmeta": "node src-script/zap-generate.js --genResultFile --stateDirectory ~/.zap/genmeta -z ./test/resource/meta/zcl.json -g ./test/resource/meta/gen-test.json --appendGenerationSubdirectory -o ./tmp -i  ./test/resource/test-meta.zap",
-    "genmeta2": "node src-script/zap-generate.js --genResultFile --stateDirectory ~/.zap/genmeta --appendGenerationSubdirectory -o ./tmp -i  ./test/resource/test-meta.zap",
+    "genmeta2": "node src-script/zap-generate.js --genResultFile --stateDirectory ~/.zap/genmeta --appendGenerationSubdirectory -o ./tmp -i  ./test/resource/test-meta.zap --packageMatch fuzzy",
     "gentest": "node src-script/zap-generate.js --genResultFile --stateDirectory ~/.zap/gentest -z ./zcl-builtin/silabs/zcl.json -g ./test/gen-template/test/gen-test.json -o ./tmp",
     "gendotdot": "node src-script/zap-generate.js --genResultFile -z ./zcl-builtin/dotdot/library.xml -g ./test/gen-template/dotdot/dotdot-templates.json -o ./tmp",
     "convert": "node src-script/zap-convert.js -o {basename}.zap -z ./zcl-builtin/silabs/zcl.json -g test/gen-template/zigbee/gen-templates.json ./test/resource/isc/*.isc ./test/resource/*.zap",

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -35,6 +35,7 @@ const importJs = require('../importexport/import.js')
 const exportJs = require('../importexport/export.js')
 const watchdog = require('./watchdog')
 const sdkUtil = require('../util/sdk-util')
+const { argv } = require('process')
 
 // This file contains various startup modes.
 
@@ -337,6 +338,7 @@ async function startRegenerateSdk(argv, options) {
             genResultFile: false,
             skipPostGeneration: false,
             appendGenerationSubdirectory: argv.appendGenerationSubdirectory,
+            generationLog: argv.generationLog,
           }
         )
       }
@@ -501,6 +503,7 @@ async function generateSingleFile(
     template: env.builtinTemplateMetafile(),
     postImportScript: null,
     packageMatch: dbEnum.packageMatch.fuzzy,
+    generationLog: null,
   }
 ) {
   let hrstart = process.hrtime.bigint()
@@ -534,6 +537,7 @@ async function generateSingleFile(
   options.logger(`🕐 File loading time: ${util.duration(nsDuration)}`)
 
   options.fileLoadTime = nsDuration
+
   let genResult = await generatorEngine.generateAndWriteFiles(
     db,
     sessionId,
@@ -607,6 +611,7 @@ async function startGeneration(argv, options) {
   options.postImportScript = argv.postImportScript
   options.appendGenerationSubdirectory = argv.appendGenerationSubdirectory
   options.packageMatch = argv.packageMatch
+  options.generationLog = argv.generationLog
 
   let nsDuration = process.hrtime.bigint() - hrstart
   options.logger(`🕐 Setup time: ${util.duration(nsDuration)} `)

--- a/src-electron/util/args.ts
+++ b/src-electron/util/args.ts
@@ -227,7 +227,7 @@ export function processCommandLineArguments(argv: string[]) {
     .option('packageMatch', {
       desc: "Determines how to associate with packages in zap file. 'strict' will cause loading to fail if specified package files are not found, 'fuzzy' will associate with similar packages, 'ignore' will ignore the packages in zap file.",
       choices: ['fuzzy', 'strict', 'ignore'],
-      default: 'fuzzy',
+      default: 'ignore',
     })
     .option('results', {
       desc: 'Specifying the output YAML file to capture convert results.',

--- a/src-electron/util/args.ts
+++ b/src-electron/util/args.ts
@@ -193,6 +193,12 @@ export function processCommandLineArguments(argv: string[]) {
       default:
         process.env[env.environmentVariable.reuseZapInstance.name] == '1',
     })
+    .option('generationLog', {
+      desc: `Whenever generation is performed, a record of it will be put into this file.`,
+      type: 'string',
+      default:
+        process.env[env.environmentVariable.zapGenerationLog.name] || null,
+    })
     .option('watchdogTimer', {
       desc: `In a server mode, how long of no-activity (in ms) shuts down the server.`,
       type: 'number',
@@ -219,8 +225,8 @@ export function processCommandLineArguments(argv: string[]) {
       default: false,
     })
     .option('packageMatch', {
-      desc: "Determines how to associate with packages in zap file. 'strict' will cause loading to fail if specified package files are not found, 'fuzzy' will associate with similar packages.",
-      choices: ['fuzzy', 'strict'],
+      desc: "Determines how to associate with packages in zap file. 'strict' will cause loading to fail if specified package files are not found, 'fuzzy' will associate with similar packages, 'ignore' will ignore the packages in zap file.",
+      choices: ['fuzzy', 'strict', 'ignore'],
       default: 'fuzzy',
     })
     .option('results', {

--- a/src-electron/util/env.ts
+++ b/src-electron/util/env.ts
@@ -69,6 +69,11 @@ export const environmentVariable = {
     description:
       'Amount of millisecons zap will wait for cleanups to perform. This is workaround for some SQLite bug. If unset, default is: 1500',
   },
+  zapGenerationLog: {
+    name: 'ZAP_GENERATION_LOG',
+    description:
+      'Points to a JSON file, which will be used to log every generation performed.',
+  },
   jenkinsHome: {
     name: 'JENKINS_HOME',
     description:


### PR DESCRIPTION
- Use 'ignore' as default packageMatch + add generation log.
- Actual switch to 'ignore'.
- Fix fuzzy as a package match for genmeta2.
