### PR TITLE
Fix: Re-enable existing session package instead of adding duplicate

### DIFF
--- a/src-electron/db/query-session.js
+++ b/src-electron/db/query-session.js
@@ -488,17 +488,22 @@ async function selectSessionPartitionInfoFromDeviceType(
 }
 
 /**
- * Retrieve session partition infor from session id and package id.
+ * Retrieve session partition info from session id and package id.
  * @param {*} db
  * @param {*} sessionId
  * @param {*} packageIds
+ * @param {*} isEnabledSessionPackages - flag to filter only enabled session packages (default is true)
  * @returns session partition info
  */
 async function selectSessionPartitionInfoFromPackageId(
   db,
   sessionId,
-  packageIds
+  packageIds,
+  isEnabledSessionPackages = true
 ) {
+  let enabledCondition = isEnabledSessionPackages
+    ? 'AND SESSION_PACKAGE.ENABLED=1'
+    : ''
   let rows = await dbApi.dbAll(
     db,
     `
@@ -520,8 +525,7 @@ async function selectSessionPartitionInfoFromPackageId(
       SESSION_PARTITION.SESSION_REF = ?
     AND
       SESSION_PACKAGE.PACKAGE_REF IN (${packageIds})
-    AND
-      SESSION_PACKAGE.ENABLED=1`,
+    ${enabledCondition}`,
     [sessionId]
   )
   return rows.map(dbMapping.map.sessionPartition)

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -661,33 +661,8 @@ function httpPostAddNewPackage(db) {
           err: data.err.message
         }
       } else {
-        // Check if session partition for package exists. If not then add it.
-        let sessionPartitionInfoForNewPackage =
-          await querySession.selectSessionPartitionInfoFromPackageId(
-            db,
-            sessionId,
-            data.packageId
-          )
-        if (sessionPartitionInfoForNewPackage.length == 0) {
-          let sessionPartitionInfo =
-            await querySession.getAllSessionPartitionInfoForSession(
-              db,
-              sessionId
-            )
-          let sessionPartitionId = await querySession.insertSessionPartition(
-            db,
-            sessionId,
-            sessionPartitionInfo.length + 1
-          )
-          await queryPackage.insertSessionPackage(
-            db,
-            sessionPartitionId,
-            data.packageId,
-            true
-          )
-        }
         status = {
-          isValid: true,
+          isValid: data.succeeded,
           sessionId: sessionId
         }
       }


### PR DESCRIPTION
- Ensure that when a package is added to a session where a session package with the given package ID already exists, the existing session package is re-enabled instead of creating a new session package.
- Removed redundant code in httpPostAddNewPackage()
- Added tests

ZAPP-1582