### PR TITLE
Feature Page Improvement: Display attribute conformance warning when open ZAP file

### DIFF
--- a/src-electron/db/query-command.js
+++ b/src-electron/db/query-command.js
@@ -2051,7 +2051,7 @@ async function selectNonManufacturerSpecificCommandDetailsFromAllEndpointTypesAn
 /**
  * Get all commands in an endpoint type cluster
  * Non-required commands are not loaded into ENDPOINT_TYPE_COMMAND table,
- * so we need to load all commands by joining DEVICE_TYPE_COMMAND table
+ * so we need to load all commands by joining DEVICE_TYPE_CLUSTER table
  * @param {*} db
  * @param {*} endpointTypeClusterId
  * @param {*} deviceTypeClusterId

--- a/src-electron/db/query-event.js
+++ b/src-electron/db/query-event.js
@@ -236,7 +236,7 @@ ORDER BY
 /**
  * Get all events in an endpoint type cluster
  * Disabled events are not loaded into ENDPOINT_TYPE_EVENT table,
- * so we need to load all events by joining DEVICE_TYPE_EVENT table
+ * so we need to load all events by joining DEVICE_TYPE_CLUSTER table
  *
  * @param {*} db
  * @param {*} endpointTypeClusterId

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -112,9 +112,10 @@ async function getEndpointTypeElements(
   deviceTypeClusterId
 ) {
   let [attributes, commands, events] = await Promise.all([
-    queryAttribute.selectAttributesByEndpointTypeClusterId(
+    queryAttribute.selectAttributesByEndpointTypeClusterIdAndDeviceTypeClusterId(
       db,
-      endpointTypeClusterId
+      endpointTypeClusterId,
+      deviceTypeClusterId
     ),
     queryCommand.selectCommandsByEndpointTypeClusterIdAndDeviceTypeClusterId(
       db,

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -623,10 +623,10 @@ describe('Endpoint Type Config Queries', () => {
       let expectedNumbers = {
         Identify: {
           server: { attributes: 2, commands: 6 },
-          client: { attributes: 1, commands: 6 }
+          client: { attributes: 2, commands: 6 }
         },
-        Basic: { server: { attributes: 3, commands: 1 } },
-        'On/off': { client: { attributes: 1, commands: 11 } }
+        Basic: { server: { attributes: 18, commands: 1 } },
+        'On/off': { client: { attributes: 9, commands: 11 } }
       }
       let deviceTypeClusters =
         await queryDeviceType.selectDeviceTypeClustersByDeviceTypeRef(
@@ -646,9 +646,10 @@ describe('Endpoint Type Config Queries', () => {
             if (deviceTypeCluster) {
               let deviceTypeClusterId = deviceTypeCluster.id
               queryAttribute
-                .selectAttributesByEndpointTypeClusterId(
+                .selectAttributesByEndpointTypeClusterIdAndDeviceTypeClusterId(
                   db,
-                  endpointTypeClusterId
+                  endpointTypeClusterId,
+                  deviceTypeClusterId
                 )
                 .then((attributes) => {
                   expect(attributes.length).toBe(


### PR DESCRIPTION
- Updated endpoint type attribute query to join DEVICE_TYPE_CLUSTER table, ensuring disabled attributes are retrieved when opening a ZAP file.
- Fixed bug where element conformance warnings were not displayed after opening a ZAP file.
- Adapted unit tests to changes in the functions.