### PR TITLE
Allow the ZAP UI to load when a custom xml file is not found instead of throwing an error

### DIFF
--- a/src-electron/db/query-package-notification.js
+++ b/src-electron/db/query-package-notification.js
@@ -29,16 +29,10 @@ const dbMapping = require('./db-mapping.js')
  * @param {*} db
  * @param {*} type
  * @param {*} status
- * @param {*} sessionId
+ * @param {*} packageId
  * @param {*} severity
  */
-async function setNotification(
-  db,
-  type,
-  status,
-  packageId,
-  severity = 2,
-) {
+async function setNotification(db, type, status, packageId, severity = 2) {
   return dbApi.dbUpdate(
     db,
     'INSERT INTO PACKAGE_NOTICE ( PACKAGE_REF, NOTICE_TYPE, NOTICE_MESSAGE, NOTICE_SEVERITY) VALUES ( ?, ?, ?, ? )',
@@ -72,8 +66,8 @@ async function getNotificationBySessionId(db, sessionId) {
   let rows = []
   rows = await dbApi.dbAll(
     db,
-    'SELECT * FROM PACKAGE_NOTICE WHERE PACKAGE_REF IN' 
-    + '( SELECT PACKAGE_REF FROM SESSION_PACKAGE WHERE SESSION_REF = ( ? ) )',
+    'SELECT * FROM PACKAGE_NOTICE WHERE PACKAGE_REF IN' +
+      '( SELECT PACKAGE_REF FROM SESSION_PACKAGE WHERE SESSION_REF = ( ? ) )',
     [sessionId]
   )
   return rows.map(dbMapping.map.packageNotification)
@@ -86,10 +80,7 @@ async function getNotificationBySessionId(db, sessionId) {
  */
 async function getAllNotification(db) {
   let rows = []
-  rows = await dbApi.dbAll(
-    db,
-    'SELECT * FROM PACKAGE_NOTICE'
-  )
+  rows = await dbApi.dbAll(db, 'SELECT * FROM PACKAGE_NOTICE')
   return rows.map(dbMapping.map.packageNotification)
 }
 /**
@@ -108,7 +99,6 @@ async function getNotificationByPackageId(db, packageId) {
   )
   return rows.map(dbMapping.map.packageNotification)
 }
-
 
 // exports
 exports.setNotification = setNotification

--- a/src-electron/importexport/import-json.js
+++ b/src-electron/importexport/import-json.js
@@ -136,7 +136,8 @@ async function importSinglePackage(db, pkg, zapFilePath, packageMatch) {
       env.logDebug(`No packages of type ${pkg.type} found in the database.`)
       return null
     } else {
-      throw new Error(`No packages of type ${pkg.type} found in the database.`)
+      env.logError(`No packages of type ${pkg.type} found in the database.`)
+      return null
     }
   } else if (packages.length == 1) {
     env.logDebug(

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -2220,7 +2220,7 @@ async function loadIndividualSilabsFile(db, filePath, sessionId) {
     querySessionNotification.setNotification(
       db,
       'ERROR',
-      `Error reading xml file: ${filePath}\n` + err.message,
+      `Error reading xml file: ${filePath}, Error Message: ` + err.message,
       sessionId,
       1,
       0


### PR DESCRIPTION
- The changes to import-json.js allows the ZAP UI to load instead of throwing an error and locking ZAP.
- Now the error message appears in the ZAP notification's pane so that the user can see a detailed error and act upon it
- Minor cleanup
- JIRA: ZAPP-1148