### PR TITLE
Fix error-handling for unknown type in asObjectiveCNumberType.

### DIFF
--- a/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
+++ b/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
@@ -110,14 +110,15 @@ function asObjectiveCNumberType(label, type, asLowerCased) {
             return 'Float';
           case 'double':
             return 'Double';
-          default:
-            error =
+          default: {
+            let error =
               label +
               ': Unhandled underlying type ' +
               zclType +
               ' for original type ' +
               type;
             throw error;
+          }
         }
       })
       .then((typeName) =>


### PR DESCRIPTION
We were not declaring "error", so ended up throwing an "undeclared variable" exception, not the actual exception we were trying to throw.