### PR TITLE
Default disable

### DIFF
--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -178,8 +178,7 @@ limitations under the License.
                 defaultValueCheck(
                   props.row.id,
                   props.row.label,
-                  selectedCluster.id,
-                  selectedCluster.label
+                  selectedCluster.id
                 )
               "
               :error="

--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -106,8 +106,7 @@ limitations under the License.
                 isDisabledStorage(
                   props.row.id,
                   props.row.label,
-                  selectedCluster.id,
-                  selectedCluster.label
+                  selectedCluster.id
                 )
               "
               class="col"
@@ -130,14 +129,7 @@ limitations under the License.
               :model-value="selectionSingleton"
               :val="hashAttributeIdClusterId(props.row.id, selectedCluster.id)"
               indeterminate-value="false"
-              :disable="
-                isDisabled(
-                  props.row.id,
-                  props.row.label,
-                  selectedCluster.id,
-                  selectedCluster.label
-                )
-              "
+              :disable="isDisabled(props.row.id, selectedCluster.id)"
               @update:model-value="
                 handleLocalSelection(
                   $event,
@@ -154,14 +146,7 @@ limitations under the License.
               :model-value="selectionBounded"
               :val="hashAttributeIdClusterId(props.row.id, selectedCluster.id)"
               indeterminate-value="false"
-              :disable="
-                isDisabled(
-                  props.row.id,
-                  props.row.label,
-                  selectedCluster.id,
-                  selectedCluster.label
-                )
-              "
+              :disable="isDisabled(props.row.id, selectedCluster.id)"
               @update:model-value="
                 handleLocalSelection(
                   $event,
@@ -188,14 +173,7 @@ limitations under the License.
                   ? 'grey'
                   : ''
               "
-              :disable="
-                isDisabledDefault(
-                  props.row.id,
-                  props.row.label,
-                  selectedCluster.id,
-                  selectedCluster.label
-                )
-              "
+              :disable="isDisabledDefault(props.row.id, selectedCluster.id)"
               :model-value="
                 defaultValueCheck(
                   props.row.id,
@@ -280,7 +258,7 @@ export default {
       }
     },
     //disabling default field if Storage is External AND if attribute is not enabled
-    isDisabledDefault(id, name, selectedClusterId) {
+    isDisabledDefault(id, selectedClusterId) {
       return (
         !this.selection.includes(
           this.hashAttributeIdClusterId(id, selectedClusterId)
@@ -304,6 +282,7 @@ export default {
         this.hashAttributeIdClusterId(id, selectedClusterId)
       )
     },
+    //if disabled set null
     defaultValueCheck(id, name, selectedClusterId) {
       if (this.isDisabledDefault(id, name, selectedClusterId)) {
         return null

--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -103,7 +103,7 @@ limitations under the License.
                 ]
               "
               :disable="
-                isDisabled(
+                isDisabledStorage(
                   props.row.id,
                   props.row.label,
                   selectedCluster.id,
@@ -279,22 +279,29 @@ export default {
         return false
       }
     },
+    //disabling default field if Storage is External
     isDisabledDefault(id, name, selectedClusterId) {
       return (
         !this.selection.includes(
           this.hashAttributeIdClusterId(id, selectedClusterId)
         ) ||
-        this.checkForcedExternal(name) ||
         this.selectionStorageOption[
           this.hashAttributeIdClusterId(id, selectedClusterId)
         ] == 'External'
       )
     },
-    isDisabled(id, name, selectedClusterId) {
+    //disabling Storage if forced External
+    isDisabledStorage(id, name, selectedClusterId) {
       return (
         !this.selection.includes(
           this.hashAttributeIdClusterId(id, selectedClusterId)
         ) || this.checkForcedExternal(name)
+      )
+    },
+    //disable if attribute is not enabled
+    isDisabled(id, selectedClusterId) {
+      return !this.selection.includes(
+        this.hashAttributeIdClusterId(id, selectedClusterId)
       )
     },
     defaultValueCheck(id, name, selectedClusterId) {

--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -189,7 +189,7 @@ limitations under the License.
                   : ''
               "
               :disable="
-                isDisabled(
+                isDisabledDefault(
                   props.row.id,
                   props.row.label,
                   selectedCluster.id,
@@ -275,6 +275,17 @@ export default {
       } else {
         return false
       }
+    },
+    isDisabledDefault(id, name, selectedClusterId, selectedCluster) {
+      return (
+        !this.selection.includes(
+          this.hashAttributeIdClusterId(id, selectedClusterId)
+        ) ||
+        this.checkForcedExternal(name) ||
+        this.selectionStorageOption[
+          this.hashAttributeIdClusterId(id, selectedClusterId)
+        ] == 'External'
+      )
     },
     isDisabled(id, name, selectedClusterId, selectedCluster) {
       return (

--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -248,7 +248,7 @@ export default {
         })
       }
     },
-    //check if cluster and attribute pairing should be forced External Storage
+    //return true if cluster and attribute pairing should be forced External Storage
     checkForcedExternal(name) {
       if (
         this.forcedExternal.byName?.[this.selectedCluster.label]?.includes(name)
@@ -258,7 +258,7 @@ export default {
         return false
       }
     },
-    //disabling default field if Storage is External AND if attribute is not enabled
+    //return true and disable default field if Storage is External AND if attribute is not enabled
     isDisabledDefault(id, selectedClusterId) {
       return (
         !this.selection.includes(
@@ -269,7 +269,7 @@ export default {
         ] == 'External'
       )
     },
-    //disabling Storage if forced External AND if attribute is not enabled
+    //return true and disable Storage if forced External AND if attribute is not enabled
     isDisabledStorage(id, name, selectedClusterId) {
       return (
         !this.selection.includes(
@@ -277,13 +277,13 @@ export default {
         ) || this.checkForcedExternal(name)
       )
     },
-    //disabling if attribute is not enabled
+    //return true and disable if attribute is not enabled
     isDisabled(id, selectedClusterId) {
       return !this.selection.includes(
         this.hashAttributeIdClusterId(id, selectedClusterId)
       )
     },
-    //if disabled set null
+    //if disabled return null to be set as the default value
     defaultValueCheck(id, name, selectedClusterId) {
       if (this.isDisabledDefault(id, name, selectedClusterId)) {
         return null

--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -241,6 +241,7 @@ export default {
   name: 'ZclAttributeManager',
   mixins: [EditableAttributeMixin],
   methods: {
+    //retrieve list of cluster and attribute pairs that should be forced External Storage
     loadForcedExternal(packages) {
       if (packages) {
         this.$serverPost(restApi.uri.forcedExternal, packages).then((resp) => {
@@ -248,6 +249,7 @@ export default {
         })
       }
     },
+    //check if cluster and attribute pairing should be forced External Storage
     checkForcedExternal(name) {
       if (
         this.forcedExternal.byName?.[this.selectedCluster.label]?.includes(name)

--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -279,7 +279,7 @@ export default {
         return false
       }
     },
-    //disabling default field if Storage is External
+    //disabling default field if Storage is External AND if attribute is not enabled
     isDisabledDefault(id, name, selectedClusterId) {
       return (
         !this.selection.includes(
@@ -290,7 +290,7 @@ export default {
         ] == 'External'
       )
     },
-    //disabling Storage if forced External
+    //disabling Storage if forced External AND if attribute is not enabled
     isDisabledStorage(id, name, selectedClusterId) {
       return (
         !this.selection.includes(
@@ -298,7 +298,7 @@ export default {
         ) || this.checkForcedExternal(name)
       )
     },
-    //disable if attribute is not enabled
+    //disabling if attribute is not enabled
     isDisabled(id, selectedClusterId) {
       return !this.selection.includes(
         this.hashAttributeIdClusterId(id, selectedClusterId)

--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -197,9 +197,12 @@ limitations under the License.
                 )
               "
               :model-value="
-                selectionDefault[
-                  hashAttributeIdClusterId(props.row.id, selectedCluster.id)
-                ]
+                defaultValueCheck(
+                  props.row.id,
+                  props.row.label,
+                  selectedCluster.id,
+                  selectedCluster.label
+                )
               "
               :error="
                 !isDefaultValueValid(
@@ -276,7 +279,7 @@ export default {
         return false
       }
     },
-    isDisabledDefault(id, name, selectedClusterId, selectedCluster) {
+    isDisabledDefault(id, name, selectedClusterId) {
       return (
         !this.selection.includes(
           this.hashAttributeIdClusterId(id, selectedClusterId)
@@ -287,12 +290,21 @@ export default {
         ] == 'External'
       )
     },
-    isDisabled(id, name, selectedClusterId, selectedCluster) {
+    isDisabled(id, name, selectedClusterId) {
       return (
         !this.selection.includes(
           this.hashAttributeIdClusterId(id, selectedClusterId)
         ) || this.checkForcedExternal(name)
       )
+    },
+    defaultValueCheck(id, name, selectedClusterId) {
+      if (this.isDisabledDefault(id, name, selectedClusterId)) {
+        return null
+      } else {
+        return this.selectionDefault[
+          this.hashAttributeIdClusterId(id, selectedClusterId)
+        ]
+      }
     },
     setToNull(row, selectedClusterId) {
       this.handleLocalChange(null, 'defaultValue', row, selectedClusterId)


### PR DESCRIPTION
This PR addresses the issue of attributes that are manually changed to External Storage.

If an attribute is set to External Storage at any moment then the default value will be uneditable.

Additionally, in this case the value should be set to null to avoid user error.