### PR TITLE
Error message fix for loading new ZAP file

### DIFF
--- a/src-electron/ide-integration/studio-rest-api.ts
+++ b/src-electron/ide-integration/studio-rest-api.ts
@@ -295,18 +295,20 @@ async function sendUcComponentStateReport(db: dbTypes.DbType) {
  * Notify front-end that current session failed to load.
  * @param {} err
  */
-function sendSessionCreationErrorStatus(db: dbTypes.DbType, err: string) {
+function sendSessionCreationErrorStatus(db: dbTypes.DbType, err: string, sessionId: number) {
   // TODO: delegate type declaration to actual function
   querySession
     .getAllSessions(db)
     .then((sessions: dbMappingTypes.SessionType[]) =>
       sessions.forEach((session) => {
-        let socket = wsServer.clientSocket(session.sessionKey)
-        if (socket) {
-          wsServer.sendWebSocketMessage(socket, {
-            category: dbEnum.wsCategory.sessionCreationError,
-            payload: err,
-          })
+        if(session.sessionId == sessionId){
+          let socket = wsServer.clientSocket(session.sessionKey)
+          if (socket) {
+            wsServer.sendWebSocketMessage(socket, {
+              category: dbEnum.wsCategory.sessionCreationError,
+              payload: err,
+            })
+          }
         }
       })
     )

--- a/src-electron/rest/file-ops.js
+++ b/src-electron/rest/file-ops.js
@@ -81,7 +81,7 @@ function httpPostFileOpen(db) {
           message: e.message,
           stack: e.stack,
         }
-        studio.sendSessionCreationErrorStatus(db, errMsg)
+        studio.sendSessionCreationErrorStatus(db, errMsg.message)
         env.logError(e.message)
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json(errMsg)
       }

--- a/src-electron/rest/file-ops.js
+++ b/src-electron/rest/file-ops.js
@@ -28,6 +28,7 @@ const exportJs = require('../importexport/export.js')
 const path = require('path')
 const { StatusCodes } = require('http-status-codes')
 const querySession = require('../db/query-session.js')
+const queryNotification = require('../db/query-notification.js')
 const dbEnum = require('../../src-shared/db-enum.js')
 const studio = require('../ide-integration/studio-rest-api')
 
@@ -81,7 +82,8 @@ function httpPostFileOpen(db) {
           message: e.message,
           stack: e.stack,
         }
-        studio.sendSessionCreationErrorStatus(db, errMsg.message)
+        queryNotification.setNotification(db, "ERROR", errMsg.message, req.zapSessionId, 1)
+        studio.sendSessionCreationErrorStatus(db, errMsg.message, req.zapSessionId)
         env.logError(e.message)
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).json(errMsg)
       }

--- a/src-electron/server/http-server.js
+++ b/src-electron/server/http-server.js
@@ -229,7 +229,7 @@ function userSessionHandler(db, options) {
             error: 'Could not create session: ' + err.message,
             errorMessage: err,
           }
-          studio.sendSessionCreationErrorStatus(db, resp)
+          studio.sendSessionCreationErrorStatus(db, resp, zapSessionId)
           env.logError(resp)
         })
     }

--- a/src/boot/ws.js
+++ b/src/boot/ws.js
@@ -120,9 +120,8 @@ onWebSocket(dbEnum.wsCategory.dirtyFlag, (data) => {
 
 onWebSocket(dbEnum.wsCategory.sessionCreationError, (data) => {
   let html = `<center>
-  <strong>${data.error}</strong>
+  <strong>${data}</strong>
   <br>
-  ${data.errorMessage}
   </center>`
   Notify.create({
     message: html,

--- a/src/boot/ws.js
+++ b/src/boot/ws.js
@@ -129,6 +129,7 @@ onWebSocket(dbEnum.wsCategory.sessionCreationError, (data) => {
     position: 'top',
     html: true,
     timeout: 0,
+    actions: [{ icon: 'close', color: 'white' }],
   })
 
   console.log(`sessionCreationError: ${JSON.stringify(data)}`)

--- a/src/layouts/ZclConfiguratorLayout.vue
+++ b/src/layouts/ZclConfiguratorLayout.vue
@@ -139,17 +139,6 @@ export default {
         this.miniState = true
       }
     },
-    getNotifications() {
-      this.$serverGet(restApi.uri.notification)
-        .then((resp) => {
-          if (resp.data[0] != undefined) {
-            this.notification = 'red'
-          }
-        })
-        .catch((err) => {
-          console.log(err)
-        })
-    },
     setSelectedEndpoint(value) {
       this.$store.dispatch('zap/updateSelectedEndpointType', {
         endpointType: this.endpointType[value],
@@ -272,12 +261,6 @@ export default {
       globalOptionsDialog: false,
       zclExtensionDialog: false,
       notification: '',
-    }
-  },
-  created() {
-    if (this.$serverGet != null) {
-      this.notification = ''
-      this.getNotifications()
     }
   },
 


### PR DESCRIPTION
When loading a ZAP file with a feature version that is higher than your currently installed ZAP, the message is incorrectly handled. This PR fixes the reference so it displays the actual error and not "undefined" as described here https://github.com/project-chip/zap/issues/995.