### PR TITLE
Fix commands not displayed in Matter clusters

### DIFF
--- a/src/components/ZclCommandManager.vue
+++ b/src/components/ZclCommandManager.vue
@@ -22,7 +22,6 @@ limitations under the License.
         :columns="columns"
         row-key="<b>name</b>"
         dense
-        virtual-scroll
         flat
         binary-state-sort
         v-model:pagination="pagination"
@@ -226,7 +225,7 @@ export default {
       validationErrorMessage:
         'This command is mandatory for the cluster and device type configuration you have enabled',
       pagination: {
-        rowsPerPage: 0
+        rowsPerPage: 50
       },
       columns: [
         {


### PR DESCRIPTION
- Fixed issue #1424.

- Removed virtual scroll to ensure all commands are properly displayed.

- Added pagination of 50 rows, same as the approach used for attributes.