### PR TITLE
Add temp-state for zigbee GSDK regen.

### DIFF
--- a/src-script/gsdk-public-regen.js
+++ b/src-script/gsdk-public-regen.js
@@ -79,6 +79,7 @@ async function run(argv) {
     '--unhandled-rejections=strict',
   ]
 
+  cmdArgs.push('--tempState')
   cmdArgs.push('-o')
   cmdArgs.push(outputDir + '/{index}/')
   cmdArgs.push('--gen')


### PR DESCRIPTION
Some latest changes have removed the forced deletion of the DB file during regen.
At the same time, I notice an uptick in zigbee token regen instability.

Assuming things are related, I'm adding --tempState to gsdk regen.
