### PR TITLE
Show standard clusters when custom device types are added from custom xml

### DIFF
--- a/src-electron/generator/template-util.js
+++ b/src-electron/generator/template-util.js
@@ -290,7 +290,12 @@ async function ensureEndpointTypeIds(context) {
             deviceType.packageRef
           )
           // Check for package category match based on gen template category and add it to relevant endpoint types
-          if (packageInfo.category == packageCategory || !packageCategory) {
+          if (
+            packageInfo.category == packageCategory ||
+            !packageCategory ||
+            (!packageInfo.category &&
+              packageInfo.type === dbEnum.packageType.zclXmlStandalone)
+          ) {
             resEptIds.push(eptIds[i])
             break
           }
@@ -327,7 +332,11 @@ async function ensureEndpointTypeIds(context) {
             context.global.db,
             deviceType.packageRef
           )
-          if (packageInfo.category == packageCategory) {
+          if (
+            packageInfo.category == packageCategory ||
+            (!packageInfo.category &&
+              packageInfo.type === dbEnum.packageType.zclXmlStandalone)
+          ) {
             resEptIds.push(eptIds[i])
             break
           }

--- a/src/store/zap/mutations.js
+++ b/src/store/zap/mutations.js
@@ -47,6 +47,7 @@ export function updateClusters(state, responseData) {
   let packageRefs = []
   // Add custom xml packages to the list of packageRefs
   let sessionPackages = state.packages
+  let customXmlPackagesCount = 0
   if (sessionPackages && sessionPackages.length > 0) {
     for (let i = 0; i < sessionPackages.length; i++) {
       if (
@@ -57,12 +58,26 @@ export function updateClusters(state, responseData) {
       }
     }
   }
+  customXmlPackagesCount = packageRefs.length
 
   if (selectedDeviceTypeRefs) {
     for (let i = 0; i < selectedDeviceTypeRefs.length; i++) {
       for (let j = 0; j < responseData.deviceTypes.data.length; j++) {
-        if (selectedDeviceTypeRefs[i] == responseData.deviceTypes.data[j].id) {
+        if (
+          selectedDeviceTypeRefs[i] == responseData.deviceTypes.data[j].id &&
+          !packageRefs.includes(responseData.deviceTypes.data[j].packageRef)
+        ) {
           packageRefs.push(responseData.deviceTypes.data[j].packageRef)
+        }
+      }
+    }
+    // Check if all package refs are standalone(Handles the custom device type use case from xml)
+    if (customXmlPackagesCount === packageRefs.length) {
+      // if all packages are custom then add the first standard zcl package to the list of package refs.
+      for (let i = 0; i < sessionPackages.length; i++) {
+        if (sessionPackages[i].pkg.type == 'zcl-properties') {
+          packageRefs.push(sessionPackages[i].pkg.id)
+          break
         }
       }
     }

--- a/test/resource/custom-cluster/custom-device-type.xml
+++ b/test/resource/custom-cluster/custom-device-type.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<configurator>
+  <deviceType>
+    <name>DUT-Client</name>
+    <domain>CUSTOM_DUT</domain>
+    <typeName>D.U.T. Client</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0xC001</profileId>
+    <deviceId editable="false">0x0001</deviceId>
+    <clusters lockOthers="true">
+      <include client="true" server="false"  clientLocked="true"  serverLocked="true" >Test Cluster</include>
+      <include cluster="Basic" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+	</clusters>
+  </deviceType>
+  <deviceType>
+    <name>DUT-Server</name>
+    <domain>CUSTOM_DUT</domain>
+    <typeName>D.U.T. Server</typeName>
+    <zigbeeType>End Device</zigbeeType>
+    <profileId editable="false">0xC001</profileId>
+    <deviceId editable="false">0x0002</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true"  clientLocked="true"  serverLocked="true" >Test Cluster</include>
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+	</clusters>
+  </deviceType>  
+</configurator>

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -145,6 +145,8 @@ exports.testServer = testServer
 
 exports.testCustomXml = './test/resource/custom-cluster/test-custom.xml'
 exports.testCustomXml2 = './test/resource/custom-cluster/custom-dut.xml'
+exports.testCustomXmlDeviceType =
+  './test/resource/custom-cluster/custom-device-type.xml'
 exports.customClusterXml =
   './test/resource/custom-cluster/custom-bead-cluster.xml'
 exports.badTestCustomXml = './test/resource/custom-cluster/bad-test-custom.xml'


### PR DESCRIPTION
 Adding standalone packages without considering package category
- Making sure that invalid session Packages are handled properly
- Making sure that sessionPartitionIndex is updated when pacakges are not loaded in the db. Also making sure they are not look into for invalidSessionPkgs since they are already verified for existence
- Adding tests to make sure custom device types are being loaded from custom xml
- JIRA: ZAPP-1450
