### PR TITLE
Add NS_SWIFT_UNAVAILABLE annotations to Darwin availability bits.

### DIFF
--- a/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
+++ b/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
@@ -746,12 +746,24 @@ async function availability(clusterName, options) {
     }
   }
 
+  let swiftUnavailableRelease = findReleaseForPath(
+    data,
+    ['swiftUnavailable', ...path],
+    options
+  );
+  let swiftUnavailable;
+  if (swiftUnavailableRelease == undefined) {
+    swiftUnavailable = '';
+  } else {
+    swiftUnavailable = ` NS_SWIFT_UNAVAILABLE("${options.hash.deprecationMessage}")`;
+  }
+
   let availabilityStrings = Object.entries(introducedVersions).map(
     ([os, version]) => `${os}(${version}, ${deprecatedVersions[os]})`
   );
   return `MTR_DEPRECATED("${
     options.hash.deprecationMessage
-  }", ${availabilityStrings.join(', ')})`;
+  }", ${availabilityStrings.join(', ')})${swiftUnavailable}`;
 }
 
 /**


### PR DESCRIPTION
This lets us add a "swiftUnavailable" section to the availability YAML to annotate deprecated things that should be marked NS_SWIFT_UNAVAILABLE.