### PR TITLE
Expose old names directly for Darwin codegen.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -62,4 +62,8 @@ module.exports = {
     '/node_modules/',
     '<rootDir>/test/download-artifact.test.js',
   ],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    '<rootDir>/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js',
+  ],
 }


### PR DESCRIPTION
Also adds a way to check whether a field in a container has been renamed.