### PR TITLE
Add new energy management built in types (power-mW, voltage-MV, amperage-mA, energy-mWh) to ZAP 

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/common/override.js
+++ b/src-electron/generator/matter/app/zap-templates/common/override.js
@@ -75,6 +75,11 @@ function atomicType(arg) {
       return 'chip::Percent';
     case 'percent100ths':
       return 'chip::Percent100ths';
+    case 'power_mW':
+    case 'amperage_mA':
+    case 'voltage_mV':
+    case 'energy_mWh':
+      return 'int64_t';
     case 'epoch_us':
       return 'uint64_t';
     case 'epoch_s':

--- a/zcl-builtin/matter/data-model/chip/chip-types.xml
+++ b/zcl-builtin/matter/data-model/chip/chip-types.xml
@@ -51,6 +51,10 @@ limitations under the License.
     <!-- Derived Data Types -->
     <type id="0x42" description="Character String"         name="char_string"                 composite="true"/>
     <type id="0x44" description="Long Character String"    name="long_char_string"            composite="true"/>
+    <type id="0xD9" description="Power milliwatts"         name="power_mW"          size="8"  analog="true"   />
+    <type id="0xDA" description="Amperage milliamps"       name="amperage_mA"       size="8"  analog="true"   />
+    <type id="0xDB" description="Voltage millivolts"       name="voltage_mV"        size="8"  analog="true"   />
+    <type id="0xDC" description="Energy milliwatt-hours"   name="energy_mWh"        size="8"  analog="true"   />
     <type id="0xE0" description="Time of day"              name="tod"               size="4"  analog="true"   />
     <type id="0xE1" description="Date"                     name="date"              size="4"  analog="true"   />
     <type id="0xE3" description="Epoch Microseconds"       name="epoch_us"          size="8"  analog="true"   />


### PR DESCRIPTION
Fixes #1219 Add new energy management built in types.

Not sure how the additional test code works, so I haven't touched that.