### PR TITLE
remove deb/rpm release distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,14 +268,6 @@
             "x64",
             "arm64"
           ]
-        },
-        {
-          "target": "deb",
-          "arch": "x64"
-        },
-        {
-          "target": "rpm",
-          "arch": "x64"
         }
       ]
     },


### PR DESCRIPTION
deb/rpm distribution is not widely use and there is no current resource dedicated in maintaining those packages. it is removed until working versions are created again.