### PR TITLE
Update caniuse-lite package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9751,9 +9751,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001649",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz",
-      "integrity": "sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==",
+      "version": "1.0.30001697",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Unit tests were failing when running locally due to the outdated `caniuse-lite` package. Running ZAP and unit tests displayed the following warning:

```
⇝ Browserslist: caniuse-lite is outdated. Please run:
   npx update-browserslist-db@latest
```

This PR updates `caniuse-lite` by executing the command above, removing the warning and helping the test failures.