### PR TITLE
change Parent Endpoint helper to return kInvalidEndpointId 

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -103,7 +103,7 @@ function endpoint_fixed_parent_id_array(options) {
   let parentIds = []
   this.endpoints.forEach((ep) => {
     if (ep.parentEndpointIdentifier == null) {
-      parentIds.push(0)
+      parentIds.push('kInvalidEndpointId')
     } else {
       parentIds.push(ep.parentEndpointIdentifier)
     }

--- a/test/gen-matter-4.test.js
+++ b/test/gen-matter-4.test.js
@@ -158,7 +158,9 @@ test(
     expect(ept).toContain(
       '#define FIXED_PROFILE_IDS { 0x0103, 0x0103, 0x0103, 0x0103 }'
     )
-    expect(ept).toContain('#define FIXED_PARENT_IDS { 0, 0, 1, 0 }')
+    expect(ept).toContain(
+      '#define FIXED_PARENT_IDS { kInvalidEndpointId, 0, 1, kInvalidEndpointId }'
+    )
     expect(ept).toContain(
       '#define FIXED_DEVICE_TYPES {{0x00000016,1},{0x00000100,1},{0x00000100,1},{0x0000F002,1}}'
     )
@@ -265,7 +267,9 @@ test(
     expect(ept).toContain(
       '#define FIXED_PROFILE_IDS { 0x0103, 0x0103, 0x0103, 0x0103 }'
     )
-    expect(ept).toContain('#define FIXED_PARENT_IDS { 0, 0, 0, 0 }')
+    expect(ept).toContain(
+      '#define FIXED_PARENT_IDS { kInvalidEndpointId, kInvalidEndpointId, kInvalidEndpointId, kInvalidEndpointId }'
+    )
     expect(ept).toContain(
       '#define FIXED_DEVICE_TYPES {{0x00000016,1},{0x00000100,1},{0x00000100,1},{0x0000F002,1}}'
     )


### PR DESCRIPTION
change Parent Endpoint helper to return kInvalidEndpointId which is a constant in Matter SDK