### PR TITLE
Work around clang-format bug.

### DIFF
--- a/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
+++ b/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
@@ -627,7 +627,7 @@ async function availability(clusterName, options) {
       );
       return `API_AVAILABLE(${availabilityStrings.join(
         ', '
-      )}) MTR_NEWLY_DEPRECATED("${options.hash.deprecationMessage}")`;
+      )})\nMTR_NEWLY_DEPRECATED("${options.hash.deprecationMessage}")`;
     }
     return `MTR_NEWLY_DEPRECATED("${options.hash.deprecationMessage}")`;
   }


### PR DESCRIPTION
clang-format doesn't deal with missing newlines in some places well: it inserts them, but not in all the places it needs to, so we end up in a situation where running it multiple times produces different output than running it once.

Work around by just manually inserting a newline.