### PR TITLE
Fix replace bug of asCleanSymbol in addon-helper

### DIFF
--- a/test/gen-template/dotdot/addon-helper.js
+++ b/test/gen-template/dotdot/addon-helper.js
@@ -195,8 +195,7 @@ function isSubstringInString(sub_string, string) {
 
 function asCleanSymbol(label) {
   let l = label.trim()
-  l = l.replace(' ', '_')
-  l = l.replace(' ', '_')
+  l = l.replace(/ /g, '_')
   l = l.replace(/[:/-]/g, '_')
   l = l.replace(/__+/g, '_').toLowerCase()
   return l


### PR DESCRIPTION
The `asCleanSymbol` function in the `addon-helper.js` file has a problem in that only up to 2 spaces can be replaced with underscores.

- `asSnakeCaseLower('Week Day Access Schedules')` -> `'week_day_access _schedules'`

This change modifies the `asCleanSymbol` function to replace all spaces with underscores.

- `asSnakeCaseLower('Week Day Access Schedules')` -> `'week_day_access_schedules'`