### PR TITLE
Set feature conformance warnings on ZAP file import and Replace outdated equivalents

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3651,7 +3651,7 @@ This module provides queries for features.
     * [~checkMissingTerms(expression, elementMap)](#module_DB API_ feature related queries..checkMissingTerms) ⇒
     * [~filterElementsContainingDesc(elements)](#module_DB API_ feature related queries..filterElementsContainingDesc) ⇒
     * [~filterRelatedDescElements(elements, featureCode)](#module_DB API_ feature related queries..filterRelatedDescElements) ⇒
-    * [~generateWarningMessage(featureData, endpointId, missingTerms, featureMap, descElements)](#module_DB API_ feature related queries..generateWarningMessage) ⇒
+    * [~generateWarningMessage(featureData, endpointId, elementMap, featureMap, descElements)](#module_DB API_ feature related queries..generateWarningMessage) ⇒
     * [~checkElementConformance(elements, featureMap, featureData, endpointId)](#module_DB API_ feature related queries..checkElementConformance) ⇒
     * [~filterElementsToUpdate(elements, elementMap, featureCode)](#module_DB API_ feature related queries..filterElementsToUpdate) ⇒
     * [~getOutdatedElementWarning(featureData, elements, elementMap)](#module_DB API_ feature related queries..getOutdatedElementWarning) ⇒
@@ -3762,9 +3762,9 @@ Filter an array of elements by if any element has conformance containing the ter
 
 <a name="module_DB API_ feature related queries..generateWarningMessage"></a>
 
-### DB API: feature related queries~generateWarningMessage(featureData, endpointId, missingTerms, featureMap, descElements) ⇒
+### DB API: feature related queries~generateWarningMessage(featureData, endpointId, elementMap, featureMap, descElements) ⇒
 Generate a warning message after processing conformance of the updated device type feature.
-Set flags to decide whether to show a popup warning or disable changes in the frontend.
+Set flags to decide whether to show warnings or disable changes in the frontend.
 
 **Kind**: inner method of [<code>DB API: feature related queries</code>](#module_DB API_ feature related queries)  
 **Returns**: warning message array, disableChange flag, and displayWarning flag  
@@ -3773,7 +3773,7 @@ Set flags to decide whether to show a popup warning or disable changes in the fr
 | --- | --- |
 | featureData | <code>\*</code> | 
 | endpointId | <code>\*</code> | 
-| missingTerms | <code>\*</code> | 
+| elementMap | <code>\*</code> | 
 | featureMap | <code>\*</code> | 
 | descElements | <code>\*</code> | 
 

--- a/src/store/zap/actions.js
+++ b/src/store/zap/actions.js
@@ -942,30 +942,11 @@ export async function setDeviceTypeFeatures(
   axiosRequests
     .$serverGet(restApi.uri.deviceTypeFeatures, config)
     .then((resp) => {
-      let deviceTypeFeatures = []
-      /* For a device type feature under the same endpoint and cluster, but different device types,
-        merge their rows into one and combine their device type names into a list. */
-      resp.data.forEach((row) => {
-        const key = `${row.endpointTypeClusterId}-${row.featureId}`
-        if (key in deviceTypeFeatures) {
-          let existingRow = deviceTypeFeatures[key]
-          if (!existingRow.deviceTypes.includes(row.deviceType)) {
-            existingRow.deviceTypes.push(row.deviceType)
-          }
-        } else {
-          deviceTypeFeatures[key] = {
-            ...row,
-            deviceTypes: [row.deviceType]
-          }
-          delete deviceTypeFeatures[key].deviceType
-        }
-      })
-      deviceTypeFeatures = Object.values(deviceTypeFeatures)
-
+      let deviceTypeFeatures = resp.data
       context.commit('setDeviceTypeFeatures', deviceTypeFeatures)
 
-      let enabledDeviceTypeFeatures = []
       // turn on the toggle for features with their bit set in featureMap attribute
+      let enabledDeviceTypeFeatures = []
       deviceTypeFeatures.forEach((feature) => {
         if (feature.featureMapValue & (1 << feature.bit)) {
           enabledDeviceTypeFeatures.push(

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -296,19 +296,23 @@ test(
     }
     let featureMap = { HS: 0, EHUE: 0, CL: 0, XY: 1, CT: 1, UNKNOWN: 0 }
     let deviceType = 'Matter Extended Color Light'
+    let cluster = 'Color Control'
     let featureHS = {
+      cluster: cluster,
       name: 'Hue/Saturation',
       code: 'HS',
       conformance: 'O',
       deviceTypes: [deviceType]
     }
     let featureXY = {
+      cluster: cluster,
       name: 'XY',
       code: 'XY',
       conformance: 'M',
       deviceTypes: [deviceType]
     }
     let featureUnknown = {
+      cluster: cluster,
       name: 'Unknown',
       code: 'UNKNOWN',
       conformance: 'Feature1 | Feature2',
@@ -317,6 +321,7 @@ test(
     let endpointId = 1
     let result = {}
     let expectedWarning = ''
+    let warningPrefix = `On endpoint ${endpointId}, cluster: ${cluster}, `
 
     // 1. test enable an optional feature
     featureMap['HS'] = 1
@@ -353,9 +358,9 @@ test(
     )
     // should throw and display warning
     expectedWarning =
-      `On endpoint ${endpointId}, ` +
-      `feature ${featureXY.name} is disabled, ` +
-      `but it is mandatory for device type ${deviceType}`
+      warningPrefix +
+      `feature: ${featureXY.name} should be enabled, ` +
+      `as it is mandatory for device type: ${deviceType}`
     expect(result.displayWarning).toBeTruthy()
     expect(result.disableChange).toBeFalsy()
     expect(result.warningMessage).toBe(expectedWarning)
@@ -379,8 +384,8 @@ test(
       endpointId
     )
     expectedWarning =
-      `On Endpoint ${endpointId}, ` +
-      `feature ${featureUnknown.name} cannot be enabled ` +
+      warningPrefix +
+      `feature: ${featureUnknown.name} cannot be enabled ` +
       `as its conformance depends on non device type features ` +
       `Feature1, Feature2 with unknown values`
     // should display warning and disable the change
@@ -409,7 +414,8 @@ test(
       endpointId
     )
     expectedWarning =
-      `On endpoint ${endpointId}, feature ${featureHS.name} ` +
+      warningPrefix +
+      `feature: ${featureHS.name} ` +
       `cannot be enabled as attribute ${descElement.name} ` +
       `depend on the feature and their conformance are too complex to parse.`
     expect(result.displayWarning).toBeTruthy()

--- a/test/importexport.test.js
+++ b/test/importexport.test.js
@@ -513,6 +513,14 @@ test(
         'On endpoint 1, cluster: On/Off, attribute: GlobalSceneControl has mandatory conformance to LT and should be enabled when feature: LT is enabled.'
       )
     ).toBeTruthy()
+
+    // disabled mandatory device type feature OnOff should trigger a notification
+    expect(
+      notificationMessages.includes(
+        'On endpoint 1, cluster: Level Control, feature: OnOff should be enabled, as it is mandatory for device type: Matter Dimmable Light'
+      )
+    ).toBeTruthy()
+    console.log(notificationMessages)
   },
   testUtil.timeout.medium()
 )

--- a/test/multi-protocol.test.js
+++ b/test/multi-protocol.test.js
@@ -181,28 +181,22 @@ test(
       (sn) => sn.message
     )
 
-    // Tests for the feature Map attribute compliance based on device type cluster features
+    // Tests for device type feature conformance
     expect(
       sessionNotificationMessages.includes(
-        '⚠ Check Device Type Compliance on endpoint: 1, device type: MA-onofflight, cluster: On/Off server needs bit 0 enabled in the Feature Map attribute'
+        'On endpoint 1, cluster: Level Control, feature: Lighting should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
     expect(
       sessionNotificationMessages.includes(
-        '⚠ Check Device Type Compliance on endpoint: 1, device type: MA-dimmablelight, cluster: Level Control server needs bit 0 enabled in the Feature Map attribute'
+        'On endpoint 1, cluster: Level Control, feature: OnOff should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
     expect(
       sessionNotificationMessages.includes(
-        '⚠ Check Device Type Compliance on endpoint: 1, device type: MA-dimmablelight, cluster: Level Control server needs bit 1 enabled in the Feature Map attribute'
-      )
-    ).toBeTruthy()
-
-    expect(
-      sessionNotificationMessages.includes(
-        '⚠ Check Device Type Compliance on endpoint: 1, device type: MA-dimmablelight, cluster: On/Off server needs bit 0 enabled in the Feature Map attribute'
+        'On endpoint 1, cluster: On/Off, feature: Lighting should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
@@ -233,10 +227,10 @@ test(
     }
 
     // one notification regarding multiple top level zcl propertoes
-    // 4 notifications regarding feature map attribute not set correctly
+    // 3 notifications regarding device type feature conformance
     // one notification regarding the enabled provisional cluster
     // 7 notifications regarding non-conformed elements
-    expect(sessionNotifications.length).toEqual(13)
+    expect(sessionNotifications.length).toEqual(12)
 
     // Test Accumulators in templates
     let zigbeeEndpointEvents = genResultZigbee.content['zap-event.h']

--- a/test/resource/non-conform-elements.zap
+++ b/test/resource/non-conform-elements.zap
@@ -2623,19 +2623,19 @@
           "enabled": 1,
           "commands": [
             {
-              "name": "AddGroupResponse",
-              "code": 0,
-              "mfgCode": null,
-              "source": "server",
-              "isIncoming": 0,
-              "isEnabled": 1
-            },
-            {
               "name": "AddGroup",
               "code": 0,
               "mfgCode": null,
               "source": "client",
               "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "AddGroupResponse",
+              "code": 0,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
               "isEnabled": 1
             },
             {
@@ -2715,7 +2715,7 @@
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
-              "reportable": 1,
+              "reportable": 0,
               "minInterval": 1,
               "maxInterval": 65534,
               "reportableChange": 0
@@ -2825,6 +2825,7 @@
           "define": "SCENES_CLUSTER",
           "side": "server",
           "enabled": 1,
+          "apiMaturity": "provisional",
           "commands": [
             {
               "name": "AddScene",
@@ -2843,19 +2844,19 @@
               "isEnabled": 1
             },
             {
-              "name": "ViewSceneResponse",
-              "code": 1,
-              "mfgCode": null,
-              "source": "server",
-              "isIncoming": 0,
-              "isEnabled": 1
-            },
-            {
               "name": "ViewScene",
               "code": 1,
               "mfgCode": null,
               "source": "client",
               "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "ViewSceneResponse",
+              "code": 1,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
               "isEnabled": 1
             },
             {
@@ -3171,7 +3172,7 @@
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0",
-              "reportable": 1,
+              "reportable": 0,
               "minInterval": 1,
               "maxInterval": 65534,
               "reportableChange": 0
@@ -3197,7 +3198,7 @@
               "code": 16387,
               "mfgCode": null,
               "side": "server",
-              "type": "StartUpOnOffEnum",
+              "type": "OnOffStartUpOnOff",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -3534,7 +3535,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "3",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
- Set warnings for non-conforming device type features when importing a ZAP file, replacing outdated warnings on feature map attributes as they do not cover all non-conforming cases
- Improve feature conform warning message and code for warning generation
- Update unit tests and a .zap file to align with the new warnings 
- Parent task: JIRA ZAPP-1565.