### PR TITLE
Fixing unintentional draft release creation upon tag push

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,6 +271,7 @@
         }
       ]
     },
+    "publish": null,
     "directories": {
       "buildResources": "resource-build",
       "output": "dist"


### PR DESCRIPTION
Pushing a tag was creating a release and a duplicate draft release with the same tag name. This draft release was unintended and was being caused by electron-builders publish behavior. Fixing this by disabling "publish" in electron-builder config.