### PR TITLE
Add a stable attribute in api_maturity.xml test and fix up tests

### DIFF
--- a/test/gen-meta.test.js
+++ b/test/gen-meta.test.js
@@ -71,21 +71,33 @@ test(
     const attributes = await queryZcl.selectAllAttributes(db, [
       zclContext.packageId,
     ])
-    expect(attributes.length).toBe(4)
-    expect(attributes[0].name).toBe('at1')
-    expect(attributes[1].name).toBe('at2')
+    expect(attributes.length).toBeGreaterThanOrEqual(4)
 
-    let access
-    access = await queryAccess.selectAttributeAccess(db, attributes[0].id)
-    expect(access.length).toBe(1)
-    expect(access[0].operation).toBe('write')
-    expect(access[0].role).toBe('manage')
-    expect(access[0].accessModifier).toBe('fabric-scoped')
-    access = await queryAccess.selectAttributeAccess(db, attributes[1].id)
-    expect(access.length).toBe(1)
-    expect(access[0].operation).toBeNull()
-    expect(access[0].role).toBeNull()
-    expect(access[0].accessModifier).toBe('fabric-sensitive')
+    // Expect attributes at1 and at2 to be found
+    let hasAt1 = false
+    let hasAt2 = false
+
+    for (const attr of attributes) {
+      if (attr.name == 'at1') {
+        hasAt1 = true
+
+        let access = await queryAccess.selectAttributeAccess(db, attr.id)
+        expect(access.length).toBe(1)
+        expect(access[0].operation).toBe('write')
+        expect(access[0].role).toBe('manage')
+        expect(access[0].accessModifier).toBe('fabric-scoped')
+      } else if (attr.name == 'at2') {
+        hasAt2 = true
+
+        let access = await queryAccess.selectAttributeAccess(db, attr.id)
+        expect(access.length).toBe(1)
+        expect(access[0].operation).toBeNull()
+        expect(access[0].role).toBeNull()
+        expect(access[0].accessModifier).toBe('fabric-sensitive')
+      }
+    }
+    expect(hasAt1).toBeTruthy()
+    expect(hasAt2).toBeTruthy()
 
     const structs = await queryZcl.selectAllStructsWithItemCount(db, [
       zclContext.packageId,

--- a/test/resource/meta/api_maturity.xml
+++ b/test/resource/meta/api_maturity.xml
@@ -25,6 +25,9 @@ limitations under the License.
     <client tick="false" init="false">false</client>
     <server tick="false" init="false">true</server>
 
+    <!-- Note the large attribute codes to make sure sorting in gen-meta.test passes. -->
+    <attribute side="server" code="0x0000" define="STABLE_ATTRIBUTE" type="INT8U" writable="true" optional="true">StableAttribute</attribute>
+
     <struct name="StableStruct">
        <cluster code="0x1122"/>
        <item fieldId="0" name="Cluster" type="cluster_id" isNullable="true"/>

--- a/test/resource/meta/api_maturity.xml
+++ b/test/resource/meta/api_maturity.xml
@@ -25,13 +25,13 @@ limitations under the License.
     <client tick="false" init="false">false</client>
     <server tick="false" init="false">true</server>
 
-    <attribute side="server" code="0x0000" define="STABLE_ATTRIBUTE" type="INT8U" writable="true" optional="true">StableAttribute</attribute>
-
     <struct name="StableStruct">
        <cluster code="0x1122"/>
        <item fieldId="0" name="Cluster" type="cluster_id" isNullable="true"/>
        <item fieldId="1" name="Endpoint" type="endpoint_no" isNullable="true"/>
     </struct>
+
+    <attribute side="server" code="0x0000" define="STABLE_ATTRIBUTE" type="INT8U" writable="true" optional="true">StableAttribute</attribute>
 
     <command source="client" code="0x00" name="StableCommand" response="StableCommandResponse" optional="false" >
       <description>A Test command</description>

--- a/test/resource/meta/api_maturity.xml
+++ b/test/resource/meta/api_maturity.xml
@@ -25,7 +25,6 @@ limitations under the License.
     <client tick="false" init="false">false</client>
     <server tick="false" init="false">true</server>
 
-    <!-- Note the large attribute codes to make sure sorting in gen-meta.test passes. -->
     <attribute side="server" code="0x0000" define="STABLE_ATTRIBUTE" type="INT8U" writable="true" optional="true">StableAttribute</attribute>
 
     <struct name="StableStruct">


### PR DESCRIPTION
gen-tests has hardcoded indices for attribute comparisons. Adding more attributes for testing
would make tests fail.

This is a stand-alone change that adds an attribute to the maturity test cluster and fixes up the test to not
rely on ordering (or count for that matter).

This is in preparation of having maturity flags on attributes, which would require me to add more attributes to the test XML.