### PR TITLE
Removed annotation for Darwin should remove everything in the container.

### DIFF
--- a/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
+++ b/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
@@ -745,7 +745,12 @@ function wasRemoved(cluster, options) {
   const data = fetchAvailabilityData(this.global);
   const path = makeAvailabilityPath(cluster, options);
 
-  let removedRelease = findReleaseForPath(data, ['removed', ...path], options);
+  let removedRelease = undefined;
+  let removalPath = [...path];
+  while (removedRelease === undefined && removalPath !== undefined) {
+    removedRelease = findReleaseForPath(data, ['removed', ...removalPath], options);
+    removalPath = findPathToContainer(removalPath);
+  }
   return removedRelease !== undefined;
 }
 


### PR DESCRIPTION
So if a cluster is removed, everything in that cluster should be considered removed.