### PR TITLE
Add CommissionerCommands::PairWithCode discoverOnce optional argument

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/clusters/CommissionerCommands.js
+++ b/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/clusters/CommissionerCommands.js
@@ -29,6 +29,7 @@ const PairWithCode = {
   arguments: [
     { type: 'NODE_ID', name: 'nodeId' },
     { type: 'CHAR_STRING', name: 'payload' },
+    { type: 'BOOLEAN', name: 'discoverOnce', isOptional: true },
   ],
 };
 


### PR DESCRIPTION
#### Problem

The matter SDK needs to modify `CommissionerCommands:PairWithCode` to takes an extra optional argument.