### PR TITLE
Reordering of struct EmberAfAttributeMetadata members

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -288,7 +288,7 @@ function endpoint_attribute_list(options) {
       }
       finalDefaultValue = `ZAP_SIMPLE_DEFAULT(${defaultValue})`
     }
-    ret += `  { ${at.id}, ${at.type}, ${at.size}, ${mask}, ${finalDefaultValue} }, /* ${at.name} */  \\\n`
+    ret += `  { ${finalDefaultValue}, ${at.id}, ${at.size}, ${at.type}, ${mask} }, /* ${at.name} */  \\\n`
   })
   ret += '}\n'
 

--- a/test/endpoint-config.test.js
+++ b/test/endpoint-config.test.js
@@ -199,7 +199,7 @@ test(
       '{ ZAP_REPORT_DIRECTION(REPORTED), 0x0029, 0x00000101, 0x00000000, ZAP_CLUSTER_MASK(SERVER), 0x0000, {{ 0, 65534, 0 }} }, /* lock state */'
     )
     expect(epc).toContain(
-      '{ 0x00000004, ZAP_TYPE(CHAR_STRING), 33, ZAP_ATTRIBUTE_MASK(TOKENIZE), ZAP_LONG_DEFAULTS_INDEX(0) }'
+      '{ ZAP_LONG_DEFAULTS_INDEX(0), 0x00000004, 33, ZAP_TYPE(CHAR_STRING), ZAP_ATTRIBUTE_MASK(TOKENIZE) }'
     )
     expect(epc.includes(bin.hexToCBytes(bin.stringToHex('Very long user id'))))
     expect(epc).toContain('#define FIXED_NETWORKS { 1, 1, 2 }')


### PR DESCRIPTION
Reordering of struct EmberAfAttributeMetadata members

On the example of lighting-app, memory savings are:
Was:
00000000 00004336 r (anonymous namespace)::generatedAttributes
After changes:
00000000 00003252 r (anonymous namespace)::generatedAttributes

As calculated 1/4 is saved or 1084 bytes.

https://github.com/project-chip/connectedhomeip/issues/23720