### PR TITLE
Add a resolveEnvVars option to .zap package.pathRelativity

### DIFF
--- a/src-electron/util/util.js
+++ b/src-electron/util/util.js
@@ -444,6 +444,16 @@ function createAbsolutePath(relativePath, relativity, zapFilePath) {
       return path.join(os.homedir(), relativePath)
     case dbEnum.pathRelativity.relativeToZap:
       return path.join(path.dirname(zapFilePath), relativePath)
+    case dbEnum.pathRelativity.resolveEnvVars:
+      for (let key in process.env) {
+        if (Object.prototype.hasOwnProperty.call(process.env, key)) {
+          relativePath = relativePath.replaceAll('$' + key, process.env[key])
+          relativePath = relativePath.replaceAll('${' + key + '}', process.env[key])
+        }
+      }
+      if (relativePath.indexOf('$') !== -1) {
+        throw new Error('resolveEnvVars: unable to resolve environment variables completely: ' + relativePath)
+      }
   }
   return relativePath
 }

--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -84,6 +84,7 @@ exports.pathRelativity = {
   relativeToZap: 'relativeToZap',
   relativeToUserHome: 'relativeToHome',
   absolute: 'absolute',
+  resolveEnvVars: 'resolveEnvVars',
 }
 
 exports.wsCategory = {


### PR DESCRIPTION
This allows variables like $CHIP_ROOT to be used, which is needed when the chip codebase is independent to the repository the zap file is in.

Throw an error when any variable used fails resolving.

PR implementing this in connectedhomeip.git/scripts/generate.py: https://github.com/project-chip/connectedhomeip/pull/24482