### PR TITLE
Output MTR_AVAILABLE, not API_AVAILABLE for Darwin codegen.

### DIFF
--- a/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
+++ b/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
@@ -704,7 +704,7 @@ async function availability(clusterName, options) {
     let availabilityStrings = Object.entries(introducedVersions).map(
       ([os, version]) => `${os}(${version})`
     );
-    return `API_AVAILABLE(${availabilityStrings.join(', ')})`;
+    return `MTR_AVAILABLE(${availabilityStrings.join(', ')})`;
   }
 
   if (!options.hash.deprecationMessage) {
@@ -719,7 +719,7 @@ async function availability(clusterName, options) {
     let availabilityStrings = Object.entries(introducedVersions).map(
       ([os, version]) => `${os}(${version})`
     );
-    return `API_AVAILABLE(${availabilityStrings.join(
+    return `MTR_AVAILABLE(${availabilityStrings.join(
       ', '
     )})\nMTR_NEWLY_DEPRECATED("${options.hash.deprecationMessage}")`;
   }


### PR DESCRIPTION
This lets us control exactly what things expand to via our defines header.