### PR TITLE
Changing user_endpoints back to non async since that is breaking the backwards compatibility with after and iteratorAccumulator

### DIFF
--- a/test/gen-template/zigbee/zap-event.h.zapt
+++ b/test/gen-template/zigbee/zap-event.h.zapt
@@ -74,3 +74,14 @@
 	{{/user_clusters}}
 {{/user_endpoints}}
 
+{{#user_endpoints}}
+  {{~addToAccumulator "event_size" 1~}}
+{{/user_endpoints}}
+
+
+{{#after}}
+	{{#iterateAccumulator accumulator="event_size"}}
+#define SL_ZIGBEE_AF_GENERATED_UC_EVENT_CONTEXT_COUNT {{sum}}
+	{{/iterateAccumulator}}
+{{/after}}
+

--- a/test/multi-protocol.test.js
+++ b/test/multi-protocol.test.js
@@ -97,7 +97,7 @@ test(
       importRes.templateIds[0],
       {},
       {
-        generateOnly: 'zap-config-version-3.h',
+        generateOnly: ['zap-config-version-3.h', 'zap-event.h'],
         disableDeprecationWarnings: true,
       }
     )
@@ -199,6 +199,12 @@ test(
     // Just one notification regarding multiple top level zcl propertoes and 4
     // notifications regarding feature map attribute not set correctly
     expect(sessionNotifications.length).toEqual(5)
+
+    // Test Accumulators in templates
+    let zigbeeEndpointEvents = genResultZigbee.content['zap-event.h']
+    expect(zigbeeEndpointEvents).toContain(
+      '#define SL_ZIGBEE_AF_GENERATED_UC_EVENT_CONTEXT_COUNT 1'
+    )
   },
   testUtil.timeout.long()
 )


### PR DESCRIPTION

- After helper waits for the promises to finish. However turning the user_endpoints to async led to accumulator not populate before the iteratorAccumulator tried to access it.
- Turned user-endpoints helper back to no asnyc
- Added test so that this is covered when we actually fix this issue with accumulators
- JIRA: ZAPP-1376