### PR TITLE
Fix accessor signatures for string/octstr attributes.

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/common/attributes/Accessors.js
+++ b/src-electron/generator/matter/app/zap-templates/common/attributes/Accessors.js
@@ -52,10 +52,13 @@ function canHaveSimpleAccessors(attr) {
 async function accessorGetterType(attr) {
   let type;
   let mayNeedPointer = false;
+  let mayNeedReference = false;
   if (StringHelper.isCharString(attr.type)) {
     type = 'chip::MutableCharSpan';
+    mayNeedReference = true;
   } else if (StringHelper.isOctetString(attr.type)) {
     type = 'chip::MutableByteSpan';
+    mayNeedReference = true;
   } else {
     mayNeedPointer = true;
     const options = {
@@ -76,6 +79,8 @@ async function accessorGetterType(attr) {
     type = `DataModel::Nullable<${type}> &`;
   } else if (mayNeedPointer) {
     type = `${type} *`;
+  } else if (mayNeedReference) {
+    type = `${type} &`;
   }
 
   return type;

--- a/src-electron/generator/matter/app/zap-templates/common/attributes/Accessors.js
+++ b/src-electron/generator/matter/app/zap-templates/common/attributes/Accessors.js
@@ -52,13 +52,10 @@ function canHaveSimpleAccessors(attr) {
 async function accessorGetterType(attr) {
   let type;
   let mayNeedPointer = false;
-  let mayNeedReference = false;
   if (StringHelper.isCharString(attr.type)) {
     type = 'chip::MutableCharSpan';
-    mayNeedReference = true;
   } else if (StringHelper.isOctetString(attr.type)) {
     type = 'chip::MutableByteSpan';
-    mayNeedReference = true;
   } else {
     mayNeedPointer = true;
     const options = {
@@ -79,7 +76,7 @@ async function accessorGetterType(attr) {
     type = `DataModel::Nullable<${type}> &`;
   } else if (mayNeedPointer) {
     type = `${type} *`;
-  } else if (mayNeedReference) {
+  } else {
     type = `${type} &`;
   }
 


### PR DESCRIPTION
See https://github.com/project-chip/connectedhomeip/issues/28357: we are not mutating the actual value the caller will observe.

Note: This is expected to change Matter codegen.  The previous codegen was broken.