### PR TITLE
Make the zap install path absolute for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,7 +366,7 @@ jobs:
       - name: Generate all
         run: |
           cd chip_repo
-          ZAP_INSTALL_PATH=../zap-release scripts/run_in_build_env.sh scripts/tools/zap_regen_all.py
+          ZAP_INSTALL_PATH=$(pwd)/../zap-release scripts/run_in_build_env.sh scripts/tools/zap_regen_all.py
 
       - name: Ensure git works in the chip repository checkout
         run: git config --global --add safe.directory `pwd`/chip_repo


### PR DESCRIPTION
Use an absolute path when testing zap generation: we likely want ZAP_INSTALL_PATH to be absolute and not depend on PWD when chip runs things (chip scripts may change their pwd to the build directory).