### PR TITLE
adding Unify code generation diff check

### DIFF
--- a/.github/workflows/unify.yml
+++ b/.github/workflows/unify.yml
@@ -1,0 +1,71 @@
+name: Unify code generation
+
+permissions:
+  contents: write
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  ZAP_TEST_TIMEOUT: 3600000
+  ZAP_TEMPSTATE: 1
+  BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+  P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+  TRUSTED_CERTIFICATE_BASE64: ${{ secrets.TRUSTED_CERTIFICATE_BASE64 }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  KEYCHAIN_PASSWORD: silabs
+
+jobs:
+  prepare-zap-and-regenerate-zigbee:
+    name: Prepare Zap and regenerate Unify
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+        os: [ubuntu-22.04]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3.0.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: sudo ./src-script/install-packages-ubuntu
+      - run: sudo apt-get install --fix-missing libxml2-utils
+      - run: node --version
+      - run: npm --version
+      - run: npm ci
+      - run: npm rebuild canvas --update-binary
+      - run: npm rebuild libxmljs --update-binary
+      - run: npm run metafile-check
+      - run: npm run version-stamp
+      - run: npm run build-spa
+      - run: npm run self-check
+
+      - name: Clone the Unify SDK
+        env:
+          GIT_CLONE_PROTECTION_ACTIVE: false
+        run: git clone https://github.com/SiliconLabs/UnifySDK.git unify_sdk
+
+      - name: Regen zap files with the cloned sdk, using latest.
+        run: node ./src-script/unify-regen.js ./unify_sdk/
+
+      - name: Check for differences in the cloned repository
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Changes detected."
+            exit 1
+          else
+            echo "No untracked or modified files detected."
+            exit 0
+          fi
+        working-directory: unify_sdk
+
+      - name: Show differences if any
+        if: failure()
+        run: git status --porcelain
+        working-directory: unify_sdk

--- a/src-script/unify-regen.js
+++ b/src-script/unify-regen.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ *
+ *    Copyright (c) 2023 Silicon Labs
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+const fs = require('fs')
+const path = require('path')
+const process = require('process')
+const scriptUtil = require('./script-util')
+
+const unifySdkPath = process.argv[2]
+if (!unifySdkPath) {
+  throw Error('Missing Argument. Usage: unify-regen.js <unify_sdk_path>')
+}
+
+async function generateZapFiles() {
+  try {
+    // get the Zcl file
+    const zclFile = `${unifySdkPath}components/uic_dotdot/dotdot-xml/library.xml`
+    if (!fs.existsSync(zclFile)) {
+      throw Error(`Invalid Zcl File ${zclFile} does not exist.`)
+    } else {
+      console.log(`👍 ZCL metafile: ${zclFile}`)
+    }
+
+    // get all template files in the unify sdk
+    const templateFiles = await scriptUtil.locateRecursively(
+      unifySdkPath,
+      'gen-templates.json'
+    )
+    if (templateFiles.length === 0) {
+      throw Error(`No template files found in ${unifySdkPath}`)
+    } else {
+      console.log(`👍 Found ${templateFiles.length} template files.`)
+    }
+
+    // get ZAP main path
+    const zapCli = scriptUtil.mainPath(false)
+
+    for (const templateFile of templateFiles) {
+      // get the output directory as per unify sdk structure
+      const outputDir = path.join(
+        path.dirname(path.dirname(templateFile)),
+        'zap-generated'
+      )
+      fs.rmSync(outputDir, { recursive: true, force: true })
+
+      let cmdArgs = [
+        'node',
+        scriptUtil.mainPath(false),
+        'generate',
+        '--unhandled-rejections=strict',
+        '--tempState' // consecutive generation of zap files breaks without this flag
+      ]
+      cmdArgs.push('-o')
+      cmdArgs.push(outputDir)
+      cmdArgs.push('--gen')
+      cmdArgs.push(templateFile)
+      cmdArgs.push('--zcl')
+      cmdArgs.push(zclFile)
+
+      await scriptUtil.executeCmd(null, 'npx', cmdArgs)
+    }
+  } catch (error) {
+    throw Error('An error occurred during the ZAP generation process:', error)
+  }
+}
+
+generateZapFiles()


### PR DESCRIPTION
Added Unify code generation diff check job:
- Clones the Unify SDK
- Regenerates all the ZAP generated files using working branch of ZAP
- Checks for git diff (fails if there is a diff)