### PR TITLE
Adding struct item helper based on struct and cluster name

### DIFF
--- a/src-electron/generator/helper-zcl.js
+++ b/src-electron/generator/helper-zcl.js
@@ -297,6 +297,32 @@ async function zcl_struct_items_by_struct_name(name, options) {
 }
 
 /**
+ * Block helper iterating over all struct items given the struct name and
+ * cluster name.
+ *
+ * @param name
+ * @param clusterName
+ * @param options
+ * @returns Promise of content.
+ */
+async function zcl_struct_items_by_struct_and_cluster_name(
+  name,
+  clusterName,
+  options
+) {
+  let packageIds = await templateUtil.ensureZclPackageIds(this)
+  let promise = queryZcl
+    .selectAllStructItemsByStructName(
+      this.global.db,
+      name,
+      packageIds,
+      clusterName
+    )
+    .then((st) => templateUtil.collectBlocks(st, options, this))
+  return templateUtil.templatePromise(this.global, promise)
+}
+
+/**
  * Block helper iterating over all deviceTypes.
  *
  * @param {*} options
@@ -2987,3 +3013,5 @@ exports.if_compare = if_compare
 exports.if_is_data_type_signed = if_is_data_type_signed
 exports.as_zcl_data_type_size = as_zcl_data_type_size
 exports.zcl_command_responses = zcl_command_responses
+exports.zcl_struct_items_by_struct_and_cluster_name =
+  zcl_struct_items_by_struct_and_cluster_name

--- a/test/gen-matter-4.test.js
+++ b/test/gen-matter-4.test.js
@@ -257,6 +257,24 @@ test(
     expect(ept).toContain(
       'attribute GeneratedCommandList of type command_id is unsigned. The size of this attribute is: 32 bits'
     )
+
+    // Testing cluster specific structs
+    expect(ept).toContain(
+      'TargetStruct item 0 from Access Control cluster: Cluster'
+    )
+    expect(ept).toContain(
+      'TargetStruct item 1 from Access Control cluster: Endpoint'
+    )
+    expect(ept).toContain(
+      'TargetStruct item 2 from Access Control cluster: DeviceType'
+    )
+    expect(ept).toContain('TargetStruct item 0 from Binding cluster: Node')
+    expect(ept).toContain('TargetStruct item 1 from Binding cluster: Group')
+    expect(ept).toContain('TargetStruct item 2 from Binding cluster: Endpoint')
+    expect(ept).toContain('TargetStruct item 3 from Binding cluster: Cluster')
+    expect(ept).toContain(
+      'TargetStruct item 4 from Binding cluster: FabricIndex'
+    )
   },
   testUtil.timeout.long()
 )

--- a/test/gen-template/matter3/miscellaneous_helper_tests.zapt
+++ b/test/gen-template/matter3/miscellaneous_helper_tests.zapt
@@ -20,3 +20,12 @@ attribute {{name}} of type {{type}} is unsigned. The size of this attribute is: 
 
   {{/zcl_attributes_server}}
 {{/chip_client_clusters}}
+
+
+{{#zcl_struct_items_by_struct_and_cluster_name "TargetStruct" "Access Control"}}
+TargetStruct item {{index}} from Access Control cluster: {{name}}
+{{/zcl_struct_items_by_struct_and_cluster_name}}
+
+{{#zcl_struct_items_by_struct_and_cluster_name "TargetStruct" "Binding"}}
+TargetStruct item {{index}} from Binding cluster: {{name}}
+{{/zcl_struct_items_by_struct_and_cluster_name}}

--- a/zcl-builtin/matter/data-model/chip/access-control-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/access-control-cluster.xml
@@ -40,7 +40,7 @@ limitations under the License.
     <item name="Removed" value="0x02"/>
   </enum>
 
-  <struct name="Target">
+  <struct name="TargetStruct">
     <cluster code="0x001F"/>
     <item fieldId="0" name="Cluster" type="cluster_id" isNullable="true"/>
     <item fieldId="1" name="Endpoint" type="endpoint_no" isNullable="true"/>
@@ -52,7 +52,7 @@ limitations under the License.
     <item fieldId="1" name="Privilege" type="AccessControlEntryPrivilegeEnum" isFabricSensitive="true"/>
     <item fieldId="2" name="AuthMode" type="AccessControlEntryAuthModeEnum" isFabricSensitive="true"/>
     <item fieldId="3" name="Subjects" type="INT64U" isNullable="true" array="true" isFabricSensitive="true"/>
-    <item fieldId="4" name="Targets" type="Target" isNullable="true" array="true" isFabricSensitive="true"/>
+    <item fieldId="4" name="Targets" type="TargetStruct" isNullable="true" array="true" isFabricSensitive="true"/>
   </struct>
 
   <struct name="AccessControlExtensionStruct" isFabricScoped="true">


### PR DESCRIPTION
- Add zcl_struct_items_by_struct_and_cluster_name helper for retrieving struct items based on struct and cluster name in helper-zcl.js
- Updating selectAllStructItemsByStructName to handle cluster name as well
- Updating the xml for TargetStruct such that it is now present in binding and access control clusters
- Adding a test to make sure the right struct items are generated based on cluster names
- Github: ZAP#916