### PR TITLE
Remove console prints for compliance when running tests

### DIFF
--- a/src-electron/importexport/import-json.js
+++ b/src-electron/importexport/import-json.js
@@ -1576,7 +1576,9 @@ async function importEndpointTypes(
         clusterSpecCheckComplianceMessage,
         dottedLine
       )
-      console.log(deviceTypeSpecCheckComplianceMessage)
+      if (!process.env.TEST) {
+        console.log(deviceTypeSpecCheckComplianceMessage)
+      }
     }
   }
 }

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -17,5 +17,6 @@
 const env = require('../src-electron/util/env')
 
 module.exports = async () => {
+  process.env.TEST = 'true'
   env.logDebug('Global setup.')
 }

--- a/test/global-teardown.js
+++ b/test/global-teardown.js
@@ -17,5 +17,6 @@
 const env = require('../src-electron/util/env')
 
 module.exports = async () => {
+  delete process.env.TEST
   env.logDebug('Global teardown.')
 }


### PR DESCRIPTION
- JIRA: ZAPP-1299

- set TEST environment variable before running jest tests, and only print when TEST is false