### PR TITLE
Fix button state issue in attribute reporting page

### DIFF
--- a/src/components/ZclAttributeReportingManager.vue
+++ b/src/components/ZclAttributeReportingManager.vue
@@ -247,6 +247,9 @@ export default {
       },
     },
   },
+  created() {
+    this.updateSelectedReporting()
+  },
   data() {
     return {
       pagination: {
@@ -331,6 +334,7 @@ export default {
           field: 'reportable',
         },
       ],
+      initialization: true,
     }
   },
   methods: {
@@ -407,6 +411,16 @@ export default {
       }
       return data
     },
+    updateSelectedReporting() {
+      this.attributeData.forEach((attribute) => {
+        if(attribute.reportingPolicy == "mandatory" || attribute.reportingPolicy == "suggested") {
+          let hashValue = this.hashAttributeIdClusterId(attribute.id, this.selectedCluster.id)
+          if(!this.selectedReporting.includes(hashValue)) {
+            this.selectedReporting.push(hashValue)
+          }
+        }
+      })
+    }
   },
 }
 </script>


### PR DESCRIPTION
Fix issue #996 
The issue is about when initializing the attribute reporting page, some attributes should have their enabled button turned on, but they are actually turned off.
After the fix, if an attribute has mandatory or suggested reporting policy, then its radio button will be turned on automatically when the page is initialized.