### PR TITLE
If log is empty, do not write it out into the zap file.

### DIFF
--- a/src-electron/importexport/export.js
+++ b/src-electron/importexport/export.js
@@ -175,7 +175,11 @@ async function exportDataIntoFile(
   }
   state = ff.convertToFile(state)
 
-  if (options.removeLog) delete state.log
+  if (options.removeLog) {
+    delete state.log
+  } else if (state.log != null && state.log.length == 0) {
+    delete state.log
+  }
 
   if (fs.existsSync(filePath)) {
     fs.copyFileSync(filePath, filePath + '~')


### PR DESCRIPTION
Zap mistakenly output `"log": []` into the zap output if log was empty. It is no longer doing that.