### PR TITLE
ZAPP-1183 added clean script to build release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,15 +210,9 @@ jobs:
       - name: Build & Release for Windows / Mac universal binary on macOS
         if: startsWith(matrix.os, 'macos')
         run: |
-          npm run pack:win
-          npm run pkg:win
-          ls ./dist/
-          npm run pack:cli:win
+          node src-script/build-release-package.js --platform w
 
-          npm run pack:mac
-          npm run pkg:mac
-          ls ./dist/
-          npm run pack:cli:mac
+          node src-script/build-release-package.js --platform m
 
         env:
           GH_TOKEN: ${{ secrets.github_token }}
@@ -230,10 +224,7 @@ jobs:
       - name: Build & Release for Linux
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          npm run pack:linux
-          npm run pkg:linux
-          ls ./dist/
-          npm run pack:cli:linux
+          node src-script/build-release-package.js --platform l
 
           mv dist/zap-linux-amd64.deb dist/zap-linux-x64.deb
           mv dist/zap-linux-x86_64.rpm dist/zap-linux-x64.rpm

--- a/docs/development-instructions.md
+++ b/docs/development-instructions.md
@@ -99,26 +99,27 @@ npm run apidoc
 
 See [Configuring quasar.conf.js](https://quasar.dev/quasar-cli/quasar-conf-js).
 
+**Building Release Packages locally**
+
 **Build & Release for Windows / Mac universal binary on macOS:**
 
-```npm run pack:win
-   npm run pkg:win
-   ls ./dist/
-   npm run pack:cli:win
+```
+npm run dist:win \\ Windows
 
-   npm run pack:mac
-   npm run pkg:mac
-   ls ./dist/
-   npm run pack:cli:mac
+npm run dist:mac \\ Mac
 ```
 
 **Build & Release for Linux:**
 
-```npm run pack:linux
-   npm run pkg:linux
-   ls ./dist/
-   npm run pack:cli:linux
-
-   mv dist/zap-linux-amd64.deb dist/zap-linux-x64.deb
-   mv dist/zap-linux-x86_64.rpm dist/zap-linux-x64.rpm
 ```
+npm run dist:linux
+```
+
+Running the following will detect and build for the os user's machine is on.
+
+```
+npm run dist
+
+```
+
+All release packages built will be found at `dist/release` and any other files from the build process will be found at `dist`.

--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
     "pkg-use-local-fork": "node ../pkg/lib-es5/bin.js -t node18-linux-x64 --output dist/zap-linux --compress GZip --options max-old-space-size=4096 .",
     "pkg:win": "npx pkg -t node18-win-x64,node18-win-arm64 --public --no-bytecode --output dist/zap-win --compress GZip --options max-old-space-size=4096 .",
     "pkg:mac": "npx pkg -t node18-macos-x64 --output dist/zap-macos --compress GZip --options max-old-space-size=4096 .",
+    "dist": "node src-script/build-release-package.js --output dist/release",
+    "dist:mac": "node src-script/build-release-package.js --platform m --output dist/release",
+    "dist:win": "node src-script/build-release-package.js --platform w --output dist/release",
+    "dist:linux": "node src-script/build-release-package.js --platform l --output dist/release",
+    "dist:all": "node src-script/build-release-package.js --platform mwl --output dist/release",
     "mattersdk": "node src-script/zap-start.js regenerateSdk --sdk ~/git/matter/scripts/tools/sdk.json",
     "metasdk": "node src-script/zap-start.js regenerateSdk --sdk test/resource/meta/sdk.json",
     "zip": "node ./src-script/7zip-bin-wrapper.js"

--- a/src-script/build-release-package.js
+++ b/src-script/build-release-package.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ *
+ *    Copyright (c) 2023 Silicon Labs
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+const scriptUtil = require('./script-util.js')
+const os = require('os')
+const path = require('path')
+const fs = require('fs')
+const yargs = require('yargs/yargs')
+const { hideBin } = require('yargs/helpers')
+
+/**
+ *
+ * @param {*} osName
+ * @param {*} outputPath
+ */
+async function buildForOS(osName, outputPath) {
+  switch (osName) {
+    case 'm':
+      console.log(`Building for Mac... Output: ${outputPath}`)
+      await scriptUtil.executeCmd({}, 'npm', ['run', 'pack:mac']) // Building electron app
+      await scriptUtil.executeCmd({}, 'npm', ['run', 'pkg:mac']) // Building zap-cli
+      await scriptUtil.executeCmd({}, 'npm', ['run', 'pack:cli:mac']) // Adding zap-cli to zip file
+      if (outputPath) {
+        await scriptUtil.executeCmd({}, 'mv', [
+          './dist/zap-mac-x64.zip',
+          path.join(outputPath, 'zap-mac-x64.zip')
+        ])
+        await scriptUtil.executeCmd({}, 'mv', [
+          './dist/zap-mac-arm64.zip',
+          path.join(outputPath, 'zap-mac-arm64.zip')
+        ])
+      }
+      break
+
+    case 'w':
+      console.log(`Building for Windows... Output: ${outputPath}`)
+      await scriptUtil.executeCmd({}, 'npm', ['run', 'pack:win']) // Building electron app
+      await scriptUtil.executeCmd({}, 'npm', ['run', 'pkg:win']) // Building zap-cli
+      await scriptUtil.executeCmd({}, 'npm', ['run', 'pack:cli:win']) // Adding zap-cli to zip file
+      if (outputPath) {
+        await scriptUtil.executeCmd({}, 'mv', [
+          'dist/zap-win-x64.zip',
+          path.join(outputPath, 'zap-win-x64.zip')
+        ])
+        await scriptUtil.executeCmd({}, 'mv', [
+          'dist/zap-win-arm64.zip',
+          path.join(outputPath, 'zap-win-arm64.zip')
+        ])
+      }
+      break
+
+    case 'l':
+      console.log(`Building for Linux... Output: ${outputPath}`)
+      await scriptUtil.executeCmd({}, 'npm', ['run', 'pack:linux']) // Building electron app
+      await scriptUtil.executeCmd({}, 'npm', ['run', 'pkg:linux']) // Building zap-cli
+      await scriptUtil.executeCmd({}, 'npm', ['run', 'pack:cli:linux']) // Adding zap-cli to zip file
+      if (outputPath) {
+        await scriptUtil.executeCmd({}, 'mv', [
+          'dist/zap-linux-x64.zip',
+          path.join(outputPath, 'zap-linux-x64.zip')
+        ])
+        await scriptUtil.executeCmd({}, 'mv', [
+          'dist/zap-linux-arm64.zip',
+          path.join(outputPath, 'zap-linux-arm64.zip')
+        ])
+        await scriptUtil.executeCmd({}, 'mv', [
+          'dist/zap-linux-amd64.deb',
+          path.join(outputPath, 'zap-linux-amd64.deb')
+        ])
+        await scriptUtil.executeCmd({}, 'mv', [
+          'dist/zap-linux-x64_64.rpm',
+          path.join(outputPath, 'zap-linux-x64_64.rpm')
+        ])
+      }
+      break
+
+    default:
+      console.error(`Error: Unsupported platform: ${osName}`)
+      process.exit(1)
+  }
+}
+
+const argv = yargs(hideBin(process.argv))
+  .option('platform', {
+    alias: 'p',
+    type: 'string',
+    description: 'Specify the platform(s) to build for (m, w, l)'
+  })
+  .option('output', {
+    alias: 'o',
+    type: 'string',
+    description: 'Specify the output directory for the build files'
+  })
+  .help()
+  .strict().argv
+
+let targets = argv.platform
+let outputPath = argv.output
+
+if (outputPath && !fs.existsSync(outputPath)) {
+  fs.mkdirSync(outputPath, { recursive: true })
+  console.log(`Created output directory: ${outputPath}`)
+}
+
+if (!targets) {
+  const currentPlatform = os.platform()
+  switch (currentPlatform) {
+    case 'darwin':
+      targets = 'm' // Mac
+      break
+    case 'win32':
+      targets = 'w' // Windows
+      break
+    case 'linux':
+      targets = 'l' // Linux
+      break
+    default:
+      console.error(`Error: Unsupported platform: ${currentPlatform}`)
+      process.exit(1)
+  }
+  console.log(`No target specified. Defaulting to current system: ${targets}`)
+}
+
+const targetPlatforms = targets.split('')
+
+targetPlatforms.forEach(async (target) => {
+  await buildForOS(target, outputPath)
+})


### PR DESCRIPTION
* added clean script to build release packages

* script can be used in CI and locally

* modified instructions to build binaries locally

* modified release workflow to use build-release-package.js script