### PR TITLE
Set the order of token attributes for minimal diff upon resetting token config

### DIFF
--- a/src-electron/db/query-attribute.js
+++ b/src-electron/db/query-attribute.js
@@ -1086,15 +1086,31 @@ AND
       ROW_NUMBER() OVER() + 45055 AS TOKEN_ID
     FROM
       (
-        ${tokenSqlQuery} AND ENDPOINT_TYPE_ATTRIBUTE.SINGLETON = 0
-        UNION
-        ${tokenSqlQuery} AND ENDPOINT_TYPE_ATTRIBUTE.SINGLETON = 1
-        GROUP BY
-          CLUSTER.CODE,
-          CLUSTER.MANUFACTURER_CODE,
-          ATTRIBUTE.CODE,
-          ATTRIBUTE.MANUFACTURER_CODE,
-          ATTRIBUTE.SIDE
+        SELECT * FROM (
+          ${tokenSqlQuery} AND ENDPOINT_TYPE_ATTRIBUTE.SINGLETON = 0
+          UNION
+          ${tokenSqlQuery} AND ENDPOINT_TYPE_ATTRIBUTE.SINGLETON = 1
+          GROUP BY
+            CLUSTER.CODE,
+            CLUSTER.MANUFACTURER_CODE,
+            ATTRIBUTE.CODE,
+            ATTRIBUTE.MANUFACTURER_CODE,
+            ATTRIBUTE.SIDE
+        )
+        ORDER BY
+          SINGLETON DESC,
+          CLUSTER_MANUFACTURER_CODE,
+          MANUFACTURER_CODE,
+          CASE
+            WHEN
+              SINGLETON = 1
+            THEN
+              SMALLEST_ENDPOINT_IDENTIFIER
+            ELSE
+              ENDPOINT_IDENTIFIER
+          END,
+          CLUSTER_CODE,
+          CODE
       )
     ORDER BY
       TOKEN_ID

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -339,37 +339,37 @@ test(
     let header = genResult.content['zap-tokens-version-2.h']
 
     // Singletons
-    expect(header).toContain('#define CREATOR_STACK_VERSION_SINGLETON 0xB008')
+    expect(header).toContain('#define CREATOR_STACK_VERSION_SINGLETON 0xB000')
     expect(header).toContain(
-      '#define NVM3KEY_STACK_VERSION_SINGLETON (NVM3KEY_DOMAIN_ZIGBEE | 0xB008)'
+      '#define NVM3KEY_STACK_VERSION_SINGLETON (NVM3KEY_DOMAIN_ZIGBEE | 0xB000)'
     )
 
-    expect(header).toContain('#define CREATOR_HW_VERSION_SINGLETON 0xB003')
+    expect(header).toContain('#define CREATOR_HW_VERSION_SINGLETON 0xB001')
     expect(header).toContain(
-      '#define NVM3KEY_HW_VERSION_SINGLETON (NVM3KEY_DOMAIN_ZIGBEE | 0xB003)'
+      '#define NVM3KEY_HW_VERSION_SINGLETON (NVM3KEY_DOMAIN_ZIGBEE | 0xB001)'
     )
 
     // Non-singletons
-    expect(header).toContain('#define CREATOR_APPLICATION_VERSION_1 0xB000')
+    expect(header).toContain('#define CREATOR_APPLICATION_VERSION_1 0xB002')
     expect(header).toContain(
-      '#define NVM3KEY_APPLICATION_VERSION_1 (NVM3KEY_DOMAIN_ZIGBEE | 0xB000)'
+      '#define NVM3KEY_APPLICATION_VERSION_1 (NVM3KEY_DOMAIN_ZIGBEE | 0xB002)'
     )
 
-    expect(header).toContain('#define CREATOR_APPLICATION_VERSION_7 0xB001')
+    expect(header).toContain('#define CREATOR_APPLICATION_VERSION_7 0xB004')
     expect(header).toContain(
-      '#define NVM3KEY_APPLICATION_VERSION_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB001)'
+      '#define NVM3KEY_APPLICATION_VERSION_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB004)'
     )
 
-    expect(header).toContain('#define CREATOR_PRODUCT_CODE_1 0xB004')
+    expect(header).toContain('#define CREATOR_PRODUCT_CODE_1 0xB003')
     expect(header).toContain(
-      '#define NVM3KEY_PRODUCT_CODE_1 (NVM3KEY_DOMAIN_ZIGBEE | 0xB004)'
+      '#define NVM3KEY_PRODUCT_CODE_1 (NVM3KEY_DOMAIN_ZIGBEE | 0xB003)'
     )
 
     expect(header).toContain(
-      '#define CREATOR_COLOR_CONTROL_COLOR_MODE_7 0xB002'
+      '#define CREATOR_COLOR_CONTROL_COLOR_MODE_7 0xB008'
     )
     expect(header).toContain(
-      '#define NVM3KEY_COLOR_CONTROL_COLOR_MODE_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB002)'
+      '#define NVM3KEY_COLOR_CONTROL_COLOR_MODE_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB008)'
     )
 
     expect(header).toContain(
@@ -380,10 +380,10 @@ test(
     )
 
     expect(header).toContain(
-      '#define CREATOR_COLOR_CONTROL_REMAINING_TIME_7 0xB006'
+      '#define CREATOR_COLOR_CONTROL_REMAINING_TIME_7 0xB007'
     )
     expect(header).toContain(
-      '#define NVM3KEY_COLOR_CONTROL_REMAINING_TIME_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB006)'
+      '#define NVM3KEY_COLOR_CONTROL_REMAINING_TIME_7 (NVM3KEY_DOMAIN_ZIGBEE | 0xB007)'
     )
 
     // DEFINETYPES


### PR DESCRIPTION
The token attributes are being set in the following order:
    For Standard attributes:
    - All singleton attributes
    - All non singleton attributes
    - Both of the above are followed by subsequent ordering of cluster mfg code, attribute mfg code, endpoint identifier(smallest endpoint identifier for singleton), cluster code, attribute code
    Configuring the tests according to the above order