### PR TITLE
Fix zapTypeToClusterObjectType to have correct output for acronyms.

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
@@ -676,7 +676,7 @@ async function zapTypeToClusterObjectType(type, isDecodable, options) {
       if (s) {
         return 'uint' + s[1] + '_t';
       }
-      return ns + type;
+      return ns + asUpperCamelCase.call(this, type, options);
     }
 
     if (types.isBitmap) {
@@ -685,7 +685,9 @@ async function zapTypeToClusterObjectType(type, isDecodable, options) {
       if (s) {
         return 'uint' + s[1] + '_t';
       }
-      return 'chip::BitMask<' + ns + type + '>';
+      return (
+        'chip::BitMask<' + ns + asUpperCamelCase.call(this, type, options) + '>'
+      );
     }
 
     if (types.isStruct) {
@@ -693,7 +695,7 @@ async function zapTypeToClusterObjectType(type, isDecodable, options) {
       return (
         ns +
         'Structs::' +
-        type +
+        asUpperCamelCase.call(this, type, options) +
         '::' +
         (isDecodable ? 'DecodableType' : 'Type')
       );
@@ -702,7 +704,11 @@ async function zapTypeToClusterObjectType(type, isDecodable, options) {
     if (types.isEvent) {
       passByReference = true;
       return (
-        ns + 'Events::' + type + '::' + (isDecodable ? 'DecodableType' : 'Type')
+        ns +
+        'Events::' +
+        asUpperCamelCase.call(this, type, options) +
+        '::' +
+        (isDecodable ? 'DecodableType' : 'Type')
       );
     }
 


### PR DESCRIPTION
zapTypeToClusterObjectType needs to be consistent with the actual types we generate for cluster objects, and it was producing different output for a struct (or event) which had an all-caps name.