### PR TITLE
Studio V6 Add WebSocket listener to track unsaved changes and update dirty state for ZAP configuration

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -339,8 +339,8 @@ export default defineComponent({
         }
       )
 
-      this.$onWebSocket(dbEnum.wsCategory.dirtyFlag, (resp) => {
-        this.$store.dispatch('zap/setDirtyState', resp)
+      this.$onWebSocket(dbEnum.wsCategory.dirtyFlag, () => {
+        this.$store.dispatch('zap/setDirtyState')
       })
     },
     addClassToBody() {

--- a/src/store/zap/actions.js
+++ b/src/store/zap/actions.js
@@ -1281,10 +1281,11 @@ export function updateSelectedUcComponentState(context, projectInfo) {
 /**
  * Set the dirty state for ZAP config when there are unsaved changes.
  * @param {*} context
- * @param {*} isDirty
  */
-export function setDirtyState(context, isDirty) {
-  context.commit('setDirtyState', isDirty)
+export function setDirtyState(context) {
+  axiosRequests.$serverGet(restApi.ide.isDirty).then((resp) => {
+    context.commit('setDirtyState', resp.data.DIRTY)
+  })
 }
 
 /**


### PR DESCRIPTION
This pull request introduces functionality to track and manage the "dirty" state of ZAP configuration by listening for WebSocket events indicating unsaved changes. Specifically, the code listens for the dirtyFlag WebSocket event, and upon receiving this event, it triggers an action to update the application's dirty state.

**Changes:**

**WebSocket listener:** Added a WebSocket listener for the dirtyFlag event, which dispatches the setDirtyState action to update the application state when unsaved changes are detected.
**Action:** The setDirtyState action is responsible for fetching the current dirty state from the backend using the isDirty API endpoint and committing the result to the store.
**Mutation:** The setDirtyState mutation updates the state with the new dirty flag (isDirty) and sends a postMessage to the parent window to notify about the state change.


**Detailed Changes:**

**WebSocket Listener:**
Listens for the dirtyFlag event (dbEnum.wsCategory.dirtyFlag).
Dispatches the zap/setDirtyState action when the event is received.
**setDirtyState Action:**
Calls the backend API (restApi.ide.isDirty) to check if there are unsaved changes.
Commits the result (DIRTY status) to the store using the mutation.
**setDirtyState Mutation:**
Updates the Vuex state with the new isDirty value.
Sends a message to the parent window indicating the new dirty state, enabling external applications or processes to be aware of unsaved changes.


**Purpose:**

Ensure the application's dirty state is accurately tracked when there are unsaved changes in the ZAP configuration.
Improve integration with external systems by notifying them of dirty state changes through postMessage.