### PR TITLE
Fix cluster list generation.

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -312,6 +312,8 @@ function endpoint_attribute_list(options) {
         case 'mask':
           items.push(mask)
           break
+        default:
+          throw new Error(`Unknown token '${tok}' in order optional argument`);
       }
     })
 
@@ -523,6 +525,8 @@ function endpoint_reporting_config_defaults(options) {
         case 'minmax':
           items.push(`{{ ${minmax} }}`)
           break
+        default:
+          throw new Error(`Unknown token '${tok}' in order optional argument`);
       }
     })
 

--- a/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
@@ -373,7 +373,7 @@ function chip_endpoint_cluster_list(options) {
         case 'attributeCount':
           individualItems.push(`.attributeCount = ${c.attributeCount}`);
           break;
-        case 'clusterSize:':
+        case 'clusterSize':
           individualItems.push(`.clusterSize = ${c.attributeSize}`);
           break;
         case 'mask':
@@ -398,11 +398,13 @@ function chip_endpoint_cluster_list(options) {
         case 'eventCount':
           individualItems.push(`.eventCount = ${eventCount}`);
           break;
+        default:
+          throw new Error(`Unknown token '${tok}' in order optional argument`);
       }
     });
     ret = ret.concat(`  { \\
       /* ${c.comment} */ \\
-      ${individualItems.join(', \\\n')}, \\
+      ${individualItems.join(', \\\n      ')}, \\
     },\\\n`);
 
     totalCommands = totalCommands + acceptedCommands + generatedCommands;


### PR DESCRIPTION
* "clusterSize:" had a stray ':' that was causing generation to produce invalidoutput.
* The old code had things indented sanely, and this is just restoring that.
* There was no detection of unknown tokens, which would have quickly caught the "clusterSize" problem.