### PR TITLE
create mac arch64 package.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,6 +421,12 @@ jobs:
         with:
           name: zap-mac-x64-zip
           path: dist/zap-mac-x64.zip
+      - name: Archive macOS arm64 .zip file
+        uses: actions/upload-artifact@v3
+        if: startsWith(matrix.os, 'macos')
+        with:
+          name: zap-mac-arm64-zip
+          path: dist/zap-mac-arm64.zip
       - name: Archive Linux (x64) .zip file
         uses: actions/upload-artifact@v3
         if: startsWith(matrix.os, 'ubuntu')
@@ -460,4 +466,4 @@ jobs:
         with:
           generateReleaseNotes: true
           prerelease: ${{ endsWith(github.ref, 'nightly') }}
-          artifacts: 'zap-linux-x64-deb/zap-linux-x64.deb, zap-linux-x64-rpm/zap-linux-x64.rpm, zap-linux-x64-zip/zap-linux-x64.zip, zap-linux-arm64-zip/zap-linux-arm64.zip, zap-mac-x64-zip/zap-mac-x64.zip, zap-win-x64-zip/zap-win-x64.zip, zap-win-arm64-zip/zap-win-arm64.zip'
+          artifacts: 'zap-linux-x64-deb/zap-linux-x64.deb, zap-linux-x64-rpm/zap-linux-x64.rpm, zap-linux-x64-zip/zap-linux-x64.zip, zap-linux-arm64-zip/zap-linux-arm64.zip, zap-mac-x64-zip/zap-mac-x64.zip, zap-mac-arm64-zip/zap-mac-arm64.zip, zap-win-x64-zip/zap-win-x64.zip, zap-win-arm64-zip/zap-win-arm64.zip'

--- a/src-script/pack-cli.js
+++ b/src-script/pack-cli.js
@@ -34,6 +34,11 @@ async function main() {
     await rename(`${file}`, cli)
     await addToZip(`zap-mac-x64.zip`, cli)
 
+    // NOTE: `pkg` build tool does not officially support building for mac arch64 yet.
+    //       until official support is out, x86 version will be packaged as
+    //       Apple Rosetta will kick in.
+    await addToZip(`zap-mac-arm64.zip`, cli)
+
     // NOTE: pkg support for macos-arm64 is experimental
     // await rename(`${file}-arm64`, cli)
     // await addToZip(`${file}-arm64.zip`, cli)


### PR DESCRIPTION
NOTE: for zap-cli binary, the mac x86 binary is used for the arch64 package
      as a workaround since pkg, the build tool, does not official support for mac-arch64 yet.