### PR TITLE
Add isSupported helper for Darwin.

### DIFF
--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -75,6 +75,7 @@ exports.map = {
       label: x.NAME,
       name: x.NAME,
       caption: x.DESCRIPTION,
+      description: x.DESCRIPTION,
       define: x.DEFINE,
       domainName: x.DOMAIN_NAME,
       isSingleton: dbApi.fromDbBool(x.IS_SINGLETON),


### PR DESCRIPTION
This supports marking this as "provisional", which unlike "removed" can be overridden by a later "introduced".