### PR TITLE
Create token helpers for generating the token files using ZAP

### DIFF
--- a/apack.json
+++ b/apack.json
@@ -4,7 +4,7 @@
   "description": "Graphical configuration tool for application and libraries based on Zigbee Cluster Library.",
   "path": [".", "node_modules/.bin/", "ZAP.app/Contents/MacOS"],
   "requiredFeatureLevel": "apack.core:9",
-  "featureLevel": 90,
+  "featureLevel": 91,
   "uc.triggerExtension": "zap",
   "executable": {
     "zap:win32.x86_64": {

--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -78,6 +78,7 @@ exports.map = {
       domainName: x.DOMAIN_NAME,
       isSingleton: dbApi.fromDbBool(x.IS_SINGLETON),
       revision: x.REVISION,
+      isManufacturingSpecific: dbApi.toDbBool(x.CLUSTER_MANUFACTURER_CODE),
     }
   },
 
@@ -439,6 +440,20 @@ exports.map = {
     }
   },
 
+  endpointTypeClusterExtended: (x) => {
+    if (x == null) return undefined
+    return {
+      endpointTypeClusterId: x.ENDPOINT_TYPE_CLUSTER_ID,
+      endpointTypeRef: x.ENDPOINT_TYPE_REF,
+      clusterRef: x.CLUSTER_REF,
+      side: x.SIDE,
+      enabled: dbApi.fromDbBool(x.ENABLED),
+      name: x.NAME, // Cluster Name
+      code: x.CODE, // Cluster Code
+      tokenAttributesCount: x.TOKEN_ATTRIBUTES_COUNT, // Number of Token Attributes within the endpoint type cluster
+    }
+  },
+
   endpointTypeAttribute: (x) => {
     if (x == null) return undefined
     return {
@@ -454,6 +469,40 @@ exports.map = {
       minInterval: x.MIN_INTERVAL,
       maxInterval: x.MAX_INTERVAL,
       reportableChange: x.REPORTABLE_CHANGE,
+    }
+  },
+
+  endpointTypeAttributeExtended: (x) => {
+    if (x == null) return undefined
+    return {
+      endpointTypeRef: x.ENDPOINT_TYPE_REF,
+      clusterRef: x.CLUSTER_REF,
+      attributeRef: x.ATTRIBUTE_REF,
+      included: dbApi.fromDbBool(x.INCLUDED),
+      storageOption: x.STORAGE_OPTION,
+      singleton: dbApi.fromDbBool(x.SINGLETON),
+      bounded: dbApi.fromDbBool(x.BOUNDED),
+      defaultValue: x.DEFAULT_VALUE,
+      includedReportable: dbApi.fromDbBool(x.INCLUDED_REPORTABLE),
+      minInterval: x.MIN_INTERVAL,
+      maxInterval: x.MAX_INTERVAL,
+      reportableChange: x.REPORTABLE_CHANGE,
+      name: x.NAME, // Attribute Name
+      code: x.CODE, // Attribute Code
+      side: x.SIDE, // Attribute Side
+      define: x.DEFINE, // Attribute define
+      type: x.TYPE, // Attribute type
+      mfgCode: x.MANUFACTURER_CODE
+        ? x.MANUFACTURER_CODE
+        : x.CLUSTER_MANUFACTURER_CODE, // Attribute manufacturer code
+      clusterMfgCode: x.CLUSTER_MANUFACTURER_CODE,
+      clusterName: x.CLUSTER_NAME,
+      isSingleton: dbApi.fromDbBool(x.SINGLETON), // Endpoint type attribute is singleton or not
+      isManufacturingSpecific: dbApi.toDbBool(
+        x.MANUFACTURER_CODE | x.CLUSTER_MANUFACTURER_CODE
+      ), // Is Attribute mfg specific or not
+      endpointId: x.ENDPOINT_IDENTIFIER, // Endpoint type attribute's endpoint Id
+      tokenId: x.TOKEN_ID, // Endpoint type attribute's token id
     }
   },
 

--- a/src-electron/db/query-attribute.js
+++ b/src-electron/db/query-attribute.js
@@ -47,11 +47,11 @@ function attributeExportMapping(x) {
  * @param {*} endpointTypeClusterRef
  * @returns Records of selected Endpoint Type Attributes.
  */
- async function selectEndpointTypeAttributesByEndpointTypeRefAndClusterRef(
+async function selectEndpointTypeAttributesByEndpointTypeRefAndClusterRef(
   db,
   endpointTypeRef,
   endpointTypeClusterRef
-){
+) {
   let rows = await dbApi.dbAll(
     db,
     `
@@ -73,7 +73,7 @@ function attributeExportMapping(x) {
       ENDPOINT_TYPE_ATTRIBUTE
     where
       ENDPOINT_TYPE_REF = ? and ENDPOINT_TYPE_CLUSTER_REF = ?`,
-    [endpointTypeRef,endpointTypeClusterRef]
+    [endpointTypeRef, endpointTypeClusterRef]
   )
   return rows.map(dbMapping.map.endpointTypeAttribute)
 }
@@ -93,7 +93,7 @@ async function duplicateEndpointTypeAttribute(
   newEndpointTypeRef,
   newEndpointTypeClusterRef,
   attribute
-){
+) {
   return await dbApi.dbInsert(
     db,
     `INSERT INTO ENDPOINT_TYPE_ATTRIBUTE (
@@ -123,7 +123,8 @@ async function duplicateEndpointTypeAttribute(
         ?,
         ?
       )`,
-    [ newEndpointTypeRef,
+    [
+      newEndpointTypeRef,
       newEndpointTypeClusterRef,
       attribute.attributeRef,
       attribute.included,
@@ -134,10 +135,10 @@ async function duplicateEndpointTypeAttribute(
       attribute.includedReportable,
       attribute.minInterval,
       attribute.maxInterval,
-      attribute.reportableChange ]
+      attribute.reportableChange,
+    ]
   )
 }
-
 
 /**
  * Returns a promise of data for attributes inside an endpoint type.
@@ -382,7 +383,9 @@ async function selectAttributeDetailsFromEnabledClusters(
       side: x.SIDE,
       type: x.TYPE,
       define: x.DEFINE,
-      mfgCode: x.MANUFACTURER_CODE,
+      mfgCode: x.MANUFACTURER_CODE
+        ? x.MANUFACTURER_CODE
+        : x.CLUSTER_MANUFACTURER_CODE,
       isWritable: x.IS_WRITABLE,
       clusterId: x.CLUSTER_ID,
       clusterSide: x.CLUSTER_SIDE,
@@ -397,7 +400,16 @@ async function selectAttributeDetailsFromEnabledClusters(
       clusterIndex: x.CLUSTER_INDEX,
       mfgAttributeCount: x.MANUFACTURING_SPECIFIC_ATTRIBUTE_COUNT,
       singletonAttributeSize: x.SINGLETON_ATTRIBUTE_SIZE,
+      singletonTokenizedAttributeSize: x.SINGLETON_TOKENIZED_ATTRIBUTE_SIZE,
+      nonSingletonTokenizedAttributeSize:
+        x.NON_SINGLETON_TOKENIZED_ATTRIBUTE_SIZE,
+      tokenizedAttributeSize: x.TOKENIZED_ATTRIBUTE_SIZE,
       maxAttributeSize: x.MAX_ATTRIBUTE_SIZE,
+      maxTokenAttributeSize: x.MAX_TOKEN_ATTRIBUTE_SIZE,
+      smallestEndpointIdentifier: x.SMALLEST_ENDPOINT_IDENTIFIER,
+      isManufacturingSpecific: dbApi.toDbBool(
+        x.MANUFACTURER_CODE | x.CLUSTER_MANUFACTURER_CODE
+      ), // Is Attribute mfg specific or not
     }
   }
   return dbApi
@@ -418,6 +430,7 @@ async function selectAttributeDetailsFromEnabledClusters(
     CLUSTER.NAME AS CLUSTER_NAME,
     CLUSTER.DEFINE AS CLUSTER_DEFINE,
     CLUSTER.CODE AS CLUSTER_CODE,
+    CLUSTER.MANUFACTURER_CODE AS CLUSTER_MANUFACTURER_CODE,
     ENDPOINT_TYPE_ATTRIBUTE.BOUNDED,
     ENDPOINT_TYPE_ATTRIBUTE.STORAGE_OPTION,
     ENDPOINT_TYPE_ATTRIBUTE.SINGLETON,
@@ -443,6 +456,25 @@ async function selectAttributeDetailsFromEnabledClusters(
           ELSE ATOMIC.ATOMIC_SIZE
           END
         ELSE 0 END) OVER () AS SINGLETON_ATTRIBUTE_SIZE,
+    SUM (CASE WHEN ENDPOINT_TYPE_ATTRIBUTE.SINGLETON=1 THEN 
+          CASE WHEN ENDPOINT_TYPE_ATTRIBUTE.STORAGE_OPTION='NVM' THEN 
+            1
+          ELSE
+            0
+          END
+        ELSE 0 END) OVER () AS SINGLETON_TOKENIZED_ATTRIBUTE_SIZE,
+    SUM (CASE WHEN ENDPOINT_TYPE_ATTRIBUTE.SINGLETON=0 THEN 
+          CASE WHEN ENDPOINT_TYPE_ATTRIBUTE.STORAGE_OPTION='NVM' THEN 
+            1
+          ELSE
+            0
+          END
+        ELSE 0 END) OVER () AS NON_SINGLETON_TOKENIZED_ATTRIBUTE_SIZE,
+    SUM (CASE WHEN ENDPOINT_TYPE_ATTRIBUTE.STORAGE_OPTION='NVM' THEN 
+            1
+         ELSE
+            0
+         END) OVER () AS TOKENIZED_ATTRIBUTE_SIZE,
     MAX(CASE WHEN ATOMIC.IS_STRING=1 THEN 
           CASE WHEN ATOMIC.IS_LONG=0 THEN ATTRIBUTE.MAX_LENGTH+1
               WHEN ATOMIC.IS_LONG=1 THEN ATTRIBUTE.MAX_LENGTH+2
@@ -450,7 +482,27 @@ async function selectAttributeDetailsFromEnabledClusters(
           END
         WHEN ATOMIC.ATOMIC_SIZE IS NULL THEN ATTRIBUTE.MAX_LENGTH
         ELSE ATOMIC.ATOMIC_SIZE
-        END) OVER () AS MAX_ATTRIBUTE_SIZE
+        END) OVER () AS MAX_ATTRIBUTE_SIZE,
+    MAX(CASE WHEN ENDPOINT_TYPE_ATTRIBUTE.STORAGE_OPTION='NVM' THEN
+          CASE WHEN ATOMIC.IS_STRING=1 THEN 
+            CASE WHEN ATOMIC.IS_LONG=0 THEN ATTRIBUTE.MAX_LENGTH+1
+                WHEN ATOMIC.IS_LONG=1 THEN ATTRIBUTE.MAX_LENGTH+2
+                ELSE ATOMIC.ATOMIC_SIZE
+            END
+          WHEN ATOMIC.ATOMIC_SIZE IS NULL THEN ATTRIBUTE.MAX_LENGTH
+          ELSE ATOMIC.ATOMIC_SIZE
+          END
+        ELSE
+          0
+        END) OVER () AS MAX_TOKEN_ATTRIBUTE_SIZE,
+    (
+      SELECT
+        MIN(ENDPOINT_IDENTIFIER)
+      FROM
+        ENDPOINT
+      WHERE
+        ENDPOINT_TYPE_ATTRIBUTE.ENDPOINT_TYPE_REF = ENDPOINT.ENDPOINT_TYPE_REF
+    ) AS SMALLEST_ENDPOINT_IDENTIFIER
   FROM ATTRIBUTE
   INNER JOIN ENDPOINT_TYPE_ATTRIBUTE
   ON ATTRIBUTE.ATTRIBUTE_ID = ENDPOINT_TYPE_ATTRIBUTE.ATTRIBUTE_REF
@@ -503,6 +555,7 @@ async function selectAttributeBoundDetails(
       attributeValueType: x.ATTRIBUTE_VALUE_TYPE,
       arrayIndex: x.ARRAY_INDEX,
       isString: x.IS_STRING,
+      isSingleton: x.SINGLETON,
     }
   }
   return dbApi
@@ -527,7 +580,8 @@ async function selectAttributeBoundDetails(
       ELSE ATOMIC.ATOMIC_SIZE
     END AS ATOMIC_SIZE,
     'DEFAULT' as ATTRIBUTE_VALUE_TYPE,
-    ATOMIC.IS_STRING AS IS_STRING
+    ATOMIC.IS_STRING AS IS_STRING,
+    ENDPOINT_TYPE_ATTRIBUTE.SINGLETON
   FROM ATTRIBUTE
   INNER JOIN ENDPOINT_TYPE_ATTRIBUTE
   ON ATTRIBUTE.ATTRIBUTE_ID = ENDPOINT_TYPE_ATTRIBUTE.ATTRIBUTE_REF
@@ -568,7 +622,8 @@ async function selectAttributeBoundDetails(
     ELSE ATOMIC.ATOMIC_SIZE
   END AS ATOMIC_SIZE,
   'MINIMUM' as ATTRIBUTE_VALUE_TYPE,
-  ATOMIC.IS_STRING AS IS_STRING
+  ATOMIC.IS_STRING AS IS_STRING,
+  ENDPOINT_TYPE_ATTRIBUTE.SINGLETON
 FROM ATTRIBUTE
 INNER JOIN ENDPOINT_TYPE_ATTRIBUTE
 ON ATTRIBUTE.ATTRIBUTE_ID = ENDPOINT_TYPE_ATTRIBUTE.ATTRIBUTE_REF
@@ -609,7 +664,8 @@ UNION
     ELSE ATOMIC.ATOMIC_SIZE
   END AS ATOMIC_SIZE,
   'MAXIMUM' as ATTRIBUTE_VALUE_TYPE,
-  ATOMIC.IS_STRING AS IS_STRING
+  ATOMIC.IS_STRING AS IS_STRING,
+  ENDPOINT_TYPE_ATTRIBUTE.SINGLETON
 FROM ATTRIBUTE
 INNER JOIN ENDPOINT_TYPE_ATTRIBUTE
 ON ATTRIBUTE.ATTRIBUTE_ID = ENDPOINT_TYPE_ATTRIBUTE.ATTRIBUTE_REF
@@ -886,6 +942,159 @@ ORDER BY
     )
 }
 
+/**
+ *
+ * @param {*} db
+ * @param {*} packageIds
+ * @param {*} endpointTypeRef
+ * @param {*} options
+ * @returns Token attributes for a specific endpoint type based on the endpoint
+ * type reference. Can also filter the attributes based on whether the
+ * attribute is configured to be singleton or not.
+ */
+async function selectTokenAttributesForEndpoint(
+  db,
+  packageIds,
+  endpointTypeRef,
+  options
+) {
+  let singletonQuery =
+    'isSingleton' in options.hash
+      ? `AND ENDPOINT_TYPE_ATTRIBUTE.SINGLETON=${options.hash.isSingleton}`
+      : ``
+
+  let rows = await dbApi.dbAll(
+    db,
+    `
+  SELECT
+    ATTRIBUTE.NAME AS NAME,
+    ATTRIBUTE.CODE AS CODE,
+    ATTRIBUTE.SIDE AS SIDE,
+    ATTRIBUTE.DEFINE,
+    ATTRIBUTE.TYPE,
+    ATTRIBUTE.MANUFACTURER_CODE AS MANUFACTURER_CODE,
+    CLUSTER.MANUFACTURER_CODE AS CLUSTER_MANUFACTURER_CODE,
+    CLUSTER.NAME AS CLUSTER_NAME,
+    ENDPOINT_TYPE_ATTRIBUTE.SINGLETON,
+    ENDPOINT_TYPE_ATTRIBUTE.STORAGE_OPTION
+  FROM
+    ATTRIBUTE
+  INNER JOIN
+    ENDPOINT_TYPE_ATTRIBUTE
+  ON
+    ENDPOINT_TYPE_ATTRIBUTE.ATTRIBUTE_REF = ATTRIBUTE.ATTRIBUTE_ID
+  INNER JOIN
+    ENDPOINT_TYPE_CLUSTER
+  ON
+    ENDPOINT_TYPE_ATTRIBUTE.ENDPOINT_TYPE_CLUSTER_REF = ENDPOINT_TYPE_CLUSTER.ENDPOINT_TYPE_CLUSTER_ID
+  INNER JOIN
+    CLUSTER
+  ON
+    ATTRIBUTE.CLUSTER_REF = CLUSTER.CLUSTER_ID
+  WHERE
+    ENDPOINT_TYPE_CLUSTER.ENABLED = 1
+  AND
+    ENDPOINT_TYPE_ATTRIBUTE.ENDPOINT_TYPE_REF = ?
+  AND
+    ENDPOINT_TYPE_ATTRIBUTE.INCLUDED = 1
+  AND
+    ENDPOINT_TYPE_ATTRIBUTE.STORAGE_OPTION = 'NVM'
+  AND
+    ATTRIBUTE.PACKAGE_REF IN (${dbApi.toInClause(packageIds)})
+  ${singletonQuery}
+    `,
+    endpointTypeRef
+  )
+  return rows.map(dbMapping.map.endpointTypeAttributeExtended)
+}
+
+/**
+ * Gets all token attribute information.
+ * @param {*} db
+ * @param {*} sessionId
+ * @param {*} packageIds
+ * @param {*} options
+ * @returns All token attributes. Singleton token attributes are only returned
+ * once whereas non-singleton token attributes are returned per endpoint.
+ */
+async function selectAllUserTokenAttributes(
+  db,
+  sessionId,
+  packageIds,
+  options
+) {
+  const tokenSqlQuery = `SELECT
+  ATTRIBUTE.NAME,
+  ATTRIBUTE.CODE,
+  ATTRIBUTE.MANUFACTURER_CODE,
+  ATTRIBUTE.DEFINE,
+  ATTRIBUTE.SIDE,
+  CLUSTER.CODE AS CLUSTER_CODE,
+  CLUSTER.MANUFACTURER_CODE AS CLUSTER_MANUFACTURER_CODE,
+  ENDPOINT_TYPE_ATTRIBUTE.SINGLETON,
+  ENDPOINT.ENDPOINT_IDENTIFIER,
+  ENDPOINT.ENDPOINT_TYPE_REF
+FROM
+  ATTRIBUTE
+INNER JOIN
+  ENDPOINT_TYPE_ATTRIBUTE
+ON
+  ENDPOINT_TYPE_ATTRIBUTE.ATTRIBUTE_REF = ATTRIBUTE.ATTRIBUTE_ID
+INNER JOIN
+  ENDPOINT_TYPE_CLUSTER
+ON 
+  ENDPOINT_TYPE_ATTRIBUTE.ENDPOINT_TYPE_CLUSTER_REF = ENDPOINT_TYPE_CLUSTER.ENDPOINT_TYPE_CLUSTER_ID
+INNER JOIN
+  ENDPOINT_TYPE
+ON
+  ENDPOINT_TYPE_CLUSTER.ENDPOINT_TYPE_REF = ENDPOINT_TYPE.ENDPOINT_TYPE_ID
+INNER JOIN
+  ENDPOINT
+ON
+  ENDPOINT_TYPE.ENDPOINT_TYPE_ID = ENDPOINT.ENDPOINT_TYPE_REF
+INNER JOIN
+  CLUSTER
+ON
+  ENDPOINT_TYPE_CLUSTER.CLUSTER_REF = CLUSTER.CLUSTER_ID
+WHERE
+  ENDPOINT_TYPE.SESSION_REF = ${sessionId}
+AND
+  ENDPOINT_TYPE_CLUSTER.ENABLED=1
+AND
+  ATTRIBUTE.PACKAGE_REF IN (${dbApi.toInClause(packageIds)})
+AND
+  ENDPOINT_TYPE_ATTRIBUTE.STORAGE_OPTION='NVM'
+AND
+  ENDPOINT_TYPE_ATTRIBUTE.INCLUDED=1`
+
+  // Selecting the rows in such a way that singletons token attributes exist
+  // only once and non-singleton token attributes exist per endpoint.
+  let rows = await dbApi.dbAll(
+    db,
+    `
+    SELECT
+      *,
+      ROW_NUMBER() OVER() + 45055 AS TOKEN_ID
+    FROM
+      (
+        ${tokenSqlQuery} AND ENDPOINT_TYPE_ATTRIBUTE.SINGLETON = 0
+        UNION
+        ${tokenSqlQuery} AND ENDPOINT_TYPE_ATTRIBUTE.SINGLETON = 1
+        GROUP BY
+          CLUSTER.CODE,
+          CLUSTER.MANUFACTURER_CODE,
+          ATTRIBUTE.CODE,
+          ATTRIBUTE.MANUFACTURER_CODE,
+          ATTRIBUTE.SIDE
+      )
+    ORDER BY
+      TOKEN_ID
+    `
+  )
+
+  return rows.map(dbMapping.map.endpointTypeAttributeExtended)
+}
+
 exports.selectAllAttributeDetailsFromEnabledClusters =
   selectAllAttributeDetailsFromEnabledClusters
 exports.selectManufacturerSpecificAttributeDetailsFromAllEndpointTypesAndClusters =
@@ -902,4 +1111,7 @@ exports.selectReportableAttributeDetailsFromEnabledClustersAndEndpoints =
 exports.selectGlobalAttributeDefaults = selectGlobalAttributeDefaults
 exports.selectAttributeByCode = selectAttributeByCode
 exports.duplicateEndpointTypeAttribute = duplicateEndpointTypeAttribute
-exports.selectEndpointTypeAttributesByEndpointTypeRefAndClusterRef = selectEndpointTypeAttributesByEndpointTypeRefAndClusterRef
+exports.selectEndpointTypeAttributesByEndpointTypeRefAndClusterRef =
+  selectEndpointTypeAttributesByEndpointTypeRefAndClusterRef
+exports.selectTokenAttributesForEndpoint = selectTokenAttributesForEndpoint
+exports.selectAllUserTokenAttributes = selectAllUserTokenAttributes

--- a/src-electron/generator/helper-zcl.js
+++ b/src-electron/generator/helper-zcl.js
@@ -2217,10 +2217,15 @@ async function if_mfg_specific_cluster(clusterId, options) {
  * @param attributeSize
  * @param options
  * @returns Formatted attribute value based on given arguments
+ * Available options:
+ * - endian: Specify 'big' or 'little' endian format
+ * - isCommaTerminated: '0' or '1' for output to have a ',' at the end
  */
 async function as_generated_default_macro(value, attributeSize, options) {
   let default_macro_signature = ''
   let temp = ''
+  let isCommaTerminated =
+    'isCommaTerminated' in options.hash ? options.hash.isCommaTerminated : true
   if (attributeSize > 2) {
     // String value
     if (isNaN(value)) {
@@ -2260,7 +2265,9 @@ async function as_generated_default_macro(value, attributeSize, options) {
       .reverse()
       .join(' ')
   }
-  return default_macro_signature
+  return isCommaTerminated
+    ? default_macro_signature
+    : default_macro_signature.trim().slice(0, -1)
 }
 
 /**

--- a/test/gen-template/zigbee/gen-templates.json
+++ b/test/gen-template/zigbee/gen-templates.json
@@ -249,6 +249,11 @@
       "output": "zap-tokens.h"
     },
     {
+      "path": "zap-tokens-version-2.zapt",
+      "name": "ZCL tokens version 2",
+      "output": "zap-tokens-version-2.h"
+    },
+    {
       "path": "atomics.zapt",
       "name": "ZCL Atomics",
       "output": "atomics.out"

--- a/test/gen-template/zigbee/zap-tokens-version-2.zapt
+++ b/test/gen-template/zigbee/zap-tokens-version-2.zapt
@@ -1,0 +1,171 @@
+{{zap_header}}
+
+// This file contains the tokens for nonSingletons stored in flash
+
+{{#token_attributes}}
+  {{#first}}
+// Identifier tags for tokens
+  {{/first}}
+  {{#if isSingleton}}
+// Creator for singleton attribute: {{name}}
+#define CREATOR_{{define}}_SINGLETON {{as_hex tokenId 4}}
+#define NVM3KEY_{{define}}_SINGLETON (NVM3KEY_DOMAIN_ZIGBEE | {{as_hex tokenId 4}})
+  {{else}}
+// Creator for attribute: {{name}}, endpoint: {{endpointId}}
+#define CREATOR_{{define}}_{{endpointId}} {{as_hex tokenId 4}}
+#define NVM3KEY_{{define}}_{{endpointId}} (NVM3KEY_DOMAIN_ZIGBEE | {{as_hex tokenId 4}})
+  {{/if}}
+{{/token_attributes}}
+
+
+{{#token_attribute_endpoints}}
+  {{#first}}
+// Types for the tokens
+#ifdef DEFINETYPES
+  {{/first}}
+{{/token_attribute_endpoints}}
+{{#all_user_cluster_generated_attributes}}
+    {{#if_compare 'NVM' storageOption operator='=='}}
+        {{#if_compare attributeSize 2 operator='>'}}
+typedef uint8_t tokType_{{as_snake_case define}}[{{attributeSize}}];
+        {{else}}
+typedef {{as_underlying_type type}} tokType_{{as_snake_case define}};
+        {{/if_compare}}
+    {{/if_compare}}
+{{/all_user_cluster_generated_attributes}}
+{{#token_attribute_endpoints}}
+  {{#first}}
+#endif // DEFINETYPES
+  {{/first}}
+{{/token_attribute_endpoints}}
+
+{{#token_attribute_endpoints}}
+  {{#first}}
+// Actual token definitions
+#ifdef DEFINETOKENS
+  {{/first}}
+{{/token_attribute_endpoints}}
+{{#all_user_cluster_generated_attributes}}
+    {{#if_compare 'NVM' storageOption operator='=='}}
+        {{#if isSingleton}}
+          {{#if (is_number_greater_than attributeSize 2)}}  
+DEFINE_BASIC_TOKEN({{define}}_SINGLETON, tokType_{{as_snake_case define}}, { {{as_generated_default_macro defaultValue attributeSize endian="big" isCommaTerminated=0}} })
+            {{else if defaultValue}}
+DEFINE_BASIC_TOKEN({{define}}_SINGLETON, tokType_{{as_snake_case define}}, {{as_hex defaultValue}})
+            {{else}}
+DEFINE_BASIC_TOKEN({{define}}_SINGLETON, tokType_{{as_snake_case define}}, 0)
+          {{/if}}
+        {{/if}}
+    {{/if_compare}}
+{{/all_user_cluster_generated_attributes}}
+
+{{#generated_clustes_details}}
+    {{#all_user_cluster_generated_attributes}}
+        {{#if_compare 'NVM' storageOption operator='=='}}
+            {{#unless isSingleton}}
+                {{#if (is_lowercase_equal ./clusterName ../clusterName)}}
+                    {{#if (is_lowercase_equal ./clusterSide ../clusterSide)}}
+                        {{#if_compare attributeSize 2 operator='>'}}
+DEFINE_BASIC_TOKEN({{define}}_{{../endpointIdentifier}}, tokType_{{as_snake_case define}}, { {{as_generated_default_macro defaultValue attributeSize endian="big" isCommaTerminated=0}} })
+                        {{else if defaultValue}}
+DEFINE_BASIC_TOKEN({{define}}_{{../endpointIdentifier}}, tokType_{{as_snake_case define}}, {{as_hex defaultValue}})
+                        {{else}}
+DEFINE_BASIC_TOKEN({{define}}_{{../endpointIdentifier}}, tokType_{{as_snake_case define}}, 0)
+                        {{/if_compare}}
+                    {{/if}}
+                {{/if}}
+            {{/unless}}
+        {{/if_compare}}
+    {{/all_user_cluster_generated_attributes}}
+{{/generated_clustes_details}}
+{{#token_attribute_endpoints}}
+  {{#first}}
+#endif // DEFINETOKENS
+  {{/first}}
+{{/token_attribute_endpoints}}
+
+{{#token_attribute_endpoints}}
+  {{#first}}
+// Macro snippet that loads all the attributes from tokens
+#define GENERATED_TOKEN_LOADER(endpoint) do {
+  {{/first}}
+{{/token_attribute_endpoints}}
+{{#all_user_cluster_generated_attributes}}
+    {{#first}}
+        {{#if_compare tokenizedAttributeSize 0 operator='>'}}
+  uint8_t ptr[{{maxTokenAttributeSize}}]; \
+        {{/if_compare}}
+        {{#if_compare nonSingletonTokenizedAttributeSize 0 operator='>'}}
+  uint8_t curNetwork = emberGetCurrentNetwork(); \
+  uint8_t epNetwork; \
+        {{/if_compare}}
+    {{/first}}
+    {{#if_compare 'NVM' storageOption operator='=='}}
+        {{#if isSingleton}}
+  halCommonGetToken((tokType_{{as_snake_case define}} *)ptr, TOKEN_{{define}}_SINGLETON); \
+  emberAfWrite{{#if isManufacturingSpecific}}ManufacturerSpecific{{/if}}{{as_camel_cased side false}}Attribute({{smallestEndpointIdentifier}}, ZCL_{{as_delimited_macro clusterName}}_CLUSTER_ID, ZCL_{{define}}_ATTRIBUTE_ID, {{#if isManufacturingSpecific}}{{as_hex mfgCode 4}}, {{/if}}(uint8_t*)ptr, ZCL_{{as_delimited_macro type}}_ATTRIBUTE_TYPE); \
+        {{/if}}
+    {{/if_compare}}
+{{/all_user_cluster_generated_attributes}}
+
+{{#token_attribute_endpoints isSingleton=0}}
+    {{#token_attributes endpointTypeRef isSingleton=0}}
+        {{#first}}
+  epNetwork = emberAfNetworkIndexFromEndpoint({{../endpointId}}); \
+  if({{../endpointId}} == (endpoint) || (EMBER_BROADCAST_ENDPOINT == (endpoint) && epNetwork == curNetwork)) { \
+        {{/first}}
+    halCommonGetToken((tokType_{{as_snake_case define}} *)ptr, TOKEN_{{define}}_{{../endpointId}}); \
+    emberAfWrite{{#if isManufacturingSpecific}}ManufacturerSpecific{{/if}}{{as_camel_cased side false}}Attribute({{../endpointId}}, ZCL_{{as_delimited_macro clusterName}}_CLUSTER_ID, ZCL_{{define}}_ATTRIBUTE_ID, {{#if isManufacturingSpecific}}{{as_hex mfgCode 4}}, {{/if}}(uint8_t*)ptr, ZCL_{{as_delimited_macro type}}_ATTRIBUTE_TYPE); \
+        {{#last}}
+  }
+        {{/last}}
+    {{/token_attributes}}
+    {{#last}}
+} while (false)
+    {{/last}}
+{{/token_attribute_endpoints}}
+
+{{#all_user_cluster_generated_attributes}}
+  {{#first}}
+    {{#if_compare tokenizedAttributeSize 0 operator='>'}}
+// Macro snippet that saves the attribute to token
+#define GENERATED_TOKEN_SAVER do {
+  uint8_t allZeroData[{{maxTokenAttributeSize}}];                                                                                                     \
+  MEMSET(allZeroData, 0, {{maxTokenAttributeSize}});                                                                                                  \
+  if ( data == NULL ) { data = allZeroData; }
+    {{/if_compare}}
+  {{/first}}
+{{/all_user_cluster_generated_attributes}}
+{{#token_attribute_clusters isSingleton=1}}
+    if ( {{as_hex code 4}} == clusterId ) {
+    {{#all_user_cluster_generated_attributes}}
+        {{#if_compare 'NVM' storageOption operator='=='}}
+            {{#if isSingleton}}
+                {{#if (is_lowercase_equal ./clusterName ../name)}}
+if ( {{as_hex code 4}} == metadata->attributeId && {{as_hex mfgCode 4}} == emberAfGetMfgCode(metadata) && {{#if_compare 'server' side operator='=='}}!{{/if_compare}}emberAfAttributeIsClient(metadata) ) {   \
+        halCommonSetToken(TOKEN_{{define}}_SINGLETON, data); } 
+                {{/if}}
+            {{/if}}
+        {{/if_compare}}
+    {{/all_user_cluster_generated_attributes}}
+    }
+{{/token_attribute_clusters}}
+{{#token_attribute_endpoints isSingleton=0}}
+if ( {{endpointId}} == endpoint ) { \
+    {{#token_attribute_clusters endpointTypeRef isSingleton=0}}
+    {{#not_first}}else {{/not_first}}if ( {{as_hex code 4}} == clusterId ) { \
+        {{#token_attributes ../endpointTypeRef isSingleton=0}}
+          {{#if (is_lowercase_equal ./clusterName ../name)}}
+if ( {{as_hex code 4}} == metadata->attributeId && {{as_hex mfgCode 4}} == emberAfGetMfgCode(metadata) && {{#if side}}!{{/if}}emberAfAttributeIsClient(metadata) ) \
+          halCommonSetToken(TOKEN_{{define}}_{{../../endpointId}}, data); \
+          {{/if}}
+        {{/token_attributes}}
+    }
+    {{/token_attribute_clusters}}
+}
+{{/token_attribute_endpoints}}
+{{#token_attribute_endpoints}}
+  {{#first}}
+} while (false)
+  {{/first}}
+{{/token_attribute_endpoints}}

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -78,7 +78,7 @@ exports.timeout = {
 
 exports.testTemplate = {
   zigbee: './test/gen-template/zigbee/gen-templates.json',
-  zigbeeCount: 28,
+  zigbeeCount: 29,
   matter: './test/gen-template/matter/gen-test.json',
   matterCount: 8,
   matter2: './test/gen-template/matter2/templates.json',

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -316,3 +316,181 @@ test(
   },
   testUtil.timeout.long()
 )
+
+test(
+  'Test tokens header generation version 2',
+  async () => {
+    let genResult = await genEngine.generate(
+      db,
+      templateContext.sessionId,
+      templateContext.packageId,
+      {},
+      { disableDeprecationWarnings: true }
+    )
+
+    expect(genResult).not.toBeNull()
+    expect(genResult.partial).toBeFalsy()
+    expect(genResult.content).not.toBeNull()
+
+    let header = genResult.content['zap-tokens-version-2.h']
+
+    // Singletons
+    expect(header).toContain('#define CREATOR_STACK_VERSION_SINGLETON 0xB00A')
+    expect(header).toContain(
+      '#define NVM3KEY_STACK_VERSION_SINGLETON (NVM3KEY_DOMAIN_ZIGBEE | 0xB00A)'
+    )
+
+    expect(header).toContain('#define CREATOR_HW_VERSION_SINGLETON 0xB004')
+    expect(header).toContain(
+      '#define NVM3KEY_HW_VERSION_SINGLETON (NVM3KEY_DOMAIN_ZIGBEE | 0xB004)'
+    )
+
+    // Non-singletons
+    expect(header).toContain('#define CREATOR_STACK_VERSION_7 0xB009')
+    expect(header).toContain(
+      '#define NVM3KEY_STACK_VERSION_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB009)'
+    )
+
+    expect(header).toContain('#define CREATOR_HW_VERSION_1 0xB003')
+    expect(header).toContain(
+      '#define NVM3KEY_HW_VERSION_1 (NVM3KEY_DOMAIN_ZIGBEE | 0xB003)'
+    )
+
+    expect(header).toContain('#define CREATOR_APPLICATION_VERSION_1 0xB000')
+    expect(header).toContain(
+      '#define NVM3KEY_APPLICATION_VERSION_1 (NVM3KEY_DOMAIN_ZIGBEE | 0xB000)'
+    )
+
+    expect(header).toContain('#define CREATOR_APPLICATION_VERSION_7 0xB001')
+    expect(header).toContain(
+      '#define NVM3KEY_APPLICATION_VERSION_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB001)'
+    )
+
+    expect(header).toContain('#define CREATOR_PRODUCT_CODE_1 0xB005')
+    expect(header).toContain(
+      '#define NVM3KEY_PRODUCT_CODE_1 (NVM3KEY_DOMAIN_ZIGBEE | 0xB005)'
+    )
+
+    expect(header).toContain(
+      '#define CREATOR_COLOR_CONTROL_COLOR_MODE_7 0xB002'
+    )
+    expect(header).toContain(
+      '#define NVM3KEY_COLOR_CONTROL_COLOR_MODE_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB002)'
+    )
+
+    expect(header).toContain(
+      '#define CREATOR_LEVEL_CONTROL_REMAINING_TIME_7 0xB006'
+    )
+    expect(header).toContain(
+      '#define NVM3KEY_LEVEL_CONTROL_REMAINING_TIME_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB006)'
+    )
+
+    expect(header).toContain(
+      '#define CREATOR_COLOR_CONTROL_REMAINING_TIME_7 0xB007'
+    )
+    expect(header).toContain(
+      '#define NVM3KEY_COLOR_CONTROL_REMAINING_TIME_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB007)'
+    )
+
+    // DEFINETYPES
+    expect(header).toContain('typedef uint8_t tokType_stack_version;')
+    expect(header).toContain('typedef uint8_t tokType_hw_version;')
+    expect(header).toContain('typedef uint8_t tokType_product_code[17];')
+    expect(header).toContain(
+      'typedef uint16_t tokType_level_control_remaining_time;'
+    )
+    expect(header).toContain(
+      'typedef uint16_t tokType_color_control_remaining_time;'
+    )
+
+    // DEFINETOKENS
+
+    expect(header).toContain(
+      'DEFINE_BASIC_TOKEN(APPLICATION_VERSION_2, tokType_application_version'
+    )
+    expect(header).toContain(
+      'DEFINE_BASIC_TOKEN(APPLICATION_VERSION_7, tokType_application_version'
+    )
+    expect(header).toContain(
+      "DEFINE_BASIC_TOKEN(PRODUCT_CODE_7, tokType_product_code, { 0x03, 'A', 'B', 'C', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  })"
+    )
+    expect(header).toContain(
+      'DEFINE_BASIC_TOKEN(LEVEL_CONTROL_REMAINING_TIME_7, tokType_level_control_remaining_time, 0xA)'
+    )
+    expect(header).toContain(
+      'DEFINE_BASIC_TOKEN(COLOR_CONTROL_REMAINING_TIME_7, tokType_color_control_remaining_time, 0xA1B2)'
+    )
+    expect(header).toContain(
+      'DEFINE_BASIC_TOKEN(COLOR_CONTROL_COLOR_MODE_7, tokType_color_control_color_mode, 0x1)'
+    )
+
+    // GENERATED_TOKEN_LOADER
+
+    expect(header).toContain(
+      'halCommonGetToken((tokType_stack_version *)ptr, TOKEN_STACK_VERSION_SINGLETON);'
+    )
+    expect(header).toContain(
+      'emberAfWriteServerAttribute(1, ZCL_BASIC_CLUSTER_ID, ZCL_STACK_VERSION_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_INT8U_ATTRIBUTE_TYPE);'
+    )
+    expect(header).toContain(
+      'halCommonGetToken((tokType_hw_version *)ptr, TOKEN_HW_VERSION_1);'
+    )
+    expect(header).toContain(
+      'emberAfWriteServerAttribute(1, ZCL_BASIC_CLUSTER_ID, ZCL_HW_VERSION_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_INT8U_ATTRIBUTE_TYPE);'
+    )
+    expect(header).toContain(
+      'halCommonGetToken((tokType_stack_version *)ptr, TOKEN_STACK_VERSION_7);'
+    )
+    expect(header).toContain(
+      'emberAfWriteServerAttribute(7, ZCL_BASIC_CLUSTER_ID, ZCL_STACK_VERSION_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_INT8U_ATTRIBUTE_TYPE);'
+    )
+    expect(header).toContain(
+      'if(1 == (endpoint) || (EMBER_BROADCAST_ENDPOINT == (endpoint) && epNetwork == curNetwork))'
+    )
+    expect(header).toContain(
+      'if(7 == (endpoint) || (EMBER_BROADCAST_ENDPOINT == (endpoint) && epNetwork == curNetwork))'
+    )
+    expect(header).toContain(
+      'halCommonGetToken((tokType_application_version *)ptr, TOKEN_APPLICATION_VERSION_1);'
+    )
+    expect(header).toContain(
+      'halCommonGetToken((tokType_application_version *)ptr, TOKEN_APPLICATION_VERSION_7);'
+    )
+    expect(header).toContain(
+      'emberAfWriteServerAttribute(1, ZCL_BASIC_CLUSTER_ID, ZCL_APPLICATION_VERSION_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_INT8U_ATTRIBUTE_TYPE);'
+    )
+
+    // GENERATED_TOKEN_SAVER
+
+    expect(header).toContain('if ( 0x0000 == clusterId )')
+    expect(header).not.toContain('if ( 0x0001 == clusterId )')
+    expect(header).toContain(
+      'if ( 0x0002 == metadata->attributeId && 0x0000 == emberAfGetMfgCode(metadata) && !emberAfAttributeIsClient(metadata) ) {'
+    )
+
+    expect(header).toContain(
+      'halCommonSetToken(TOKEN_STACK_VERSION_SINGLETON, data); }'
+    )
+
+    expect(header).toContain(
+      'if ( 0x0003 == metadata->attributeId && 0x0000 == emberAfGetMfgCode(metadata) && !emberAfAttributeIsClient(metadata) )'
+    )
+
+    expect(header).toContain('halCommonSetToken(TOKEN_HW_VERSION_1, data);')
+
+    expect(header).toContain('if ( 1 == endpoint )')
+    expect(header).toContain('if ( 7 == endpoint )')
+    expect(header).toContain(
+      'if ( 0x0001 == metadata->attributeId && 0x0000 == emberAfGetMfgCode(metadata) && !emberAfAttributeIsClient(metadata) )'
+    )
+
+    expect(header).toContain(
+      'halCommonSetToken(TOKEN_APPLICATION_VERSION_1, data);'
+    )
+
+    expect(header).toContain(
+      'halCommonSetToken(TOKEN_APPLICATION_VERSION_7, data);'
+    )
+  },
+  testUtil.timeout.long()
+)


### PR DESCRIPTION
- Updated helper-tokens with token_attributes, token_attribute_clusters and token_attribute_endpoints helpers which can be used by the generation templates.
- Deprecated tokens_context and token_next helpers which were giving incomplete and wrong generation results
- Updated some existing block helpers in helper-zcl with token information to help with generation
- Added the queries for token helpers in query-attribute and query-cluster files
- Updated dbMapping with endpointTypeClusterExtended and endpointTypeAttributeExtended such that map functions can be used in a generic way
- JIRA: ZAPP-1036