### PR TITLE
handling enums and bitmaps declared as unsigned integers in Unify XML

### DIFF
--- a/src-electron/zcl/zcl-loader-dotdot.js
+++ b/src-electron/zcl/zcl-loader-dotdot.js
@@ -950,10 +950,10 @@ async function processString(db, filePath, packageId, data) {
 function prepareEnumsOrBitmaps(a, dataTypeRef, dataType) {
   if (a.type.toLowerCase().includes('uint')) {
     let correctedType = dataType == dbEnum.zclType.enum ? 'enum' : 'map'
-    a.type = a.type.toLowerCase().replace('uint', correctedType)
     env.logWarning(
-      `Warning: ${correctedType} ${a.name} is declared as uint in Unify XMLs. Replacing with ${correctedType} -${a.type}`
+      `Warning: ${a.name} is declared incorrectly as ${a.type} in XML. Replace ${a.type} with ${correctedType} type.`
     )
+    a.type = a.type.toLowerCase().replace('uint', correctedType)
   }
   return {
     name: a.name,


### PR DESCRIPTION
Unify XMLs have some enums and bitmaps declared as unsigned integers. While they work on cleaning up their XML - added support in ZAP to infer these inconsistencies correctly.
