### PR TITLE
improve zap-config.h generation speed by 7x

### DIFF
--- a/src-electron/db/query-attribute.js
+++ b/src-electron/db/query-attribute.js
@@ -22,6 +22,7 @@
  */
 const dbApi = require('./db-api.js')
 const dbMapping = require('./db-mapping.js')
+const dbCache = require('./db-cache')
 
 function attributeExportMapping(x) {
   return {
@@ -1120,17 +1121,21 @@ AND
   return rows.map(dbMapping.map.endpointTypeAttributeExtended)
 }
 
-exports.selectAllAttributeDetailsFromEnabledClusters =
+exports.selectAllAttributeDetailsFromEnabledClusters = dbCache.cacheQuery(
   selectAllAttributeDetailsFromEnabledClusters
+)
 exports.selectManufacturerSpecificAttributeDetailsFromAllEndpointTypesAndClusters =
   selectManufacturerSpecificAttributeDetailsFromAllEndpointTypesAndClusters
 exports.selectNonManufacturerSpecificAttributeDetailsFromAllEndpointTypesAndClusters =
   selectNonManufacturerSpecificAttributeDetailsFromAllEndpointTypesAndClusters
 exports.selectAttributeDetailsWithABoundFromEnabledClusters =
-  selectAttributeDetailsWithABoundFromEnabledClusters
-exports.selectAttributeDetailsFromEnabledClusters =
+  dbCache.cacheQuery(selectAttributeDetailsWithABoundFromEnabledClusters)
+exports.selectAttributeDetailsFromEnabledClusters = dbCache.cacheQuery(
   selectAttributeDetailsFromEnabledClusters
-exports.selectAttributeBoundDetails = selectAttributeBoundDetails
+)
+exports.selectAttributeBoundDetails = dbCache.cacheQuery(
+  selectAttributeBoundDetails
+)
 exports.selectReportableAttributeDetailsFromEnabledClustersAndEndpoints =
   selectReportableAttributeDetailsFromEnabledClustersAndEndpoints
 exports.selectGlobalAttributeDefaults = selectGlobalAttributeDefaults


### PR DESCRIPTION
    7x speed up on zap-config.h generation speed

    machine: mac x86 2.6 GHz 6-Core Intel Core i7
    Before:
    PASS  test/gen-zigbee-9.test.js (91.223 s)
      ✓ Basic gen template parsing and generation (18 ms)
      ✓ Validate package loading (1 ms)
      ✓ Load the zap file: /Users/jiteng/repo/zap/test/resource/full-th.zap (1149 ms)
      ✓ Generate "zap-cluster-command-parser.h" (196 ms)
      ✓ Generate "zap-print.h" (14 ms)
      ✓ Generate "zap-id.h" (402 ms)
      ✓ Generate "zap-event.c" (111 ms)
      ✓ Generate "zap-enabled-incoming-commands.h" (41 ms)
      ✓ Generate "zap-event.h" (746 ms)
      ✓ Generate "zap-config.h" (72763 ms)
      ✓ Generate "zap-type.h" (223 ms)
      ✓ Generate "zap-tokens.h" (574 ms)
      ✓ Generate "zap-cli.c" (3542 ms)
      ✓ Generate "zap-command.h" (1161 ms)
      ✓ Generate "zap-command-structs.h" (448 ms)
      ✓ Generate "zap-cluster-command-parser.c" (275 ms)

    After:

     PASS  test/gen-zigbee-9.test.js (24.919 s)
      ✓ Basic gen template parsing and generation (21 ms)
      ✓ Validate package loading
      ✓ Load the zap file: /Users/jiteng/repo/zap/test/resource/full-th.zap (1667 ms)
      ✓ Generate "zap-cluster-command-parser.h" (156 ms)
      ✓ Generate "zap-print.h" (39 ms)
      ✓ Generate "zap-id.h" (439 ms)
      ✓ Generate "zap-event.c" (127 ms)
      ✓ Generate "zap-enabled-incoming-commands.h" (49 ms)
      ✓ Generate "zap-event.h" (905 ms)
      ✓ Generate "zap-config.h" (10471 ms)
      ✓ Generate "zap-type.h" (241 ms)
      ✓ Generate "zap-tokens.h" (627 ms)
      ✓ Generate "zap-cli.c" (3802 ms)
      ✓ Generate "zap-command.h" (1238 ms)
      ✓ Generate "zap-command-structs.h" (555 ms)
      ✓ Generate "zap-cluster-command-parser.c" (251 ms)