### PR TITLE
Support Parsing "name" inside Attribute Tag

### DIFF
--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -584,6 +584,9 @@ function prepareCluster(cluster, context, isExtension = false) {
     cluster.attribute.forEach((attribute) => {
       let name = attribute._
       let quality = null
+      if (attribute.$ && name == null) {
+        name = attribute.$.name
+      }
       if ('description' in attribute && name == null) {
         name = attribute.description.join('')
       }


### PR DESCRIPTION
- Support parsing attribute name with new format: `<attribute name="attributeName">`
- Will not affect current parsing format including `<attribute>attributeName</attribute>` and `<description> attributeName</description>`
- Required by [#36223](https://github.com/project-chip/connectedhomeip/pull/36233) as CHIP XMLs are moving to the new format