### PR TITLE
added triggers to check for and handle code conflicts in custom XMLs and updated relevant tests

### DIFF
--- a/test/resource/custom-cluster/matter-conflict.xml
+++ b/test/resource/custom-cluster/matter-conflict.xml
@@ -26,4 +26,12 @@ limitations under the License.
         <!-- A simple boolean attribute that flips or flops -->
         <attribute side="server" code="0x0000" define="FLIP_FLOP" type="BOOLEAN" writable="true" default="false" optional="false">FlipFlop</attribute>
 </cluster>
+
+<clusterExtension code="0x0006">
+    <attribute side="server" code="0xFFF10000" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME_2" type="INT8U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">Sample Mfg Specific Attribute 2 Conflict</attribute>
+        <command source="client" code="0xFFF100" name="SampleMfgSpecificOnWithTransition2Conflict" optional="true">
+        <description>Client command that turns the device on with a transition given
+        by the transition time in the Ember Sample transition time attribute.</description>
+    </command>
+</clusterExtension>
 </configurator>


### PR DESCRIPTION
- Added triggers to check for mfg code and code conflicts in custom xml. 
- When a session package (that is a manufacturer specific custom xml) is inserted or re-enabled these triggers check for the following:
    * If any other custom XMLs linked to the same session have cluster code conflicts
    * If any other custom XMLs extend the same cluster and have attribute or command code conflicts
- and adds the relevant session notifications
- Also added triggers to delete all code conflict session notifications related to a session package when that session package is deleted/disabled
- Updated relevant tests to check for these session notifications
    
ZAPP-1467

