### PR TITLE
Fix handling of manufacturerCode in various places.

### DIFF
--- a/src-electron/db/query-endpoint-type.js
+++ b/src-electron/db/query-endpoint-type.js
@@ -172,6 +172,7 @@ async function selectAllClustersDetailsFromEndpointTypes(db, endpointTypes) {
       description: x.DESCRIPTION,
       define: x.DEFINE,
       mfgCode: x.MANUFACTURER_CODE,
+      manufacturerCode: x.MANUFACTURER_CODE,
       side: x.SIDE,
       enabled: x.ENABLED,
       endpointClusterId: x.ENDPOINT_TYPE_CLUSTER_ID,

--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -465,7 +465,10 @@ function endpoint_attribute_long_defaults(options) {
 }
 
 function asMEI(manufacturerCode, code) {
-  return '0x' + bin.int32ToHex((manufacturerCode << 16) + code)
+  // Left-shift (and for that matter bitwise or) produces a _signed_ 32-bit
+  // number, which will probably be negative.  Force it to unsigned 32-bit using
+  // >>> 0.
+  return '0x' + bin.int32ToHex(((manufacturerCode << 16) | code) >>> 0);
 }
 
 // The representation of null depends on the type, so we can't use a single

--- a/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
@@ -469,7 +469,10 @@ function chip_friendly_endpoint_type_name(options) {
 }
 
 function asMEI(prefix, suffix) {
-  return cHelper.asHex((prefix << 16) + suffix, 8);
+  // Left-shift (and for that matter bitwise or) produces a _signed_ 32-bit
+  // number, which will probably be negative.  Force it to unsigned 32-bit using
+  // >>> 0.
+  return cHelper.asHex(((prefix << 16) | suffix) >>> 0, 8);
 }
 
 // Not to be exported.


### PR DESCRIPTION
There were two bugs:

1) asMEI produced incorrect output if the manufacturer code was high enough that
   the high bit in it was set, due to ending up with negative numbers.
2) chip_server_clusters for some reason used mfgCode, not manufacturerCode
   (which almost everything else uses).