### PR TITLE
Adapt ZAP to Support Both List Type Definition Formats for Attributes

### DIFF
--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -630,6 +630,12 @@ function prepareCluster(cluster, context, isExtension = false) {
           attribute.$.reportingPolicy
         )
       }
+      /* If the XML uses `array="true" type="X"` to define a list type,
+         convert it to `type="array" entryType="X"` to support both formats */
+      if (attribute.$.array == 'true') {
+        attribute.$.entryType = attribute.$.type
+        attribute.$.type = 'array'
+      }
       let storagePolicy = dbEnum.storagePolicy.any
       if (context.listsUseAttributeAccessInterface && attribute.$.entryType) {
         storagePolicy = dbEnum.storagePolicy.attributeAccessInterface

--- a/zcl-builtin/matter/data-model/chip/access-control-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/access-control-cluster.xml
@@ -72,7 +72,9 @@ limitations under the License.
       and enforce Access Control for the Node's endpoints and their associated
       cluster instances.</description>
 
-    <attribute side="server" code="0x0000" define="ACL" type="ARRAY" entryType="AccessControlEntryStruct" writable="true">
+    <!-- Modified attribute definition from `type="array" entryType="X"` to `array="true" type="X"`  
+     to support testing loading list-typed attributes -->
+    <attribute side="server" code="0x0000" define="ACL" array="true" type="AccessControlEntryStruct" writable="true">
       <description>ACL</description>
       <access op="read" privilege="administer"/>
       <access op="write" privilege="administer"/>


### PR DESCRIPTION
- This PR adapts ZAP to support parsing list type definition `array="true" type="X"` for attributes, ensuring consistency with command and event definitions in the XML.
- ZAP now converts `array="true" type="X"` to `type="array" entryType="X"` before parsing, allowing support for both formats.
- This update prepares ZAP for upcoming XML changes to standardize list type definitions across elements
- Issue: #1474
- Jira: GHM_ZAP-461