### PR TITLE
Backwards Compatibility Fix

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -249,7 +249,7 @@ function endpoint_attribute_list(options) {
   let order = options.hash.order
   if (order == null || order.length == 0) {
     // This is the default value if none is specified
-    order = 'default,id,size,type,mask'
+    order = 'id, type, size, mask, default'
   }
   let comment = null
 

--- a/test/endpoint-config.test.js
+++ b/test/endpoint-config.test.js
@@ -199,7 +199,7 @@ test(
       '{ ZAP_REPORT_DIRECTION(REPORTED), 0x0029, 0x00000101, 0x00000000, ZAP_CLUSTER_MASK(SERVER), 0x0000, {{ 0, 65534, 0 }} }, /* lock state */'
     )
     expect(epc).toContain(
-      '{ ZAP_LONG_DEFAULTS_INDEX(0), 0x00000004, 33, ZAP_TYPE(CHAR_STRING), ZAP_ATTRIBUTE_MASK(TOKENIZE) }'
+      '{ 0x00000004, ZAP_TYPE(CHAR_STRING), 33, ZAP_ATTRIBUTE_MASK(TOKENIZE), ZAP_LONG_DEFAULTS_INDEX(0) }'
     )
     expect(epc.includes(bin.hexToCBytes(bin.stringToHex('Very long user id'))))
     expect(epc).toContain('#define FIXED_NETWORKS { 1, 1, 2 }')


### PR DESCRIPTION
- Changing the default order of endpoint_attribute_list to what it was such that previously released SDKs continue to build their apps seamlessly. Newer templates can mention this order within the template itself
- fixing the endpoint_config test to default to old order
- JIRA: ZAPP-1081