### PR TITLE
Fix Windows file save bug & menu bug

### DIFF
--- a/src-electron/ui/menu.js
+++ b/src-electron/ui/menu.js
@@ -292,6 +292,9 @@ function doSaveAs(browserWindow) {
     })
     .then((result) => {
       if (!result.canceled) {
+        if (process.platform == 'win32') {
+          result.filePath = result.filePath.replace(/\\/g, '\\\\')
+        }
         fileSave(browserWindow, result.filePath)
         return result.filePath
       } else {

--- a/src-electron/ui/window.ts
+++ b/src-electron/ui/window.ts
@@ -114,7 +114,7 @@ export function windowCreate(port: number, args?: WindowCreateArgs) {
     title: args?.filePath == null ? menu.newConfiguration : args?.filePath,
     useContentSize: true,
     webPreferences: webPreferences,
-    titleBarStyle: 'hidden',
+    titleBarStyle: process.platform === 'win32' ? 'default' : 'hidden',
     trafficLightPosition: { x: 15, y: 20 },
     titleBarOverlay: {
       color: '#F4F4F4',


### PR DESCRIPTION
After fixing, Windows users can save ZAP projects properly to a local file and see the menu bar at the top of ZAP when do `npm run zap`.
Fix issue #764