### PR TITLE
bug fix - duplicating endpoints

### DIFF
--- a/src-electron/db/query-attribute.js
+++ b/src-electron/db/query-attribute.js
@@ -54,8 +54,7 @@ async function selectEndpointTypeAttributesByEndpointTypeRefAndClusterRef(
       INCLUDED_REPORTABLE,
       MIN_INTERVAL,
       MAX_INTERVAL,
-      REPORTABLE_CHANGE,
-      API_MATURITY
+      REPORTABLE_CHANGE
     from 
       ENDPOINT_TYPE_ATTRIBUTE
     where

--- a/src-electron/db/query-config.js
+++ b/src-electron/db/query-config.js
@@ -701,7 +701,6 @@ async function duplicateEndpointType(db, endpointTypeId) {
       ENDPOINT_TYPE_DEVICE.ENDPOINT_TYPE_REF = ?`,
     [endpointTypeId]
   )
-
   let newEndpointTypeId = 0
   if (endpointTypeDeviceInfo && endpointTypeDeviceInfo.length > 0) {
     // Enter into the endpoint_type table
@@ -710,7 +709,7 @@ async function duplicateEndpointType(db, endpointTypeId) {
       `INSERT INTO ENDPOINT_TYPE (SESSION_PARTITION_REF, NAME)
       VALUES (?, ?)`,
       [
-        endpointTypeDeviceInfo[0].SESSION_PARTITION_REF,
+        endpointTypeDeviceInfo[0].SESSION_PARTITION_ID,
         endpointTypeDeviceInfo[0].NAME,
       ]
     )


### PR DESCRIPTION
Fixing bug when selecting API_MATURITY from a table where it does not exist

: Error: SQLITE_ERROR: no such column: API_MATURITY"}
⇝ (node:2539) UnhandledPromiseRejectionWarning: Error: SQLITE_ERROR: no such column: API_MATURITY