### PR TITLE
Fix non-determinism in the .zap file for endpointType and device type ids

### DIFF
--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -382,6 +382,16 @@ exports.map = {
     }
   },
 
+  deviceTypeExport: (x) => {
+    if (x == null) return undefined
+    return {
+      code: x.CODE,
+      profileId: x.PROFILE_ID,
+      label: x.NAME,
+      name: x.NAME,
+    }
+  },
+
   deviceTypeCluster: (x) => {
     if (x == null) return undefined
     return {
@@ -440,6 +450,16 @@ exports.map = {
       id: x.ENDPOINT_TYPE_ID,
       endpointTypeId: x.ENDPOINT_TYPE_ID,
       sessionRef: x.SESSION_REF,
+      name: x.NAME,
+      deviceTypeRef: x.DEVICE_TYPE_REF,
+      deviceTypes: x.deviceTypes, // Populated outside the sql query mapping.
+    }
+  },
+  endpointTypeExport: (x) => {
+    if (x == null) return undefined
+    return {
+      id: x.ENDPOINT_TYPE_INDEX, // Index of endpoint type from list of endpoints types based on endpoint identifier
+      endpointTypeId: x.ENDPOINT_TYPE_ID,
       name: x.NAME,
       deviceTypeRef: x.DEVICE_TYPE_REF,
       deviceTypes: x.deviceTypes, // Populated outside the sql query mapping.
@@ -698,7 +718,7 @@ exports.map = {
       severity: x.NOTICE_SEVERITY,
       id: x.NOTICE_ID,
     }
-  }
+  },
 }
 
 exports.reverseMap = {

--- a/src-electron/db/query-impexp.js
+++ b/src-electron/db/query-impexp.js
@@ -124,7 +124,8 @@ async function exportEndpointTypes(db, sessionId) {
       `
 SELECT
   ENDPOINT_TYPE.ENDPOINT_TYPE_ID,
-  ENDPOINT_TYPE.NAME
+  ENDPOINT_TYPE.NAME,
+  ROW_NUMBER() OVER(ORDER BY ENDPOINT.ENDPOINT_IDENTIFIER) AS ENDPOINT_TYPE_INDEX
 FROM
   ENDPOINT_TYPE
 LEFT JOIN
@@ -138,7 +139,7 @@ ORDER BY
   ENDPOINT_TYPE.NAME`,
       [sessionId]
     )
-    .then((rows) => rows.map(dbMapping.map.endpointType))
+    .then((rows) => rows.map(dbMapping.map.endpointTypeExport))
 
   //Associate each endpoint type to the device types
   for (let i = 0; i < endpointTypes.length; i++) {
@@ -172,10 +173,9 @@ ORDER BY
     )
 
     // Updating the device type info for the endpoint
-    endpointTypes[i].deviceTypeRefs = rows.map((x) => x.DEVICE_TYPE_ID)
     endpointTypes[i].deviceVersions = rows.map((x) => x.DEVICE_VERSION)
     endpointTypes[i].deviceIdentifiers = rows.map((x) => x.CODE)
-    endpointTypes[i].deviceTypes = rows.map(dbMapping.map.deviceType)
+    endpointTypes[i].deviceTypes = rows.map(dbMapping.map.deviceTypeExport)
 
     // Loading endpointTypeRef as primary endpointType for backwards compatibility
     endpointTypes[i].deviceTypeRef = endpointTypes[i].deviceTypes[0]


### PR DESCRIPTION
Fixing the non-determinism of endpoint type refs and device type refs in the .zap files by removing it for device type refs and using the index for endpoint type id instead of the primary keys of their corresponding tables since they are non deterministic