### PR TITLE
disabing default if storage is manually changed to external

### DIFF
--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -189,7 +189,7 @@ limitations under the License.
                   : ''
               "
               :disable="
-                isDisabled(
+                isDisabledDefault(
                   props.row.id,
                   props.row.label,
                   selectedCluster.id,
@@ -275,6 +275,17 @@ export default {
       } else {
         return false
       }
+    },
+    isDisabledDefault(id, name, selectedClusterId, selectedCluster) {
+      return (
+        !this.selection.includes(
+          this.hashAttributeIdClusterId(id, selectedClusterId)
+        ) ||
+        this.checkForcedExternal(name) ||
+        this.selectionStorageOption[
+          this.hashAttributeIdClusterId(id, selectedClusterId)
+        ] == 'External'
+      )
     },
     isDisabled(id, name, selectedClusterId, selectedCluster) {
       return (

--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -197,9 +197,12 @@ limitations under the License.
                 )
               "
               :model-value="
-                selectionDefault[
-                  hashAttributeIdClusterId(props.row.id, selectedCluster.id)
-                ]
+                defaultValueCheck(
+                  props.row.id,
+                  props.row.label,
+                  selectedCluster.id,
+                  selectedCluster.label
+                )
               "
               :error="
                 !isDefaultValueValid(
@@ -276,7 +279,7 @@ export default {
         return false
       }
     },
-    isDisabledDefault(id, name, selectedClusterId, selectedCluster) {
+    isDisabledDefault(id, name, selectedClusterId) {
       return (
         !this.selection.includes(
           this.hashAttributeIdClusterId(id, selectedClusterId)
@@ -287,12 +290,21 @@ export default {
         ] == 'External'
       )
     },
-    isDisabled(id, name, selectedClusterId, selectedCluster) {
+    isDisabled(id, name, selectedClusterId) {
       return (
         !this.selection.includes(
           this.hashAttributeIdClusterId(id, selectedClusterId)
         ) || this.checkForcedExternal(name)
       )
+    },
+    defaultValueCheck(id, name, selectedClusterId) {
+      if (this.isDisabledDefault(id, name, selectedClusterId)) {
+        return null
+      } else {
+        return this.selectionDefault[
+          this.hashAttributeIdClusterId(id, selectedClusterId)
+        ]
+      }
     },
     setToNull(row, selectedClusterId) {
       this.handleLocalChange(null, 'defaultValue', row, selectedClusterId)


### PR DESCRIPTION
This PR addresses the issue of attributes that are manually changed to External Storage. 

If an attribute is set to External Storage at any moment then the default value will be uneditable.

Additionally, in this case the value should be set to null to avoid user error.