### PR TITLE
Creating a .zap file format with just enabled content

### DIFF
--- a/src-electron/importexport/export.js
+++ b/src-electron/importexport/export.js
@@ -28,6 +28,7 @@ const querySession = require('../db/query-session.js')
 const queryImpExp = require('../db/query-impexp.js')
 const dbEnum = require('../../src-shared/db-enum.js')
 const ff = require('./file-format')
+const ffenabledOnly = require('./enabled-only-file-format')
 
 async function exportEndpointType(db, endpointType) {
   let data = await queryImpExp.exportClustersFromEndpointType(
@@ -173,7 +174,11 @@ async function exportDataIntoFile(
       (x) => x.key != dbEnum.sessionKey.ideProjectPath
     )
   }
-  state = ff.convertToFile(state)
+  if (state.fileFormat === 1) {
+    state = ff.convertToFile(state)
+  } else {
+    state = ffenabledOnly.convertToFile(state)
+  }
 
   if (options.removeLog) delete state.log
 

--- a/src-electron/importexport/import.js
+++ b/src-electron/importexport/import.js
@@ -28,6 +28,7 @@ const env = require('../util/env')
 const script = require('../util/script')
 const dbEnum = require('../../src-shared/db-enum')
 const ff = require('./file-format.js')
+const ffenabledOnly = require('./enabled-only-file-format')
 const util = require('../util/util.js')
 
 /**
@@ -90,7 +91,12 @@ async function importDataFromFile(
   }
 ) {
   let state = await readDataFromFile(filePath, options.defaultZclMetafile)
-  state = ff.convertFromFile(state)
+  if (state.fileFormat === 1) {
+    state = ff.convertFromFile(state)
+  } else {
+    state = ffenabledOnly.convertFromFile(state)
+  }
+
   try {
     await dbApi.dbBeginTransaction(db)
     let sid
@@ -102,8 +108,10 @@ async function importDataFromFile(
         {
           zcl: env.builtinSilabsZclMetafile(),
           template: env.builtinTemplateMetafile(),
-        }, null, null
-      )  
+        },
+        null,
+        null
+      )
     } else {
       sid = options.sessionId
     }

--- a/src-electron/util/env.ts
+++ b/src-electron/util/env.ts
@@ -23,7 +23,7 @@ const zapBaseUrl = 'http://localhost:'
 
 import { VersionType, ErrorType } from '../types/env-types'
 
-let saveFileFormat = 0
+let saveFileFormat = 2
 
 export function setSaveFileFormat(n: number) {
   saveFileFormat = n


### PR DESCRIPTION
- creating enabled-only-file-format.js for the purpose of saving .zap file with just enabled content
- aLso making sure that the content is easy to read and editable on an editor instead of just the UI
- The file format for saving with enabled only content is 2
- JIRA: ZAPP-1113