### PR TITLE
new: support for cluster shutdown functions

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
@@ -102,6 +102,16 @@ function chip_endpoint_generated_functions() {
         hasFunctionArray = true;
       }
 
+      if (configData.ClustersWithShutdownFunctions.includes(clusterName)) {
+        hasFunctionArray = true;
+        functionList = functionList.concat(
+          `  (EmberAfGenericClusterFunction) Matter${cHelper.asCamelCased(
+             clusterName,
+             false
+          )}ClusterServerShutdownCallback,\\\n`
+        );
+      }
+
       if (configData.ClustersWithPreAttributeChangeFunctions.includes(clusterName)) {
         functionList = functionList.concat(
           `  (EmberAfGenericClusterFunction) Matter${cHelper.asCamelCased(
@@ -216,6 +226,11 @@ function chip_endpoint_cluster_list() {
 
       if (configData.ClustersWithAttributeChangedFunctions.includes(clusterName)) {
         c.mask.push('ATTRIBUTE_CHANGED_FUNCTION');
+        hasFunctionArray = true;
+      }
+
+      if (configData.ClustersWithShutdownFunctions.includes(clusterName)) {
+        c.mask.push('SHUTDOWN_FUNCTION');
         hasFunctionArray = true;
       }
 


### PR DESCRIPTION
As discussed on https://github.com/project-chip/connectedhomeip/pull/24844, we should have some type of callback that is able to called to shutdown pending timers on clusters that are being torn down.

This code adds `MatterXXClusterServerShutdownCallback` in the same way zap generates callbacks to `emberAfXXClusterServerInitCallback`

@bzbarsky-apple @andy31415 