### PR TITLE
excluding global lists from the GUI

### DIFF
--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -36,7 +36,11 @@ limitations under the License.
       separator="horizontal"
     >
       <template v-slot:body="props">
-        <q-tr :props="props" class="table_body">
+        <q-tr
+          :props="props"
+          class="table_body"
+          v-if="!globalLists.includes(props.row.label)"
+        >
           <q-td
             key="status"
             :props="props"
@@ -236,10 +240,11 @@ import restApi from '../../src-shared/rest-api.js'
 
 //This mixin derives from common-mixin.
 import EditableAttributeMixin from '../util/editable-attributes-mixin'
+import uiOptions from '../util/ui-options'
 
 export default {
   name: 'ZclAttributeManager',
-  mixins: [EditableAttributeMixin],
+  mixins: [EditableAttributeMixin, uiOptions],
   methods: {
     //retrieve list of cluster and attribute pairs that should be forced External Storage
     loadForcedExternal(packages) {

--- a/src/util/ui-options.js
+++ b/src/util/ui-options.js
@@ -26,6 +26,12 @@ export default {
       enableServerOnly: false,
       enableSingleton: false,
       enableBounded: false,
+      globalLists: [
+        'EventList',
+        'AttributeList',
+        'GeneratedCommandList',
+        'AcceptedCommandList',
+      ],
     }
   },
   mounted() {


### PR DESCRIPTION
global attribute lists are automatically enabled and must be excluded from the GUI to avoid confusing the user

issue: https://github.com/project-chip/zap/issues/1085