### PR TITLE
[matter] Ignore values: null in readEvent response for YAML tests

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src-electron/generator/matter/app/zap-templates/common/ClusterTestGeneration.js
@@ -280,6 +280,15 @@ function setDefaultResponse(test, useSynthesizeWaitForReport) {
   const defaultResponse = test.expectMultipleResponses ? [] : {};
   setDefault(test, kResponseName, defaultResponse);
 
+  // filter 'values: null' for readEvent command.
+  if (kResponseName in test && test.expectMultipleResponses) {
+      const response = test[kResponseName];
+      if (kValuesName in response && response[kValuesName] == null) {
+          test[kResponseName] = []
+      }
+  }
+
+
   // There is different syntax for expressing the expected response, but in the
   // end it needs to be converted to an array of responses.
   if (kResponseName in test && !Array.isArray(test[kResponseName])) {


### PR DESCRIPTION
##### Problem

The javascript parser annotate `readEvent` test step with `expectMultipleResponses`. I would like to do differently onto the python parser and as such I need to update `TestEvents` with:
```
response:
    - values: null
```

But the current parser will just generate codes for that that won't work. So the simplest migration path is just to ask it to ignore this type of response which has no meaning for it.