### PR TITLE
Add CommissionerCommands::GetCommissionerNodeId

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/clusters/CommissionerCommands.js
+++ b/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/clusters/CommissionerCommands.js
@@ -37,8 +37,18 @@ const Unpair = {
   arguments: [{ type: 'NODE_ID', name: 'nodeId' }],
 };
 
+const GetCommissionerNodeId = {
+  name: 'GetCommissionerNodeId',
+  responseName: 'GetCommissionerNodeIdResponse',
+  response: {
+    arguments: [
+      { name: 'nodeId', type: 'NODE_ID' }, //
+    ]
+  }
+}
+
 const name = 'CommissionerCommands';
-const commands = [PairWithCode, Unpair];
+const commands = [PairWithCode, Unpair, GetCommissionerNodeId];
 
 const CommissionerCommands = {
   name,


### PR DESCRIPTION
#### Problem

The `matter` YAML tests exposes `commissionerNodeId` as an internal variable. This PR is the first step to expose it as a pseudo-clusters method instead.