### PR TITLE
Uccli upgrade fix

### DIFF
--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -177,6 +177,7 @@ function gatherFiles(filesArg, options = { suffix: '.zap', doBlank: true }) {
  * @param {*} output
  */
 async function startConvert(argv, options) {
+  let zapFiles = argv.zapFiles
   let files = gatherFiles(zapFiles, { suffix: '.zap', doBlank: true })
   if (files.length == 0) {
     options.logger(`    👎 no zap files found in: ${zapFiles}`)

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -183,6 +183,7 @@ async function startConvert(argv, options) {
     options.logger(`    👎 no zap files found in: ${zapFiles}`)
     throw `👎 no zap files found in: ${zapFiles}`
   }
+  if (argv.output == null) throw 'You need to specify output file.'
   let output = argv.output
   let conversion_results = argv.results
   options.logger(`🤖 Conversion started

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -177,7 +177,11 @@ function gatherFiles(filesArg, options = { suffix: '.zap', doBlank: true }) {
  * @param {*} output
  */
 async function startConvert(argv, options) {
-  let files = argv.zapFiles
+  let files = gatherFiles(zapFiles, { suffix: '.zap', doBlank: true })
+  if (files.length == 0) {
+    options.logger(`    👎 no zap files found in: ${zapFiles}`)
+    throw `👎 no zap files found in: ${zapFiles}`
+  }
   let output = argv.output
   let conversion_results = argv.results
   options.logger(`🤖 Conversion started
@@ -780,9 +784,6 @@ async function startUpMainInstance(argv, callbacks) {
   } else if (argv._.includes('server')) {
     return startServer(argv, quitFunction)
   } else if (argv._.includes('convert')) {
-    if (argv.zapFiles.length < 1)
-      throw 'You need to specify at least one zap file.'
-    if (argv.output == null) throw 'You need to specify output file.'
     return startConvert(argv, {
       logger: console.log,
       quitFunction: quitFunction,


### PR DESCRIPTION
When Upgrading a Zigbee or Matter App there is one error message 

```Failed to run upgrade apack_zclConfigurator UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "You need to specify at least one zap file."```

This message is not because of the ZAP upgrade process but rather because the ZAP source code checks the .ZAP file for upgrades before finding the .ZAP file in its folder. The result is that even if there is a .zap file in the config folder, the user will be told they need to specify a .zap file.

In order to fix this, changed the order of operations so the code gathers the files before checking the files.

After making this change my tests passed. The files completed their upgrade.

