### PR TITLE
Warn users when project linked packages cannot satisfy the .zap file import/open

### DIFF
--- a/src-electron/importexport/import-json.js
+++ b/src-electron/importexport/import-json.js
@@ -1343,7 +1343,8 @@ async function importEndpointTypes(
         db,
         sessionPartitionInfo[0].sessionPartitionId,
         allZclPackageIds,
-        endpointTypes[i]
+        endpointTypes[i],
+        sessionId
       )
       let endpointId = ''
       if (sortedEndpoints[i]) {


### PR DESCRIPTION


- Throw an error in importEndpointType when device types cannot be found for an endpoint type
- JIRA: ZAPP-1363