### PR TITLE
add mrpActiveThreshold value and ICDOperatesAsLit to the simulated Di…

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/clusters/DiscoveryCommands.js
+++ b/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/clusters/DiscoveryCommands.js
@@ -76,7 +76,7 @@ const kDefaultResponse = {
       isOptional: true,
     }, //
     {
-      name: 'ICDOperatesAsLIT',
+      name: 'isICDOperatingAsLIT',
       type: 'BOOLEAN',
       chipType: 'bool',
       isOptional: true,

--- a/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/clusters/DiscoveryCommands.js
+++ b/src-electron/generator/matter/app/zap-templates/common/simulated-clusters/clusters/DiscoveryCommands.js
@@ -69,6 +69,18 @@ const kDefaultResponse = {
       chipType: 'uint32_t',
       isOptional: true,
     }, //
+    {
+      name: 'mrpRetryActiveThreshold',
+      type: 'INT16U',
+      chipType: 'uint16_t',
+      isOptional: true,
+    }, //
+    {
+      name: 'ICDOperatesAsLIT',
+      type: 'BOOLEAN',
+      chipType: 'bool',
+      isOptional: true,
+    }, //
   ],
 };
 


### PR DESCRIPTION
…scoveryCommandResponse

Tested locally with `$ZAP_DEVELOPMENT_PATh,` regen matter and test app (build with `./scripts/examples/gn_build_test_example.sh app1`).

The new variables are generated and usable in the simulated test app.