### PR TITLE
Fix backwards compatibility for recent zap changes

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
@@ -49,14 +49,15 @@ function getConfigData(global) {
   if (configData === undefined) {
     let f = global.resource('config-data');
     // NOTE: This has to be sync, so we can use this data in if conditions.
-    let rawData = fs.readFileSync(f, { encoding: 'utf8', flag: 'r' });
-    configData = YAML.parse(rawData);
+    if (f) {
+      let rawData = fs.readFileSync(f, { encoding: 'utf8', flag: 'r' });
+      configData = YAML.parse(rawData);
+    }
   }
   return configData;
 }
 
-function isInConfigList(string, listName)
-{
+function isInConfigList(string, listName) {
   const data = getConfigData(this.global);
   return data[listName].includes(string);
 }
@@ -65,6 +66,43 @@ function isInConfigList(string, listName)
 // these helpers are a Hot fix for the "GENERATED_FUNCTIONS" problem
 // They should be removed or replace once issue #4369 is resolved
 // These helpers only works within the endpoint_config iterator
+
+// List of clusters with generated functions maintained for backwards
+// compatibility. The following lists are outdated and are kept to
+// make sure older SDK releases continue working with zap updates.
+const endpointClusterWithInit = [
+  'Basic',
+  'Color Control',
+  'Groups',
+  'Identify',
+  'Level Control',
+  'Localization Configuration',
+  'Occupancy Sensing',
+  'On/Off',
+  'Pump Configuration and Control',
+  'Scenes',
+  'Time Format Localization',
+  'Thermostat',
+  'Mode Select',
+];
+const endpointClusterWithAttributeChanged = [
+  'Bridged Device Basic',
+  'Door Lock',
+  'Identify',
+  'Pump Configuration and Control',
+  'Window Covering',
+  'Fan Control',
+];
+const endpointClusterWithPreAttribute = [
+  'Door Lock',
+  'Pump Configuration and Control',
+  'Thermostat User Interface Configuration',
+  'Time Format Localization',
+  'Localization Configuration',
+  'Mode Select',
+  'Fan Control',
+  'Thermostat',
+];
 
 /**
  * Populate the GENERATED_FUNCTIONS field
@@ -82,7 +120,18 @@ function chip_endpoint_generated_functions() {
     }
     if (c.comment.includes('server')) {
       let hasFunctionArray = false;
-      if (configData.ClustersWithInitFunctions.includes(clusterName)) {
+      let isClusterInitFunctionIncluded = configData
+        ? configData.ClustersWithInitFunctions.includes(clusterName)
+        : endpointClusterWithInit.includes(clusterName);
+      let isClusterAttributeChangedFunctionIncluded = configData
+        ? configData.ClustersWithAttributeChangedFunctions.includes(clusterName)
+        : endpointClusterWithAttributeChanged.includes(clusterName);
+      let isClusterPreAttributeChangedFunctionIncluded = configData
+        ? configData.ClustersWithPreAttributeChangeFunctions.includes(
+            clusterName
+          )
+        : endpointClusterWithPreAttribute.includes(clusterName);
+      if (isClusterInitFunctionIncluded) {
         hasFunctionArray = true;
         functionList = functionList.concat(
           `  (EmberAfGenericClusterFunction) emberAf${cHelper.asCamelCased(
@@ -92,7 +141,7 @@ function chip_endpoint_generated_functions() {
         );
       }
 
-      if (configData.ClustersWithAttributeChangedFunctions.includes(clusterName)) {
+      if (isClusterAttributeChangedFunctionIncluded) {
         functionList = functionList.concat(
           `  (EmberAfGenericClusterFunction) Matter${cHelper.asCamelCased(
             clusterName,
@@ -102,17 +151,21 @@ function chip_endpoint_generated_functions() {
         hasFunctionArray = true;
       }
 
-      if (configData.ClustersWithShutdownFunctions.includes(clusterName)) {
+      if (
+        configData &&
+        'ClustersWithShutdownFunctions' in configData &&
+        configData.ClustersWithShutdownFunctions.includes(clusterName)
+      ) {
         hasFunctionArray = true;
         functionList = functionList.concat(
           `  (EmberAfGenericClusterFunction) Matter${cHelper.asCamelCased(
-             clusterName,
-             false
+            clusterName,
+            false
           )}ClusterServerShutdownCallback,\\\n`
         );
       }
 
-      if (configData.ClustersWithPreAttributeChangeFunctions.includes(clusterName)) {
+      if (isClusterPreAttributeChangedFunctionIncluded) {
         functionList = functionList.concat(
           `  (EmberAfGenericClusterFunction) Matter${cHelper.asCamelCased(
             clusterName,
@@ -182,25 +235,25 @@ function chip_endpoint_generated_commands_list(options) {
 }
 
 function chip_endpoint_generated_event_count(options) {
-  return this.eventList.length
+  return this.eventList.length;
 }
 
 function chip_endpoint_generated_event_list(options) {
-  let comment = null
+  let comment = null;
 
-  let index = 0
-  let ret = '{ \\\n'
+  let index = 0;
+  let ret = '{ \\\n';
   this.eventList.forEach((ev) => {
     if (ev.comment != comment) {
-      ret += `  /* ${ev.comment} */ \\\n`
-      ret += `  /* EventList (index=${index}) */ \\\n`
-      comment = ev.comment
+      ret += `  /* ${ev.comment} */ \\\n`;
+      ret += `  /* EventList (index=${index}) */ \\\n`;
+      comment = ev.comment;
     }
-    ret += `  ${ev.eventId}, /* ${ev.name} */ \\\n`
-    index++
-  })
-  ret += '}\n'
-  return ret
+    ret += `  ${ev.eventId}, /* ${ev.name} */ \\\n`;
+    index++;
+  });
+  ret += '}\n';
+  return ret;
 }
 
 /**
@@ -216,25 +269,38 @@ function chip_endpoint_cluster_list() {
     let mask = '';
     let functionArray = c.functions;
     let clusterName = c.clusterName;
+    let isClusterInitFunctionIncluded = configData
+      ? configData.ClustersWithInitFunctions.includes(clusterName)
+      : endpointClusterWithInit.includes(clusterName);
+    let isClusterAttributeChangedFunctionIncluded = configData
+      ? configData.ClustersWithAttributeChangedFunctions.includes(clusterName)
+      : endpointClusterWithAttributeChanged.includes(clusterName);
+    let isClusterPreAttributeChangedFunctionIncluded = configData
+      ? configData.ClustersWithPreAttributeChangeFunctions.includes(clusterName)
+      : endpointClusterWithPreAttribute.includes(clusterName);
 
     if (c.comment.includes('server')) {
       let hasFunctionArray = false;
-      if (configData.ClustersWithInitFunctions.includes(clusterName)) {
+      if (isClusterInitFunctionIncluded) {
         c.mask.push('INIT_FUNCTION');
         hasFunctionArray = true;
       }
 
-      if (configData.ClustersWithAttributeChangedFunctions.includes(clusterName)) {
+      if (isClusterAttributeChangedFunctionIncluded) {
         c.mask.push('ATTRIBUTE_CHANGED_FUNCTION');
         hasFunctionArray = true;
       }
 
-      if (configData.ClustersWithShutdownFunctions.includes(clusterName)) {
+      if (
+        configData &&
+        'ClustersWithShutdownFunctions' in configData &&
+        configData.ClustersWithShutdownFunctions.includes(clusterName)
+      ) {
         c.mask.push('SHUTDOWN_FUNCTION');
         hasFunctionArray = true;
       }
 
-      if (configData.ClustersWithPreAttributeChangeFunctions.includes(clusterName)) {
+      if (isClusterPreAttributeChangedFunctionIncluded) {
         c.mask.push('PRE_ATTRIBUTE_CHANGED_FUNCTION');
         hasFunctionArray = true;
       }
@@ -427,7 +493,7 @@ function asCamelCase(label, firstLower, preserveAcronyms) {
     .map((token, index) => {
       let isAllUpperCase = token == token.toUpperCase();
       // PERSONAL is not actually an acronym.
-      let isAcronym =  isAllUpperCase && token != "PERSONAL";
+      let isAcronym = isAllUpperCase && token != 'PERSONAL';
 
       if (isAcronym && preserveAcronyms) {
         return token;
@@ -828,6 +894,71 @@ function getPythonFieldDefault(type, options) {
   return _getPythonFieldDefault.call(this, type, options);
 }
 
+// Allow-list of enums that we generate as enums, not enum classes.
+let weakEnumList = undefined;
+function isWeaklyTypedEnum(label) {
+  if (weakEnumList === undefined) {
+    let f = this.global.resource('weak-enum-list');
+    // NOTE: This has to be sync, so we can use this data in if conditions.
+    if (f) {
+      let rawData = fs.readFileSync(f, { encoding: 'utf8', flag: 'r' });
+      weakEnumList = YAML.parse(rawData);
+    } else {
+      weakEnumList = [
+        'AttributeWritePermission',
+        'BarrierControlBarrierPosition',
+        'BarrierControlMovingState',
+        'ColorControlOptions',
+        'ColorLoopAction',
+        'ColorLoopDirection',
+        'ColorMode',
+        'ContentLaunchStatus',
+        'ContentLaunchStreamingType',
+        'EnhancedColorMode',
+        'HardwareFaultType',
+        'HueDirection',
+        'HueMoveMode',
+        'HueStepMode',
+        'IdentifyEffectIdentifier',
+        'IdentifyEffectVariant',
+        'IdentifyIdentifyType',
+        'InterfaceType',
+        'KeypadLockout',
+        'LevelControlOptions',
+        'MoveMode',
+        'NetworkFaultType',
+        'OnOffDelayedAllOffEffectVariant',
+        'OnOffDyingLightEffectVariant',
+        'OnOffEffectIdentifier',
+        'PHYRateType',
+        'RadioFaultType',
+        'RoutingRole',
+        'SaturationMoveMode',
+        'SaturationStepMode',
+        'SecurityType',
+        'SetpointAdjustMode',
+        'StartUpOnOffValue',
+        'StatusCode',
+        'StepMode',
+        'TemperatureDisplayMode',
+        'WiFiVersionType',
+      ];
+    }
+  }
+  return weakEnumList.includes(label);
+}
+
+let legacyStructList = undefined;
+function isLegacyStruct(label) {
+  if (legacyStructList === undefined) {
+    let f = this.global.resource('legacy-struct-list');
+    // NOTE: This has to be sync, so we can use this data in if conditions.
+    let rawData = fs.readFileSync(f, { encoding: 'utf8', flag: 'r' });
+    legacyStructList = YAML.parse(rawData);
+  }
+  return legacyStructList.includes(label);
+}
+
 function incrementDepth(depth) {
   return depth + 1;
 }
@@ -918,6 +1049,8 @@ async function if_is_non_zero_default(value, options) {
   }
 }
 
+const dep = templateUtil.deprecatedHelper;
+
 //
 // Module exports
 //
@@ -926,7 +1059,8 @@ exports.chip_endpoint_cluster_list = chip_endpoint_cluster_list;
 exports.chip_endpoint_data_version_count = chip_endpoint_data_version_count;
 exports.chip_endpoint_generated_commands_list =
   chip_endpoint_generated_commands_list;
-exports.chip_endpoint_generated_event_count = chip_endpoint_generated_event_count;
+exports.chip_endpoint_generated_event_count =
+  chip_endpoint_generated_event_count;
 exports.chip_endpoint_generated_event_list = chip_endpoint_generated_event_list;
 exports.asTypedExpression = asTypedExpression;
 exports.asTypedLiteral = asTypedLiteral;
@@ -941,6 +1075,12 @@ exports.zapTypeToEncodableClusterObjectType =
 exports.zapTypeToDecodableClusterObjectType =
   zapTypeToDecodableClusterObjectType;
 exports.zapTypeToPythonClusterObjectType = zapTypeToPythonClusterObjectType;
+exports.isWeaklyTypedEnum = dep(isWeaklyTypedEnum, {
+  to: 'isInConfigList',
+});
+exports.isLegacyStruct = dep(isLegacyStruct, {
+  to: 'isInConfigList',
+});
 exports.isInConfigList = isInConfigList;
 exports.getPythonFieldDefault = getPythonFieldDefault;
 exports.incrementDepth = incrementDepth;

--- a/src-electron/generator/template-engine.js
+++ b/src-electron/generator/template-engine.js
@@ -24,6 +24,7 @@ const nativeRequire = require('../util/native-require')
 const fsPromise = require('fs').promises
 const promisedHandlebars = require('promised-handlebars')
 const defaultHandlebars = require('handlebars')
+const notification = require('../db/query-notification.js')
 
 const includedHelpers = [
   require('./helper-zcl'),
@@ -120,9 +121,14 @@ async function produceContent(
         if (key in metaInfo.resources) {
           return metaInfo.resources[key]
         } else {
-          throw new Error(
-            `Resource "${key}" not found among the context resources. Check your template.json file.`
+          notification.setNotification(
+            db,
+            'UPGRADE WARNING',
+            'Resource "${key}" not found among the context resources. Check your template.json file. You may need a Matter SDK upgrade.',
+            sessionId,
+            1
           )
+          return null
         }
       },
       stats: {},

--- a/test/helper-api-baseline.json
+++ b/test/helper-api-baseline.json
@@ -667,6 +667,7 @@
   { "name": "isString", "isDeprecated": false, "category": "matter" },
   { "name": "isStruct", "isDeprecated": true },
   { "name": "isTestOnlyCluster", "isDeprecated": false, "category": "matter" },
+  { "name": "isWeaklyTypedEnum", "isDeprecated": false, "category": "matter" },
   { "name": "iterate", "isDeprecated": false },
   { "name": "iterate_accumulator", "isDeprecated": false },
   { "name": "iterateAccumulator", "isDeprecated": true },


### PR DESCRIPTION
- Throwing a warning in the notifications page of the zap UI instead of throwing an error in template-engine such that we backwards compatibility can be maintained
- Changes to helper.js files have been made to fall back to old way of implementation in the case of global.resource([key]) not finding the data required
- Github: ZAP#941, ZAP#942