### PR TITLE
Allowing Data types having the same name to be loaded into the DB

### DIFF
--- a/apack.json
+++ b/apack.json
@@ -4,7 +4,7 @@
   "description": "Graphical configuration tool for application and libraries based on Zigbee Cluster Library.",
   "path": [".", "node_modules/.bin/", "ZAP.app/Contents/MacOS"],
   "requiredFeatureLevel": "apack.core:9",
-  "featureLevel": 89,
+  "featureLevel": 90,
   "uc.triggerExtension": "zap",
   "executable": {
     "zap:win32.x86_64": {

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -1262,7 +1262,7 @@ async function processEnumItems(db, filePath, packageId, knownPackages, data) {
         lastFieldId = item.$.fieldId ? parseInt(item.$.fieldId) : defaultFieldId
         enumItems.push({
           enumName: e.$.name,
-          enumClusterCode: e.cluster ? parseInt(e.clusterCode) : null,
+          enumClusterCode: e.cluster ? e.cluster : null,
           name: item.$.name,
           value: parseInt(item.$.value),
           fieldIdentifier: lastFieldId,
@@ -1355,7 +1355,7 @@ async function processBitmapFields(
         lastFieldId = item.$.fieldId ? parseInt(item.$.fieldId) : defaultFieldId
         bitmapFields.push({
           bitmapName: bm.$.name,
-          bitmapClusterCode: bm.cluster ? parseInt(bm.clusterCode) : null,
+          bitmapClusterCode: bm.cluster ? bm.cluster : null,
           name: item.$.name,
           mask: parseInt(item.$.mask),
           fieldIdentifier: lastFieldId,
@@ -1427,7 +1427,7 @@ async function processStructItems(db, filePath, packageIds, data, context) {
         lastFieldId = item.$.fieldId ? parseInt(item.$.fieldId) : defaultFieldId
         structItems.push({
           structName: si.$.name,
-          structClusterCode: si.cluster ? parseInt(si.clusterCode) : null,
+          structClusterCode: si.cluster ? si.cluster : null,
           name: item.$.name,
           type:
             item.$.type == item.$.type.toUpperCase() && item.$.type.length > 1


### PR DESCRIPTION
- These changes allow data types having the same name belonging to different clusters to be loaded.
- The queries have been modified such that cluster specific data types are searched for and inserted into the DB. If not found then generic data types which do not specifically belong to a cluster are used.
- The changes have been applied to enums, bitmaps and structs and then corresponding changes have been made to enum_items, bitmap_fields and struct_items
- Extracting the cluster codes correctly in zcl-loader-silabs.js such that it can be used in query-loader.js
- Updating the requiredFeatureLevel such that the stacks can use the new feature level if templates change according to these changes
- Github: ZAP#906