### PR TITLE
Stop relying on the input .zap file in Matter test codegen.

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src-electron/generator/matter/app/zap-templates/common/ClusterTestGeneration.js
@@ -640,6 +640,12 @@ async function chip_tests(listOrJson, options) {
   let global = this.global;
   let items;
 
+  if (options.hash.includeAllClusters) {
+    // Trigger fetch of the cluster bits before some of the iterators inside us
+    // try to do it and fail to pass includeAllClusters=true.
+    getClusters(this, /* includeAllClusters = */ true)
+  }
+
   if (Array.isArray(listOrJson)) {
     items = listOrJson;
   } else {
@@ -1036,7 +1042,7 @@ function checkIsInsideTestOnlyClusterBlock(conditions, name) {
  * @param {*} options
  */
 async function chip_tests_only_clusters(options) {
-  const clusters = await getClusters(this);
+  const clusters = await getClusters(this, options.hash.includeAllClusters);
   const testOnlyClusters = clusters.filter((cluster) =>
     isTestOnlyCluster(cluster.name)
   );

--- a/src-electron/generator/matter/app/zap-templates/common/ClustersHelper.js
+++ b/src-electron/generator/matter/app/zap-templates/common/ClustersHelper.js
@@ -789,7 +789,7 @@ Clusters._computeUsedStructureNames = async function (structs) {
  * If includeAll is true, all events/commands/attributes will be included, not
  * just the ones enabled in the ZAP configuration.
  */
-Clusters.init = async function (context, includeAll) {
+Clusters.init = async function (context, includeAllClusterConstructs, includeAllClusters) {
   try {
     if (this.ready.running) {
       return this.ready;
@@ -813,17 +813,17 @@ Clusters.init = async function (context, includeAll) {
     const promises = [
       Promise.all(loadTypes),
       loadEndpoints.call(context),
-      // For now just always use loadClusters, because we have a bunch of things
-      // defined in our XML that are not actually part of Matter.
-      loadClusters.call(context),
-      includeAll
+      includeAllClusters
+        ? loadAllClusters.call(context, packageIds)
+        : loadClusters.call(context),
+      includeAllClusterConstructs
         ? loadAllCommands.call(context, packageIds)
         : loadCommands.call(context, packageIds),
-      includeAll
+      includeAllClusterConstructs
         ? loadAllAttributes.call(context, packageIds)
         : loadAttributes.call(context),
       loadGlobalAttributes.call(context, packageIds),
-      (includeAll ? loadAllEvents : loadEvents).call(context, packageIds),
+      (includeAllClusterConstructs ? loadAllEvents : loadEvents).call(context, packageIds),
     ];
 
     let [
@@ -865,12 +865,12 @@ function asBlocks(promise, options) {
   );
 }
 
-function ensureClusters(context, includeAll = false) {
+function ensureClusters(context, includeAllClusterConstructs = false, includeAllClusters = false) {
   // Kick off Clusters initialization.  This is async, but that's fine: all the
   // getters on Clusters wait on that initialziation to complete.
   ensureState(context, "Don't have a context");
 
-  Clusters.init(context, includeAll);
+  Clusters.init(context, includeAllClusterConstructs, includeAllClusters);
   return Clusters;
 }
 

--- a/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
+++ b/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
@@ -63,8 +63,8 @@ function getSimulatedCluster(clusterName) {
   return SimulatedClusters.find((cluster) => cluster.name == clusterName);
 }
 
-function getClusters(context) {
-  return ensureClusters(context, true)
+function getClusters(context, includeAllClusters = false) {
+  return ensureClusters(context, true, includeAllClusters)
     .getClusters()
     .then((clusters) => clusters.concat(SimulatedClusters).flat(1));
 }


### PR DESCRIPTION
To keep backwards compat with old Matter revisions, we require explicit includeAllClusters=true in the templates to get the new behavior.