### PR TITLE
Swap out the ugprade action that does nothing with a genuine --noop.

### DIFF
--- a/apack.json
+++ b/apack.json
@@ -64,7 +64,7 @@
       "cmd": "$(zap-cli) generate --noUi --noServer -o ${generationOutput} --packageMatch fuzzy --zcl ${sdkRoot}/app/zcl/zcl-zap.json --zcl ${sdkRoot}/extension/matter_extension/src/app/zap-templates/zcl/zcl.json --generationTemplate ${sdkRoot}/protocol/zigbee/app/framework/gen-template/gen-templates.json --generationTemplate ${sdkRoot}/extension/matter_extension/src/app/zap-templates/app-templates.json --in ${contentFolder} --noLoadingFailure --appendGenerationSubdirectory"
     },
     "uc_upgrade": {
-      "cmd": "$(zap-cli) convert --noUi --noServer -o {name} --packageMatch fuzzy --zcl ${sdkRoot}/app/zcl/zcl-zap.json --zcl ${sdkRoot}/extension/matter_extension/src/app/zap-templates/zcl/zcl.json --generationTemplate ${sdkRoot}/protocol/zigbee/app/framework/gen-template/gen-templates.json --generationTemplate ${sdkRoot}/extension/matter_extension/src/app/zap-templates/app-templates.json --in ${tempContentFolder} --results ${results} --noLoadingFailure --appendGenerationSubdirectory"
+      "cmd": "$(zap-cli) convert  --results ${results} --noop"
     },
     "zapHelp": {
       "cmd": "$(zap) --help"


### PR DESCRIPTION
This is accomodating for a bug in a certain driving software that
wants to execute zap as a part of the upgrade, yet there is no way
to configure it in a way where you tell it "there is nothing to upgrade"
without even calling zap.

So it calls zap, and then errors with timeouts. The quick no-op
is here to essentially make that software back off quickly and move
on.

There is no changes whatsoever to actual zap functionality.