### PR TITLE
Allow version stamp skipping and local pkg install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "pack:cli:mac": "node ./src-script/pack-cli.js -p mac",
     "pkg": "npx pkg --out-path dist/ --compress GZip --options max-old-space-size=4096 .",
     "pkg:linux": "npx pkg -t node16-linux-x64 --output dist/zap-linux --compress GZip --options max-old-space-size=4096 .",
+    "pkg-use-local-fork": "node ../pkg/lib-es5/bin.js -t node16-linux-x64 --output dist/zap-linux --compress GZip --options max-old-space-size=4096 .",
     "pkg:win": "npx pkg -t node16-win-x64 --output dist/zap-win.exe --compress GZip --options max-old-space-size=4096 .",
     "pkg:mac": "npx pkg -t node16-macos-x64 --output dist/zap-macos --compress GZip --options max-old-space-size=4096 .",
     "mattersdk": "node src-script/zap-start.js regenerateSdk --sdk ~/git/matter/scripts/tools/sdk.json",

--- a/src-script/script-util.js
+++ b/src-script/script-util.js
@@ -216,6 +216,12 @@ async function stampVersion() {
  * @param {*} mode 'fake', 'real' or 'print'
  */
 async function setPackageJsonVersion(date, mode) {
+  if (process.env.ZAP_SKIP_REAL_VERSION != null) {
+    // If you set ZAP_SKIP_REAL_VERSION environment variable, then this whole
+    // version muddling is turned off.
+    return true
+  }
+
   let promise = new Promise((resolve, reject) => {
     let packageJson = path.join(__dirname, '../package.json')
     let output = ''


### PR DESCRIPTION
- Add temporary target used to test with local fork of pkg.
- Honor ZAP_SKIP_REAL_VERSION environment variable.
