### PR TITLE
fixing issue_1356

### DIFF
--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -836,9 +836,9 @@ async function collectAttributes(db, sessionId, endpointTypes, options) {
             // We don't want to make longTypeDefaultValue know about our null
             // string representation.
             if (types.isOneBytePrefixedString(a.type)) {
-              def = ['0xFF']
+              def = '0xFF,'
             } else if (types.isTwoBytePrefixedString(a.type)) {
-              def = ['0xFF', '0xFF']
+              def = '0xFF, 0xFF,'
             } else {
               throw new Error(`Unknown string type: ${type}`)
             }


### PR DESCRIPTION
when a nullable string is null, the javascript code should be a string and not an array so the generated code compiles