### PR TITLE
Fix row number discrepancy in Matter attributes

### DIFF
--- a/src/components/ZclAttributeManager.vue
+++ b/src/components/ZclAttributeManager.vue
@@ -36,11 +36,7 @@ limitations under the License.
       id="ZclAttributeManager"
     >
       <template v-slot:body="props">
-        <q-tr
-          :props="props"
-          class="table_body attribute_table_body"
-          v-if="!globalLists.includes(props.row.label)"
-        >
+        <q-tr :props="props" class="table_body attribute_table_body">
           <q-td
             key="status"
             :props="props"

--- a/src/util/editable-attributes-mixin.js
+++ b/src/util/editable-attributes-mixin.js
@@ -41,13 +41,7 @@ export default {
                   .includes(this.individualClusterFilterString.toLowerCase())
           })
           .filter((attribute) => {
-            const globalLists = [
-              'EventList',
-              'AttributeList',
-              'GeneratedCommandList',
-              'AcceptedCommandList',
-            ]
-            return !globalLists.includes(attribute.label)
+            return !this.globalLists.includes(attribute.label)
           })
       },
     },

--- a/src/util/editable-attributes-mixin.js
+++ b/src/util/editable-attributes-mixin.js
@@ -40,6 +40,15 @@ export default {
                   .toLowerCase()
                   .includes(this.individualClusterFilterString.toLowerCase())
           })
+          .filter((attribute) => {
+            const globalLists = [
+              'EventList',
+              'AttributeList',
+              'GeneratedCommandList',
+              'AcceptedCommandList',
+            ]
+            return !globalLists.includes(attribute.label)
+          })
       },
     },
     selection: {

--- a/src/util/ui-options.js
+++ b/src/util/ui-options.js
@@ -26,12 +26,6 @@ export default {
       enableServerOnly: false,
       enableSingleton: false,
       enableBounded: false,
-      globalLists: [
-        'EventList',
-        'AttributeList',
-        'GeneratedCommandList',
-        'AcceptedCommandList',
-      ],
     }
   },
   mounted() {

--- a/src/util/ui-options.js
+++ b/src/util/ui-options.js
@@ -26,6 +26,12 @@ export default {
       enableServerOnly: false,
       enableSingleton: false,
       enableBounded: false,
+      globalLists: [
+        'EventList',
+        'AttributeList',
+        'GeneratedCommandList',
+        'AcceptedCommandList',
+      ],
     }
   },
   mounted() {


### PR DESCRIPTION
- fix issue #1399

- exclude global attributes from relevantAttributeData to make row number aligns with rendered rows