### PR TITLE
Restructure getEndpointIds function to pass ui.test.js

### DIFF
--- a/src/components/ZclCreateModifyEndpoint.vue
+++ b/src/components/ZclCreateModifyEndpoint.vue
@@ -544,9 +544,11 @@ export default {
       }
     },
     getEndpointIds() {
-      this.$store.dispatch('zap/getEndpointIds').then((res) => {
-        this.endpointIds = res.data
-      })
+      if (this.$serverGet != null) {
+        this.$serverGet(RestApi.uri.endpointIds).then((resp) => {
+          this.endpointIds = resp.data
+        })
+      }
     },
     // This function will close the endpoint modal
     toggleCreateEndpointModal() {

--- a/src/store/zap/actions.js
+++ b/src/store/zap/actions.js
@@ -514,14 +514,6 @@ export function addEndpoint(context, newEndpointContext) {
 }
 
 /**
- * Get endpoint ids.
- * @returns endpoints ids
- */
-export async function getEndpointIds() {
-  return await axiosRequests.$serverGet(restApi.uri.endpointIds)
-}
-
-/**
  * Add endpoint type for ZAP UI.
  * @param {*} context
  * @param {*} endpointTypeData


### PR DESCRIPTION
- call API directly without action
- check if $serverGet is defined before calling it
- the change would help #1482 pass unit tests and prevent `ui.test.js` from failing in the future