### PR TITLE
Exclude Features with Disallowed Conformance from Bitmaps

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20121,6 +20121,7 @@ This module provides the APIs for dotdot Loading
     * [~parseFeatureFlags(db, packageId, featureFlags)](#module_Loader API_ Loader APIs..parseFeatureFlags) ⇒
     * [~parseConformanceFromXML(operand)](#module_Loader API_ Loader APIs..parseConformanceFromXML) ⇒
     * [~parseConformanceRecursively(operand, depth, parentJoinChar)](#module_Loader API_ Loader APIs..parseConformanceRecursively) ⇒
+    * [~hasAllowedFeatures(features)](#module_Loader API_ Loader APIs..hasAllowedFeatures) ⇒
     * [~parseUiOptions(db, packageId, featureFlags)](#module_Loader API_ Loader APIs..parseUiOptions) ⇒
     * [~parseOptions(db)](#module_Loader API_ Loader APIs..parseOptions) ⇒
     * [~parseTextOptions(db, pkgRef, textOptions)](#module_Loader API_ Loader APIs..parseTextOptions) ⇒
@@ -21530,6 +21531,18 @@ When they appear, stop recursing and return the name inside directly
 | operand | <code>\*</code> |  | 
 | depth | <code>\*</code> | <code>0</code> | 
 | parentJoinChar | <code>\*</code> |  | 
+
+<a name="module_Loader API_ Loader APIs..hasAllowedFeatures"></a>
+
+### Loader API: Loader APIs~hasAllowedFeatures(features) ⇒
+Check if any feature in the cluster has conformance other than disallowed
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: true if any feature has allowed conformance, false otherwise  
+
+| Param | Type |
+| --- | --- |
+| features | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..parseUiOptions"></a>
 
@@ -21955,6 +21968,7 @@ This module provides the APIs for new data model loading
     * [~parseFeatureFlags(db, packageId, featureFlags)](#module_Loader API_ Loader APIs..parseFeatureFlags) ⇒
     * [~parseConformanceFromXML(operand)](#module_Loader API_ Loader APIs..parseConformanceFromXML) ⇒
     * [~parseConformanceRecursively(operand, depth, parentJoinChar)](#module_Loader API_ Loader APIs..parseConformanceRecursively) ⇒
+    * [~hasAllowedFeatures(features)](#module_Loader API_ Loader APIs..hasAllowedFeatures) ⇒
     * [~parseUiOptions(db, packageId, featureFlags)](#module_Loader API_ Loader APIs..parseUiOptions) ⇒
     * [~parseOptions(db)](#module_Loader API_ Loader APIs..parseOptions) ⇒
     * [~parseTextOptions(db, pkgRef, textOptions)](#module_Loader API_ Loader APIs..parseTextOptions) ⇒
@@ -23364,6 +23378,18 @@ When they appear, stop recursing and return the name inside directly
 | operand | <code>\*</code> |  | 
 | depth | <code>\*</code> | <code>0</code> | 
 | parentJoinChar | <code>\*</code> |  | 
+
+<a name="module_Loader API_ Loader APIs..hasAllowedFeatures"></a>
+
+### Loader API: Loader APIs~hasAllowedFeatures(features) ⇒
+Check if any feature in the cluster has conformance other than disallowed
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: true if any feature has allowed conformance, false otherwise  
+
+| Param | Type |
+| --- | --- |
+| features | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..parseUiOptions"></a>
 
@@ -23789,6 +23815,7 @@ This module provides the APIs for ZCL/Data-Model loading.
     * [~parseFeatureFlags(db, packageId, featureFlags)](#module_Loader API_ Loader APIs..parseFeatureFlags) ⇒
     * [~parseConformanceFromXML(operand)](#module_Loader API_ Loader APIs..parseConformanceFromXML) ⇒
     * [~parseConformanceRecursively(operand, depth, parentJoinChar)](#module_Loader API_ Loader APIs..parseConformanceRecursively) ⇒
+    * [~hasAllowedFeatures(features)](#module_Loader API_ Loader APIs..hasAllowedFeatures) ⇒
     * [~parseUiOptions(db, packageId, featureFlags)](#module_Loader API_ Loader APIs..parseUiOptions) ⇒
     * [~parseOptions(db)](#module_Loader API_ Loader APIs..parseOptions) ⇒
     * [~parseTextOptions(db, pkgRef, textOptions)](#module_Loader API_ Loader APIs..parseTextOptions) ⇒
@@ -25198,6 +25225,18 @@ When they appear, stop recursing and return the name inside directly
 | operand | <code>\*</code> |  | 
 | depth | <code>\*</code> | <code>0</code> | 
 | parentJoinChar | <code>\*</code> |  | 
+
+<a name="module_Loader API_ Loader APIs..hasAllowedFeatures"></a>
+
+### Loader API: Loader APIs~hasAllowedFeatures(features) ⇒
+Check if any feature in the cluster has conformance other than disallowed
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: true if any feature has allowed conformance, false otherwise  
+
+| Param | Type |
+| --- | --- |
+| features | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..parseUiOptions"></a>
 
@@ -25623,6 +25662,7 @@ This module provides the APIs for for common functionality related to loading.
     * [~parseFeatureFlags(db, packageId, featureFlags)](#module_Loader API_ Loader APIs..parseFeatureFlags) ⇒
     * [~parseConformanceFromXML(operand)](#module_Loader API_ Loader APIs..parseConformanceFromXML) ⇒
     * [~parseConformanceRecursively(operand, depth, parentJoinChar)](#module_Loader API_ Loader APIs..parseConformanceRecursively) ⇒
+    * [~hasAllowedFeatures(features)](#module_Loader API_ Loader APIs..hasAllowedFeatures) ⇒
     * [~parseUiOptions(db, packageId, featureFlags)](#module_Loader API_ Loader APIs..parseUiOptions) ⇒
     * [~parseOptions(db)](#module_Loader API_ Loader APIs..parseOptions) ⇒
     * [~parseTextOptions(db, pkgRef, textOptions)](#module_Loader API_ Loader APIs..parseTextOptions) ⇒
@@ -27032,6 +27072,18 @@ When they appear, stop recursing and return the name inside directly
 | operand | <code>\*</code> |  | 
 | depth | <code>\*</code> | <code>0</code> | 
 | parentJoinChar | <code>\*</code> |  | 
+
+<a name="module_Loader API_ Loader APIs..hasAllowedFeatures"></a>
+
+### Loader API: Loader APIs~hasAllowedFeatures(features) ⇒
+Check if any feature in the cluster has conformance other than disallowed
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: true if any feature has allowed conformance, false otherwise  
+
+| Param | Type |
+| --- | --- |
+| features | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..parseUiOptions"></a>
 

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -1524,13 +1524,16 @@ async function processBitmapFields(
     'feature' in data.features[0]
   ) {
     data.features[0].feature.forEach((item) => {
-      bitmapFields.push({
-        bitmapName: 'Feature',
-        bitmapClusterCode: [{ $: { code: data.code[0] } }],
-        name: item.$.name,
-        mask: 1 << item.$.bit,
-        fieldIdentifier: item.$.bit
-      })
+      // do not add feature to bitmapFields if it has disallowed conformance
+      if (parseConformanceFromXML(item) != 'X') {
+        bitmapFields.push({
+          bitmapName: 'Feature',
+          bitmapClusterCode: [{ $: { code: data.code[0] } }],
+          name: item.$.name,
+          mask: 1 << item.$.bit,
+          fieldIdentifier: item.$.bit
+        })
+      }
     })
   }
   return queryLoader.insertBitmapFields(


### PR DESCRIPTION
- Add features to the Feature Bitmap only if their conformance is not disallowed.
- Avoid empty Feature Bitmap by removing them entirely if all contained features have disallowed conformance. This change assumes an empty Feature Bitmap should be removed

- Issue: #1413 
- JIRA: GHM_ZAP-449

```
      <!-- TODO: ZAP still generates feature bits for things with disallowConform! -->
      <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster is disallowed for this cluster">
        <disallowConform/>
      </feature>
```
With this PR, the OnOff feature will no longer be added to bitmaps in codegen when the above XML configuration is applied.