### PR TITLE
Remove the references to zcl_config.zap from the apack.json.

### DIFF
--- a/apack.json
+++ b/apack.json
@@ -64,7 +64,7 @@
       "cmd": "$(zap-cli) generate --noUi --noServer -o ${generationOutput} --packageMatch fuzzy --zcl ${sdkRoot}/app/zcl/zcl-zap.json --zcl ${sdkRoot}/extension/matter_extension/src/app/zap-templates/zcl/zcl.json --generationTemplate ${sdkRoot}/protocol/zigbee/app/framework/gen-template/gen-templates.json --generationTemplate ${sdkRoot}/extension/matter_extension/src/app/zap-templates/app-templates.json --in ${contentFolder} --noLoadingFailure --appendGenerationSubdirectory"
     },
     "uc_upgrade": {
-      "cmd": "$(zap-cli) convert --noUi --noServer -o ${tempContentFolder}/zcl_config.zap --packageMatch fuzzy --zcl ${sdkRoot}/app/zcl/zcl-zap.json --zcl ${sdkRoot}/extension/matter_extension/src/app/zap-templates/zcl/zcl.json --generationTemplate ${sdkRoot}/protocol/zigbee/app/framework/gen-template/gen-templates.json --generationTemplate ${sdkRoot}/extension/matter_extension/src/app/zap-templates/app-templates.json --in ${tempContentFolder}/zcl_config.zap --results ${results} --noLoadingFailure --appendGenerationSubdirectory"
+      "cmd": "$(zap-cli) convert --noUi --noServer -o {name} --packageMatch fuzzy --zcl ${sdkRoot}/app/zcl/zcl-zap.json --zcl ${sdkRoot}/extension/matter_extension/src/app/zap-templates/zcl/zcl.json --generationTemplate ${sdkRoot}/protocol/zigbee/app/framework/gen-template/gen-templates.json --generationTemplate ${sdkRoot}/extension/matter_extension/src/app/zap-templates/app-templates.json --in ${tempContentFolder} --results ${results} --noLoadingFailure --appendGenerationSubdirectory"
     },
     "zapHelp": {
       "cmd": "$(zap) --help"

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -170,6 +170,15 @@ function gatherFiles(filesArg, options = { suffix: '.zap', doBlank: true }) {
   return list
 }
 
+async function noopConvert(resultsFile, logger) {
+  if (resultsFile != null) {
+    logger(`😎 No-op conversion: ${resultsFile}`)
+    return writeConversionResultsFile(resultsFile)
+  } else {
+    logger(`😎 No-op, no result, conversion.`)
+  }
+}
+
 /**
  * Perform file conversion.
  *
@@ -177,6 +186,12 @@ function gatherFiles(filesArg, options = { suffix: '.zap', doBlank: true }) {
  * @param {*} output
  */
 async function startConvert(argv, options) {
+  let noop = argv.noop === true
+
+  if (noop) {
+    return noopConvert(argv.results, options.logger)
+  }
+
   let zapFiles = argv.zapFiles
   let files = gatherFiles(zapFiles, { suffix: '.zap', doBlank: true })
   if (files.length == 0) {
@@ -257,18 +272,7 @@ async function startConvert(argv, options) {
 
   try {
     if (conversion_results != null)
-      await fsp.writeFile(
-        conversion_results,
-        YAML.stringify({
-          upgrade_results: [
-            {
-              message:
-                'Zigbee Cluster Configurator configuration has been successfully upgraded.',
-              status: 'automatic',
-            },
-          ],
-        })
-      )
+      await writeConversionResultsFile(conversion_results)
     options.logger(`    👉 write out: ${conversion_results}`)
   } catch (error) {
     options.logger(`    ⚠️  failed to write out: ${conversion_results}`)
@@ -278,6 +282,21 @@ async function startConvert(argv, options) {
   if (options.quitFunction != null) {
     options.quitFunction()
   }
+}
+
+async function writeConversionResultsFile(file) {
+  return fsp.writeFile(
+    file,
+    YAML.stringify({
+      upgrade_results: [
+        {
+          message:
+            'Zigbee Cluster Configurator configuration has been successfully upgraded.',
+          status: 'automatic',
+        },
+      ],
+    })
+  )
 }
 
 /**

--- a/src-electron/util/args.ts
+++ b/src-electron/util/args.ts
@@ -244,6 +244,11 @@ export function processCommandLineArguments(argv: string[]) {
       desc: 'Disable query caching when accessing database',
       type: 'boolean',
     })
+    .option('noop', {
+      desc: 'If this flag is present, then conversion will not do anything, while reporting success.',
+      type: 'boolean',
+      deafult: false,
+    })
     .usage('Usage: $0 <command> [options] ... [file.zap] ...')
     .version(
       `Version: ${zapVersion.version}\nFeature level: ${


### PR DESCRIPTION
There was a hard-coded reference to `zcl_config.zap` in the "zap file upgrading" entry point, because ZIgbee SDK happens to use those files. Matter was not happy.

The entry point was updated to accomodate for any name in any directory...