### PR TITLE
Fix old zap file imports for device types

### DIFF
--- a/src-electron/db/query-impexp.js
+++ b/src-electron/db/query-impexp.js
@@ -231,12 +231,14 @@ async function importEndpointType(db, sessionId, packageIds, endpointType) {
   } else {
     deviceTypes = [
       {
-        name: endpointType.deviceTypeName
-          ? endpointType.deviceTypeName
-          : endpointType.name, // Else case for backwards compatibility of old zap files
-        code: endpointType.deviceTypeCode
-          ? endpointType.deviceTypeCode
-          : endpointType.deviceIdentifier, // Else case for backwards compatibility of old zap files
+        name:
+          endpointType.deviceTypeName != null
+            ? endpointType.deviceTypeName
+            : endpointType.name, // Else case for backwards compatibility of old zap files
+        code:
+          endpointType.deviceTypeCode != null
+            ? endpointType.deviceTypeCode
+            : endpointType.deviceIdentifier, // Else case for backwards compatibility of old zap files
         profileId: endpointType.deviceTypeProfileId,
       },
     ]

--- a/src-electron/db/query-impexp.js
+++ b/src-electron/db/query-impexp.js
@@ -231,8 +231,12 @@ async function importEndpointType(db, sessionId, packageIds, endpointType) {
   } else {
     deviceTypes = [
       {
-        name: endpointType.deviceTypeName,
-        code: endpointType.deviceTypeCode,
+        name: endpointType.deviceTypeName
+          ? endpointType.deviceTypeName
+          : endpointType.name, // Else case for backwards compatibility of old zap files
+        code: endpointType.deviceTypeCode
+          ? endpointType.deviceTypeCode
+          : endpointType.deviceIdentifier, // Else case for backwards compatibility of old zap files
         profileId: endpointType.deviceTypeProfileId,
       },
     ]


### PR DESCRIPTION
populating device code and device name correctly when importing from old .zap files

Github: ZAP#862