### PR TITLE
Fixing Attribute Reporting Columns

### DIFF
--- a/src/components/ZclAttributeReportingManager.vue
+++ b/src/components/ZclAttributeReportingManager.vue
@@ -292,17 +292,17 @@ export default {
           sortable: true,
         },
         {
-          name: 'clientServer',
-          label: 'Client/Server',
-          field: 'clientServer',
-          align: 'left',
-          sortable: true,
-        },
-        {
           name: 'mfgID',
           label: 'Mfg Code',
           align: 'left',
           field: 'mfgID',
+          sortable: true,
+        },
+        {
+          name: 'clientServer',
+          label: 'Client/Server',
+          field: 'clientServer',
+          align: 'left',
           sortable: true,
         },
         {


### PR DESCRIPTION
 Fixing the Attribute Reporting columns so mfg code is not shown under Client/Server and vice versa