### PR TITLE
Issue 1397

### DIFF
--- a/src-electron/db/query-config.js
+++ b/src-electron/db/query-config.js
@@ -235,7 +235,10 @@ async function insertOrUpdateAttributeState(
     )
     staticAttribute.defaultValue = featureMapDefaultValue
   }
-  let forcedExternal = await queryUpgrade.getForcedExternalStorage(db)
+  let forcedExternal = await queryUpgrade.getForcedExternalStorage(
+    db,
+    staticAttribute.packageRef
+  )
   staticAttribute.storagePolicy =
     await queryUpgrade.computeStoragePolicyNewConfig(
       db,

--- a/src-electron/db/query-impexp.js
+++ b/src-electron/db/query-impexp.js
@@ -737,7 +737,10 @@ WHERE
     attribute.reportable = false
   }
   if (attributeId) {
-    forcedExternal = await queryUpgrade.getForcedExternalStorage(db)
+    forcedExternal = await queryUpgrade.getForcedExternalStorage(
+      db,
+      packageIds[0]
+    )
     storagePolicy = await queryUpgrade.computeStorageImport(
       db,
       cluster.name,

--- a/src-electron/db/query-impexp.js
+++ b/src-electron/db/query-impexp.js
@@ -737,10 +737,7 @@ WHERE
     attribute.reportable = false
   }
   if (attributeId) {
-    forcedExternal = await queryUpgrade.getForcedExternalStorage(
-      db,
-      packageIds[0]
-    )
+    forcedExternal = await queryUpgrade.getForcedExternalStorage(db, packageIds)
     storagePolicy = await queryUpgrade.computeStorageImport(
       db,
       cluster.name,

--- a/src-electron/db/query-package.js
+++ b/src-electron/db/query-package.js
@@ -706,19 +706,14 @@ async function getAllPackages(db) {
  */
 async function getAttributeAccessInterface(db, code, packageIds) {
   try {
-    // Ensure packageIds is always an array
-    if (!Array.isArray(packageIds)) {
-      packageIds = [packageIds]
-    }
-
     let packageRefCondition = `po.PACKAGE_REF = ?`
     let attributePackageRefCondition = `a.PACKAGE_REF = ?`
     let queryParams = [code, ...packageIds, code, ...packageIds]
 
-    // Since packageIds is now always an array, adjust the query and parameters accordingly
-    const placeholders = packageIds.map(() => '?').join(', ')
-    packageRefCondition = `po.PACKAGE_REF IN (${placeholders})`
-    attributePackageRefCondition = `a.PACKAGE_REF IN (${placeholders})`
+    // Use dbApi.toInClause to automatically create the placeholders for the IN clause
+    const inClause = dbApi.toInClause(packageIds)
+    packageRefCondition = `po.PACKAGE_REF IN (${inClause})`
+    attributePackageRefCondition = `a.PACKAGE_REF IN (${inClause})`
 
     const extendedQuery = `
       SELECT

--- a/src-electron/db/query-package.js
+++ b/src-electron/db/query-package.js
@@ -704,34 +704,38 @@ async function getAllPackages(db) {
  * @returns {Promise<Array>} A promise that resolves to an array of option objects, each containing the option category, code, and label.
  */
 async function getAttributeAccessInterface(db, code, packageId) {
-  const extendedQuery = `
-    SELECT
-        po.OPTION_CATEGORY,
-        po.OPTION_CODE,
-        po.OPTION_LABEL
-    FROM
-        PACKAGE_OPTION po
-    WHERE
-        po.OPTION_CODE = ?
-        AND po.PACKAGE_REF = ?
+  try {
+    const extendedQuery = `
+      SELECT
+          po.OPTION_CATEGORY,
+          po.OPTION_CODE,
+          po.OPTION_LABEL
+      FROM
+          PACKAGE_OPTION po
+      WHERE
+          po.OPTION_CODE = ?
+          AND po.PACKAGE_REF = ?
 
-    UNION 
+      UNION 
 
-    SELECT
-        c.NAME AS OPTION_CATEGORY,
-        a.STORAGE_POLICY AS OPTION_CODE,
-        a.NAME AS OPTION_LABEL
-    FROM
-        ATTRIBUTE a
-    LEFT JOIN CLUSTER c ON a.CLUSTER_REF = c.CLUSTER_ID
-    WHERE
-        a.STORAGE_POLICY = ?
-        AND a.PACKAGE_REF = ?
-
-  `
-  return dbApi
-    .dbAll(db, extendedQuery, [code, packageId, code, packageId]) // Note the [code, code] to match both placeholders
-    .then((rows) => rows.map(dbMapping.map.options))
+      SELECT
+          c.NAME AS OPTION_CATEGORY,
+          a.STORAGE_POLICY AS OPTION_CODE,
+          a.NAME AS OPTION_LABEL
+      FROM
+          ATTRIBUTE a
+      LEFT JOIN CLUSTER c ON a.CLUSTER_REF = c.CLUSTER_ID
+      WHERE
+          a.STORAGE_POLICY = ?
+          AND a.PACKAGE_REF = ?
+    `
+    return dbApi
+      .dbAll(db, extendedQuery, [code, packageId, code, packageId]) // Note the [code, packageId, code, packageId] to match both placeholders
+      .then((rows) => rows.map(dbMapping.map.options))
+  } catch (error) {
+    console.error('Error fetching attribute access interface:', error)
+    throw error // Rethrow the error for further handling if necessary
+  }
 }
 
 /**

--- a/src-electron/db/query-package.js
+++ b/src-electron/db/query-package.js
@@ -693,14 +693,15 @@ async function getAllPackages(db) {
 /**
  * Retrieves attribute access interface options from the database.
  *
- * This function performs a complex query to fetch options related to a specific code and package ID. It combines results from
+ * This function performs a complex query to fetch options related to a specific code and package IDs. It combines results from
  * the PACKAGE_OPTION table with those from ATTRIBUTE and CLUSTER tables using a UNION. The purpose is to gather a comprehensive
  * list of options that include both direct package options and those inferred from attributes' storage policies and their associated
- * clusters.
+ * clusters. It supports querying for multiple package IDs by ensuring the packageIds parameter is treated as an array, allowing
+ * for more flexible queries.
  *
  * @param {Object} db - The database connection object.
  * @param {string} code - The option code or storage policy code to query for.
- * @param {number} packageId - The ID of the package to which the options are related.
+ * @param {number|Array<number>} packageIds - The ID(s) of the package(s) to which the options are related. Can be a single ID or an array of IDs.
  * @returns {Promise<Array>} A promise that resolves to an array of option objects, each containing the option category, code, and label.
  */
 async function getAttributeAccessInterface(db, code, packageIds) {

--- a/src-electron/db/query-package.js
+++ b/src-electron/db/query-package.js
@@ -699,9 +699,11 @@ async function getAllPackages(db) {
  * clusters. It supports querying for multiple package IDs by ensuring the packageIds parameter is treated as an array, allowing
  * for more flexible queries.
  *
+ * The ATTRIBUTES table is spec only data so PACKAGE_OPTION was used to add SDK data without interfering with the spec data
+ *
  * @param {Object} db - The database connection object.
  * @param {string} code - The option code or storage policy code to query for.
- * @param {number|Array<number>} packageIds - The ID(s) of the package(s) to which the options are related. Can be a single ID or an array of IDs.
+ * @param {Array<number>} packageIds - The ID(s) of the package(s) to which the options are related. Can be a single ID or an array of IDs.
  * @returns {Promise<Array>} A promise that resolves to an array of option objects, each containing the option category, code, and label.
  */
 async function getAttributeAccessInterface(db, code, packageIds) {

--- a/src-electron/db/query-package.js
+++ b/src-electron/db/query-package.js
@@ -690,7 +690,17 @@ async function getAllPackages(db) {
     )
     .then((rows) => rows.map(dbMapping.map.package))
 }
-
+/**
+ * Retrieves attribute access interface options from the database.
+ * This function executes a query that combines results from the PACKAGE_OPTION and ATTRIBUTE tables,
+ * filtering by a specific code. It uses UNION to ensure no duplicate rows are returned, even if the same
+ * code exists in both tables. The results are then mapped to a standard format using dbMapping.map.options.
+ *
+ * @param {Object} db - The database connection object.
+ * @param {string} code - The code used to filter the results from both PACKAGE_OPTION and ATTRIBUTE tables.
+ * @returns {Promise<Array>} A promise that resolves to an array of objects, each representing an option
+ *                           with properties: PACKAGE_REF, OPTION_CATEGORY, OPTION_CODE, and OPTION_LABEL.
+ */
 async function getAttributeAccessInterface(db, code) {
   const extendedQuery = `
     SELECT

--- a/src-electron/db/query-package.js
+++ b/src-electron/db/query-package.js
@@ -715,11 +715,7 @@ async function getAttributeAccessInterface(db, code) {
     LEFT JOIN CLUSTER c ON a.CLUSTER_REF = c.CLUSTER_ID
     WHERE
         a.STORAGE_POLICY = ?
-        AND NOT EXISTS (
-            SELECT 1
-            FROM PACKAGE_OPTION po
-            WHERE po.OPTION_LABEL = a.NAME
-        )
+
   `
 
   return dbApi

--- a/src-electron/db/query-package.js
+++ b/src-electron/db/query-package.js
@@ -701,7 +701,7 @@ async function getAllPackages(db) {
  * @returns {Promise<Array>} A promise that resolves to an array of objects, each representing an option
  *                           with properties: PACKAGE_REF, OPTION_CATEGORY, OPTION_CODE, and OPTION_LABEL.
  */
-async function getAttributeAccessInterface(db, code) {
+async function getAttributeAccessInterface(db, code, packageId) {
   const extendedQuery = `
     SELECT
         po.PACKAGE_REF,
@@ -712,6 +712,7 @@ async function getAttributeAccessInterface(db, code) {
         PACKAGE_OPTION po
     WHERE
         po.OPTION_CODE = ?
+        AND po.PACKAGE_REF = ?
 
     UNION 
 
@@ -725,11 +726,12 @@ async function getAttributeAccessInterface(db, code) {
     LEFT JOIN CLUSTER c ON a.CLUSTER_REF = c.CLUSTER_ID
     WHERE
         a.STORAGE_POLICY = ?
+        AND a.PACKAGE_REF = ?
 
   `
 
   return dbApi
-    .dbAll(db, extendedQuery, [code, code]) // Note the [code, code] to match both placeholders
+    .dbAll(db, extendedQuery, [code, packageId, code, packageId]) // Note the [code, code] to match both placeholders
     .then((rows) => rows.map(dbMapping.map.options))
 }
 

--- a/src-electron/db/query-package.js
+++ b/src-electron/db/query-package.js
@@ -703,7 +703,7 @@ async function getAttributeAccessInterface(db, code) {
     WHERE
         po.OPTION_CODE = ?
 
-    UNION ALL
+    UNION 
 
     SELECT
         a.PACKAGE_REF,

--- a/src-electron/db/query-package.js
+++ b/src-electron/db/query-package.js
@@ -705,18 +705,19 @@ async function getAllPackages(db) {
  */
 async function getAttributeAccessInterface(db, code, packageIds) {
   try {
+    // Ensure packageIds is always an array
+    if (!Array.isArray(packageIds)) {
+      packageIds = [packageIds]
+    }
+
     let packageRefCondition = `po.PACKAGE_REF = ?`
     let attributePackageRefCondition = `a.PACKAGE_REF = ?`
-    let queryParams = [code, packageIds, code, packageIds]
+    let queryParams = [code, ...packageIds, code, ...packageIds]
 
-    // Check if packageIds is an array and adjust the query and parameters accordingly
-    if (Array.isArray(packageIds)) {
-      const placeholders = packageIds.map(() => '?').join(', ')
-      packageRefCondition = `po.PACKAGE_REF IN (${placeholders})`
-      attributePackageRefCondition = `a.PACKAGE_REF IN (${placeholders})`
-      // Adjust queryParams for the IN clause
-      queryParams = [code, ...packageIds, code, ...packageIds]
-    }
+    // Since packageIds is now always an array, adjust the query and parameters accordingly
+    const placeholders = packageIds.map(() => '?').join(', ')
+    packageRefCondition = `po.PACKAGE_REF IN (${placeholders})`
+    attributePackageRefCondition = `a.PACKAGE_REF IN (${placeholders})`
 
     const extendedQuery = `
       SELECT

--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -866,6 +866,7 @@ async function selectAttributeByAttributeIdAndClusterRef(
       `
 SELECT
   A.ATTRIBUTE_ID,
+  A.PACKAGE_REF,
   A.CLUSTER_REF,
   A.CODE,
   A.MANUFACTURER_CODE,

--- a/src-electron/generator/helper-zcl.js
+++ b/src-electron/generator/helper-zcl.js
@@ -771,7 +771,8 @@ async function zcl_attributes(options) {
     attributes = await upgrade.computeStoragePolicyForGlobalAttributes(
       this.global.db,
       this.id,
-      attributes
+      attributes,
+      packageIds[0]
     )
   } else {
     attributes = await queryZcl.selectAllAttributes(this.global.db, packageIds)
@@ -805,7 +806,8 @@ async function zcl_attributes_client(options) {
     clientAttributes = await upgrade.computeStoragePolicyForGlobalAttributes(
       this.global.db,
       this.id,
-      clientAttributes
+      clientAttributes,
+      packageIds[0]
     )
   } else {
     clientAttributes = await queryZcl.selectAllAttributesBySide(
@@ -846,7 +848,8 @@ async function zcl_attributes_server(options) {
     serverAttributes = await upgrade.computeStoragePolicyForGlobalAttributes(
       this.global.db,
       this.id,
-      serverAttributes
+      serverAttributes,
+      packageIds[0]
     )
   } else {
     serverAttributes = await queryZcl.selectAllAttributesBySide(

--- a/src-electron/generator/helper-zcl.js
+++ b/src-electron/generator/helper-zcl.js
@@ -772,7 +772,7 @@ async function zcl_attributes(options) {
       this.global.db,
       this.id,
       attributes,
-      packageIds[0]
+      packageIds
     )
   } else {
     attributes = await queryZcl.selectAllAttributes(this.global.db, packageIds)
@@ -807,7 +807,7 @@ async function zcl_attributes_client(options) {
       this.global.db,
       this.id,
       clientAttributes,
-      packageIds[0]
+      packageIds
     )
   } else {
     clientAttributes = await queryZcl.selectAllAttributesBySide(
@@ -849,7 +849,7 @@ async function zcl_attributes_server(options) {
       this.global.db,
       this.id,
       serverAttributes,
-      packageIds[0]
+      packageIds
     )
   } else {
     serverAttributes = await queryZcl.selectAllAttributesBySide(

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -273,8 +273,8 @@ function httpPostForcedExternal(db) {
       db,
       sessionId
     )
-    let packageId = packages[0].pkg.id
-    let forcedExternal = await upgrade.getForcedExternalStorage(db, packageId)
+    let packageIds = packages.map((pkg) => pkg.id)
+    let forcedExternal = await upgrade.getForcedExternalStorage(db, packageIds)
     response.status(StatusCodes.OK).json(forcedExternal)
   }
 }

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -255,6 +255,17 @@ function httpPostCluster(db) {
     }
   }
 }
+
+/**
+ * Handles a POST request to retrieve forced external storage options.
+ *
+ * This function is designed to be used as a middleware in an Express.js route. It extracts the session ID from the request,
+ * queries the database for package information associated with that session, and then retrieves forced external storage
+ * options for the identified package. The results are sent back to the client as a JSON response.
+ *
+ * @param {Object} db - The database connection object.
+ * @returns {Function} An asynchronous function that takes Express.js request and response objects.
+ */
 function httpPostForcedExternal(db) {
   return async (request, response) => {
     let sessionId = request.zapSessionId
@@ -267,6 +278,7 @@ function httpPostForcedExternal(db) {
     response.status(StatusCodes.OK).json(forcedExternal)
   }
 }
+
 /**
  * HTTP POST attribute update
  *

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -257,7 +257,13 @@ function httpPostCluster(db) {
 }
 function httpPostForcedExternal(db) {
   return async (request, response) => {
-    let forcedExternal = await upgrade.getForcedExternalStorage(db)
+    let sessionId = request.zapSessionId
+    let packages = await queryPackage.getPackageSessionPackagePairBySessionId(
+      db,
+      sessionId
+    )
+    let packageId = packages[0].pkg.id
+    let forcedExternal = await upgrade.getForcedExternalStorage(db, packageId)
     response.status(StatusCodes.OK).json(forcedExternal)
   }
 }

--- a/src-electron/sdk/matter.js
+++ b/src-electron/sdk/matter.js
@@ -21,20 +21,20 @@ const queryCluster = require('../db/query-cluster.js')
 const dbEnum = require('../../src-shared/db-enum.js')
 
 /**
- * This asynchronous function retrieves and returns the forced external storage options.
+ * Fetches forced external storage settings based on the given package ID.
+ * Utilizes the attribute access interface to query storage policies
+ * associated with the specified package ID.
  *
- * @param {Object} db - The database instance.
- *
- * The function calls the 'getAttributeAccessInterface' method from 'queryPackage' with
- * the database instance and 'attributeAccessInterface' from 'storagePolicy' as parameters.
- * The result is assigned to 'forcedExternal'.
- * Finally, it returns the 'forcedExternal' options.
+ * @param {Object} db - Database connection object.
+ * @param {Number} packageId - The ID of the package to query.
+ * @returns {Promise<Array>} A promise that resolves to an array of forced external storage settings.
  */
 
-async function getForcedExternalStorage(db) {
+async function getForcedExternalStorage(db, packageId) {
   let forcedExternal = await queryPackage.getAttributeAccessInterface(
     db,
-    dbEnum.storagePolicy.attributeAccessInterface
+    dbEnum.storagePolicy.attributeAccessInterface,
+    packageId
   )
   return forcedExternal
 }

--- a/src-electron/sdk/matter.js
+++ b/src-electron/sdk/matter.js
@@ -31,27 +31,33 @@ const dbEnum = require('../../src-shared/db-enum.js')
  */
 
 async function getForcedExternalStorage(db, packageId) {
-  let forcedExternal = await queryPackage.getAttributeAccessInterface(
-    db,
-    dbEnum.storagePolicy.attributeAccessInterface,
-    packageId
-  )
-  return forcedExternal
+  try {
+    let forcedExternal = await queryPackage.getAttributeAccessInterface(
+      db,
+      dbEnum.storagePolicy.attributeAccessInterface,
+      packageId
+    )
+    return forcedExternal
+  } catch (error) {
+    console.error('Error fetching forced external storage:', error)
+    throw error // Optionally re-throw the error for further handling
+  }
 }
 
 /**
- * This function takes a clusterId (the database ID, not the specification-defined ID) and an array of attributes (associated with the database defined clusterID)
- * and changes the global attributes (attributes with specification defined clusterId = null) to represent storage policy
- * based on the cluster/attribute pair in zcl.json
+ * This function takes a clusterId (the database ID, not the specification-defined ID), an array of attributes (associated with the database defined clusterID),
+ * and a packageId to identify the specific package the attributes belong to. It changes the global attributes (attributes with specification defined clusterId = null) to represent storage policy
+ * based on the cluster/attribute pair in zcl.json.
  *
- * Although the specification defined clusterID of the attriibute is null indicating it is a global attribute, we know what the database defined clusterID is by what is passed in as a parameter.
+ * Although the specification defined clusterID of the attribute is null indicating it is a global attribute, we know what the database defined clusterID is by what is passed in as a parameter.
  *
- * That database defined clusterID is used to query the name of the cluster which is in turn used to compute the storage policy for that cluster/attribute pair.
+ * That database defined clusterID is used to query the name of the cluster which is in turn used to compute the storage policy for that cluster/attribute pair based on the packageId.
  *
  * @export
  * @param {*} db
  * @param {*} clusterId (database defined) the clusterId representing a cluster from the database being used in the application
  * @param {*} attributes an array of objects representing the attributes associated with the cluster
+ * @param {*} packageId the ID of the package to which the attributes belong, used to determine storage policies specific to the package
  * @returns an array of objects representing attributes in the database
  */
 
@@ -61,26 +67,34 @@ async function computeStoragePolicyForGlobalAttributes(
   attributes,
   packageId
 ) {
-  let forcedExternal
-  let clusterName = await queryCluster.selectClusterName(db, clusterId)
-  return Promise.all(
-    attributes.map(async (attribute) => {
-      if (attribute.clusterId == null) {
-        forcedExternal = await getForcedExternalStorage(db, packageId)
-        forcedExternal.some((option) => {
-          if (
-            option.optionCategory == clusterName &&
-            option.optionLabel == attribute.name
-          ) {
-            attribute.storagePolicy =
-              dbEnum.storagePolicy.attributeAccessInterface
-            return true
-          }
-        })
-      }
-      return attribute
-    })
-  )
+  try {
+    let forcedExternal
+    let clusterName = await queryCluster.selectClusterName(db, clusterId)
+    return Promise.all(
+      attributes.map(async (attribute) => {
+        if (attribute.clusterId == null) {
+          forcedExternal = await getForcedExternalStorage(db, packageId)
+          forcedExternal.some((option) => {
+            if (
+              option.optionCategory == clusterName &&
+              option.optionLabel == attribute.name
+            ) {
+              attribute.storagePolicy =
+                dbEnum.storagePolicy.attributeAccessInterface
+              return true
+            }
+          })
+        }
+        return attribute
+      })
+    )
+  } catch (error) {
+    console.error(
+      'Failed to compute storage policy for global attributes:',
+      error
+    )
+    throw error // Rethrow the error if you want to handle it further up the call stack
+  }
 }
 /**
  * This asynchronous function computes and returns the new configuration for a storage option.
@@ -95,15 +109,20 @@ async function computeStoragePolicyForGlobalAttributes(
  */
 
 async function computeStorageOptionNewConfig(storagePolicy) {
-  let storageOption
-  if (storagePolicy == dbEnum.storagePolicy.attributeAccessInterface) {
-    storageOption = dbEnum.storageOption.external
-  } else if (storagePolicy == dbEnum.storagePolicy.any) {
-    storageOption = dbEnum.storageOption.ram
-  } else {
-    throw 'check storage policy'
+  try {
+    let storageOption
+    if (storagePolicy == dbEnum.storagePolicy.attributeAccessInterface) {
+      storageOption = dbEnum.storageOption.external
+    } else if (storagePolicy == dbEnum.storagePolicy.any) {
+      storageOption = dbEnum.storageOption.ram
+    } else {
+      throw new Error('Invalid storage policy')
+    }
+    return storageOption
+  } catch (error) {
+    console.error('Error computing new storage option config:', error)
+    throw error // Rethrow the error for further handling if necessary
   }
-  return storageOption
 }
 /**
  * This asynchronous function computes and returns the new configuration for a storage policy.
@@ -126,17 +145,22 @@ async function computeStoragePolicyNewConfig(
   forcedExternal,
   attributeName
 ) {
-  let clusterName = await queryCluster.selectClusterName(db, clusterRef)
-  forcedExternal.some((option) => {
-    if (
-      option.optionCategory == clusterName &&
-      option.optionLabel == attributeName
-    ) {
-      storagePolicy = dbEnum.storagePolicy.attributeAccessInterface
-      return true
-    }
-  })
-  return storagePolicy
+  try {
+    let clusterName = await queryCluster.selectClusterName(db, clusterRef)
+    forcedExternal.some((option) => {
+      if (
+        option.optionCategory == clusterName &&
+        option.optionLabel == attributeName
+      ) {
+        storagePolicy = dbEnum.storagePolicy.attributeAccessInterface
+        return true
+      }
+    })
+    return storagePolicy
+  } catch (error) {
+    console.error('Error computing storage policy new config:', error)
+    throw error // Rethrow the error for further handling if necessary
+  }
 }
 
 /**
@@ -162,18 +186,23 @@ async function computeStorageImport(
   forcedExternal,
   attributeName
 ) {
-  let updatedStoragePolicy = storagePolicy
-  forcedExternal.some((option) => {
-    if (
-      option.optionCategory == clusterName &&
-      option.optionLabel == attributeName
-    ) {
-      updatedStoragePolicy = dbEnum.storagePolicy.attributeAccessInterface
-      return true
-    }
-    return false
-  })
-  return updatedStoragePolicy
+  try {
+    let updatedStoragePolicy = storagePolicy
+    forcedExternal.some((option) => {
+      if (
+        option.optionCategory == clusterName &&
+        option.optionLabel == attributeName
+      ) {
+        updatedStoragePolicy = dbEnum.storagePolicy.attributeAccessInterface
+        return true
+      }
+      return false
+    })
+    return updatedStoragePolicy
+  } catch (error) {
+    console.error('Error computing storage import:', error)
+    throw error // Rethrow the error for further handling if necessary
+  }
 }
 
 exports.getForcedExternalStorage = getForcedExternalStorage

--- a/src-electron/sdk/matter.js
+++ b/src-electron/sdk/matter.js
@@ -18,7 +18,6 @@
 const dbApi = require('../db/db-api.js')
 const queryPackage = require('../db/query-package.js')
 const queryCluster = require('../db/query-cluster.js')
-const queryAttribute = require('../db/query-attribute.js')
 const dbEnum = require('../../src-shared/db-enum.js')
 
 /**
@@ -33,7 +32,7 @@ const dbEnum = require('../../src-shared/db-enum.js')
  */
 
 async function getForcedExternalStorage(db) {
-  let forcedExternal = queryPackage.getAttributeAccessInterface(
+  let forcedExternal = await queryPackage.getAttributeAccessInterface(
     db,
     dbEnum.storagePolicy.attributeAccessInterface
   )

--- a/src-electron/sdk/matter.js
+++ b/src-electron/sdk/matter.js
@@ -26,7 +26,7 @@ const dbEnum = require('../../src-shared/db-enum.js')
  * associated with the specified package ID.
  *
  * @param {Object} db - Database connection object.
- * @param {Number} packageId - The ID of the package to query.
+ * @param {Number} packageIds - The ID of the packages to query.
  * @returns {Promise<Array>} A promise that resolves to an array of forced external storage settings.
  */
 

--- a/src-electron/sdk/matter.js
+++ b/src-electron/sdk/matter.js
@@ -58,14 +58,15 @@ async function getForcedExternalStorage(db, packageId) {
 async function computeStoragePolicyForGlobalAttributes(
   db,
   clusterId,
-  attributes
+  attributes,
+  packageId
 ) {
   let forcedExternal
   let clusterName = await queryCluster.selectClusterName(db, clusterId)
   return Promise.all(
     attributes.map(async (attribute) => {
       if (attribute.clusterId == null) {
-        forcedExternal = await getForcedExternalStorage(db, attribute.id)
+        forcedExternal = await getForcedExternalStorage(db, packageId)
         forcedExternal.some((option) => {
           if (
             option.optionCategory == clusterName &&

--- a/src-electron/sdk/matter.js
+++ b/src-electron/sdk/matter.js
@@ -32,10 +32,15 @@ const dbEnum = require('../../src-shared/db-enum.js')
 
 async function getForcedExternalStorage(db, packageIds) {
   try {
+    // Ensure packageIds is an array
+    const packageIdsArray = Array.isArray(packageIds)
+      ? packageIds
+      : [packageIds]
+
     let forcedExternal = await queryPackage.getAttributeAccessInterface(
       db,
       dbEnum.storagePolicy.attributeAccessInterface,
-      packageIds
+      packageIdsArray
     )
     return forcedExternal
   } catch (error) {

--- a/src-electron/sdk/matter.js
+++ b/src-electron/sdk/matter.js
@@ -30,12 +30,12 @@ const dbEnum = require('../../src-shared/db-enum.js')
  * @returns {Promise<Array>} A promise that resolves to an array of forced external storage settings.
  */
 
-async function getForcedExternalStorage(db, packageId) {
+async function getForcedExternalStorage(db, packageIds) {
   try {
     let forcedExternal = await queryPackage.getAttributeAccessInterface(
       db,
       dbEnum.storagePolicy.attributeAccessInterface,
-      packageId
+      packageIds
     )
     return forcedExternal
   } catch (error) {
@@ -65,7 +65,7 @@ async function computeStoragePolicyForGlobalAttributes(
   db,
   clusterId,
   attributes,
-  packageId
+  packageIds
 ) {
   try {
     let forcedExternal
@@ -73,7 +73,7 @@ async function computeStoragePolicyForGlobalAttributes(
     return Promise.all(
       attributes.map(async (attribute) => {
         if (attribute.clusterId == null) {
-          forcedExternal = await getForcedExternalStorage(db, packageId)
+          forcedExternal = await getForcedExternalStorage(db, packageIds)
           forcedExternal.some((option) => {
             if (
               option.optionCategory == clusterName &&

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -2310,13 +2310,14 @@ async function parseattributeAccessInterfaceAttributes(
   pkgRef,
   attributeAccessInterfaceAttributes
 ) {
-  // Use forEach for side effects without expecting a return value
-  Object.keys(attributeAccessInterfaceAttributes).forEach(async (cluster) => {
+  const clusters = Object.keys(attributeAccessInterfaceAttributes)
+  for (let i = 0; i < clusters.length; i++) {
+    const cluster = clusters[i]
     const values = attributeAccessInterfaceAttributes[cluster]
     // Prepare the data for insertion
-    const optionsKeyValues = values.map((optionValue) => ({
+    const optionsKeyValues = values.map((attribute) => ({
       code: dbEnum.storagePolicy.attributeAccessInterface,
-      label: optionValue,
+      label: attribute,
     }))
     // Insert the data into the database
     try {
@@ -2329,7 +2330,7 @@ async function parseattributeAccessInterfaceAttributes(
     } catch (error) {
       console.error(`Error inserting attributes for cluster ${cluster}:`, error)
     }
-  })
+  }
 }
 
 /**

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -2298,6 +2298,9 @@ async function parseBoolOptions(db, pkgRef, booleanCategories) {
  * by mapping its values to a specific structure and then inserting them into the database using
  * the insertOptionsKeyValues function.
  *
+ * The main purpose of this function is to store cluster/attribute pairs to include global attributes and their cluster pair
+ * The ATTRIBUTE table has cluster_ref as null for global attributes so this second method was necessary
+ *
  * @param {*} db - The database connection object.
  * @param {*} pkgRef - The package reference id for which the attributes are being parsed.
  * @param {*} attributeAccessInterfaceAttributes - An object containing the attribute access interface attributes,

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -2298,7 +2298,7 @@ async function parseBoolOptions(db, pkgRef, booleanCategories) {
  * by mapping its values to a specific structure and then inserting them into the database using
  * the insertOptionsKeyValues function.
  *
- * The main purpose of this function is to store cluster/attribute pairs to include global attributes and their cluster pair
+ * The main purpose of this function is to store cluster/attribute pairs including global attributes and their cluster pair
  * The ATTRIBUTE table has cluster_ref as null for global attributes so this second method was necessary
  *
  * @param {*} db - The database connection object.

--- a/test/matter.test.js
+++ b/test/matter.test.js
@@ -4,8 +4,6 @@ const env = require('../src-electron/util/env')
 const dbApi = require('../src-electron/db/db-api')
 const zclLoader = require('../src-electron/zcl/zcl-loader')
 
-const testFile = testUtil.matterTestFile.matterTest
-
 beforeAll(async () => {
   env.setDevelopmentEnv()
   let file = env.sqliteTestFile('gen-matter-1')

--- a/test/matter.test.js
+++ b/test/matter.test.js
@@ -1,0 +1,32 @@
+const matter = require('../src-electron/sdk/matter.js')
+const testUtil = require('./test-util')
+const env = require('../src-electron/util/env')
+const dbApi = require('../src-electron/db/db-api')
+const zclLoader = require('../src-electron/zcl/zcl-loader')
+
+const testFile = testUtil.matterTestFile.matterTest
+
+beforeAll(async () => {
+  env.setDevelopmentEnv()
+  let file = env.sqliteTestFile('gen-matter-1')
+  db = await dbApi.initDatabaseAndLoadSchema(
+    file,
+    env.schemaFile(),
+    env.zapVersion()
+  )
+  let ctx = await zclLoader.loadZcl(db, env.builtinMatterZclMetafile())
+  zclPackageId = ctx.packageId
+}, testUtil.timeout.long())
+
+test(
+  'forced external',
+  async () => {
+    let forcedExternal = await matter.getForcedExternalStorage(db, zclPackageId)
+    expect(forcedExternal.length).toBeGreaterThan(0)
+    forcedExternal.forEach((item) => {
+      expect(item).toHaveProperty('optionLabel')
+      expect(item).toHaveProperty('optionCategory')
+    })
+  },
+  testUtil.timeout.long()
+)

--- a/test/matter.test.js
+++ b/test/matter.test.js
@@ -3,6 +3,7 @@ const testUtil = require('./test-util')
 const env = require('../src-electron/util/env')
 const dbApi = require('../src-electron/db/db-api')
 const zclLoader = require('../src-electron/zcl/zcl-loader')
+const dbEnum = require('../src-shared/db-enum.js')
 
 beforeAll(async () => {
   env.setDevelopmentEnv()
@@ -28,3 +29,13 @@ test(
   },
   testUtil.timeout.long()
 )
+test('compute storage policy new config', async () => {
+  const result1 = await matter.computeStorageOptionNewConfig(
+    dbEnum.storagePolicy.attributeAccessInterface
+  )
+  expect(result1).toEqual(dbEnum.storageOption.external)
+  const result2 = await matter.computeStorageOptionNewConfig(
+    dbEnum.storagePolicy.any
+  )
+  expect(result2).toEqual(dbEnum.storageOption.ram)
+})


### PR DESCRIPTION
Fixes https://github.com/project-chip/zap/issues/1397

This pull request retrieves the cluster/attribute pairs for all attributeAccessInterface attributes, including those of the list type.

Background: The ATTRIBUTE table designates CLUSTER_REF as null for global attributes.

To incorporate cluster/attribute pairs that are global attributes, the attributeAccessInterface list from zcl.json needs to be imported into an alternative table, PACKAGE_OPTION.

Given that PACKAGE_OPTION exclusively contains pairs enumerated in zcl.json and does not encompass all attributeAccessInterface pairings, it becomes essential to query both the ATTRIBUTE and PACKAGE_OPTION tables.