### PR TITLE
Adding clusterExtension Support from standard xml file loading like we do from zcl.json

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20112,8 +20112,12 @@ This module provides the APIs for dotdot Loading
     * [~processStructItems(db, filePath, packageIds, data)](#module_Loader API_ Loader APIs..processStructItems) ⇒
     * [~prepareDeviceType(deviceType)](#module_Loader API_ Loader APIs..prepareDeviceType) ⇒ <code>Object</code>
     * [~processDeviceTypes(db, filePath, packageId, data, context)](#module_Loader API_ Loader APIs..processDeviceTypes) ⇒ <code>Promise</code>
-    * [~processParsedZclData(db, argument)](#module_Loader API_ Loader APIs..processParsedZclData) ⇒
-    * [~parseSingleZclFile(db, packageId, file)](#module_Loader API_ Loader APIs..parseSingleZclFile) ⇒
+    * [~processDataTypes(db, filePath, packageId, knownPackages, toplevel)](#module_Loader API_ Loader APIs..processDataTypes) ⇒
+    * [~processAtomicTypes(db, filePath, packageId, knownPackages, toplevel)](#module_Loader API_ Loader APIs..processAtomicTypes) ⇒
+    * [~processNonAtomicTypes(db, filePath, packageId, knownPackages, toplevel, featureClusters)](#module_Loader API_ Loader APIs..processNonAtomicTypes) ⇒
+    * [~processSubItems(db, filePath, packageId, knownPackages, toplevel, featureClusters, context, collectedStructItems)](#module_Loader API_ Loader APIs..processSubItems) ⇒
+    * [~processParsedZclData(db, argument, previouslyKnownPackages, context, collectedStructItems)](#module_Loader API_ Loader APIs..processParsedZclData) ⇒
+    * [~parseSingleZclFile(db, packageId, file, context, collectedStructItems)](#module_Loader API_ Loader APIs..parseSingleZclFile) ⇒
     * [~isCrcMismatchOrPackageDoesNotExist(db, packageId, files)](#module_Loader API_ Loader APIs..isCrcMismatchOrPackageDoesNotExist) ⇒
     * [~parseZclFiles(db, packageId, zclFiles, context)](#module_Loader API_ Loader APIs..parseZclFiles) ⇒
     * [~parseManufacturerData(db, ctx)](#module_Loader API_ Loader APIs..parseManufacturerData) ⇒
@@ -20142,7 +20146,7 @@ This module provides the APIs for dotdot Loading
     * [~loadZcl(db, metadataFile)](#module_Loader API_ Loader APIs..loadZcl) ⇒
     * [~loadIndividualFile(db, filePath, sessionId)](#module_Loader API_ Loader APIs..loadIndividualFile)
     * [~qualifyZclFile(db, info, parentPackageId, isCustom)](#module_Loader API_ Loader APIs..qualifyZclFile) ⇒
-    * [~processZclPostLoading(db)](#module_Loader API_ Loader APIs..processZclPostLoading) ⇒
+    * [~processZclPostLoading(db, packageId)](#module_Loader API_ Loader APIs..processZclPostLoading) ⇒
     * [~getDiscriminatorMap(db, packageIds)](#module_Loader API_ Loader APIs..getDiscriminatorMap) ⇒
 
 <a name="module_Loader API_ Loader APIs..collectDataFromLibraryXml"></a>
@@ -21366,9 +21370,79 @@ Finally, it inserts all prepared device types into the database.
 | data | <code>Array</code> | The array of device types to be processed. |
 | context | <code>\*</code> | Additional context that might be required for processing. |
 
+<a name="module_Loader API_ Loader APIs..processDataTypes"></a>
+
+### Loader API: Loader APIs~processDataTypes(db, filePath, packageId, knownPackages, toplevel) ⇒
+Process promises for loading the data types
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of data types  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processAtomicTypes"></a>
+
+### Loader API: Loader APIs~processAtomicTypes(db, filePath, packageId, knownPackages, toplevel) ⇒
+Processes promises for loading individual tables per data type for
+atomics/baseline types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of atomic/baseline processing.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processNonAtomicTypes"></a>
+
+### Loader API: Loader APIs~processNonAtomicTypes(db, filePath, packageId, knownPackages, toplevel, featureClusters) ⇒
+Processes promises for loading individual tables per data type for no-atomic
+and inherited types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of non-atomic/inherited data type processing.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+| featureClusters | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processSubItems"></a>
+
+### Loader API: Loader APIs~processSubItems(db, filePath, packageId, knownPackages, toplevel, featureClusters, context, collectedStructItems) ⇒
+Processes promises for loading items within a bitmap, struct, and enum data types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of processing sub items within a bitmap, enum and structs.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+| featureClusters | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
+
 <a name="module_Loader API_ Loader APIs..processParsedZclData"></a>
 
-### Loader API: Loader APIs~processParsedZclData(db, argument) ⇒
+### Loader API: Loader APIs~processParsedZclData(db, argument, previouslyKnownPackages, context, collectedStructItems) ⇒
 After XML parser is done with the barebones parsing, this function
 branches the individual toplevel tags.
 
@@ -21379,10 +21453,13 @@ branches the individual toplevel tags.
 | --- | --- |
 | db | <code>\*</code> | 
 | argument | <code>\*</code> | 
+| previouslyKnownPackages | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..parseSingleZclFile"></a>
 
-### Loader API: Loader APIs~parseSingleZclFile(db, packageId, file) ⇒
+### Loader API: Loader APIs~parseSingleZclFile(db, packageId, file, context, collectedStructItems) ⇒
 This function is used for parsing each individual ZCL file at a grouped zcl file package level.
 This should _not_ be used for custom XML addition due to custom xmls potentially relying on existing packges.
 
@@ -21394,6 +21471,8 @@ This should _not_ be used for custom XML addition due to custom xmls potentially
 | db | <code>\*</code> | 
 | packageId | <code>\*</code> | 
 | file | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..isCrcMismatchOrPackageDoesNotExist"></a>
 
@@ -21653,7 +21732,7 @@ Parse the boolean defaults inside options.
 
 ### Loader API: Loader APIs~loadIndividualSilabsFile(db, filePath) ⇒
 Parses a single file. This function is used specifically
-for adding a package through an existing session because of its reliance
+for adding a package through an existing ZAP session because of its reliance
 on relating the new XML content to the packages associated with that session.
 e.g. for ClusterExtensions.
 
@@ -21830,7 +21909,7 @@ If not, then it will resolve with {error}
 
 <a name="module_Loader API_ Loader APIs..processZclPostLoading"></a>
 
-### Loader API: Loader APIs~processZclPostLoading(db) ⇒
+### Loader API: Loader APIs~processZclPostLoading(db, packageId) ⇒
 Promises to perform a post loading step.
 
 **Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
@@ -21839,6 +21918,7 @@ Promises to perform a post loading step.
 | Param | Type |
 | --- | --- |
 | db | <code>\*</code> | 
+| packageId | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..getDiscriminatorMap"></a>
 
@@ -21946,8 +22026,12 @@ This module provides the APIs for new data model loading
     * [~processStructItems(db, filePath, packageIds, data)](#module_Loader API_ Loader APIs..processStructItems) ⇒
     * [~prepareDeviceType(deviceType)](#module_Loader API_ Loader APIs..prepareDeviceType) ⇒ <code>Object</code>
     * [~processDeviceTypes(db, filePath, packageId, data, context)](#module_Loader API_ Loader APIs..processDeviceTypes) ⇒ <code>Promise</code>
-    * [~processParsedZclData(db, argument)](#module_Loader API_ Loader APIs..processParsedZclData) ⇒
-    * [~parseSingleZclFile(db, packageId, file)](#module_Loader API_ Loader APIs..parseSingleZclFile) ⇒
+    * [~processDataTypes(db, filePath, packageId, knownPackages, toplevel)](#module_Loader API_ Loader APIs..processDataTypes) ⇒
+    * [~processAtomicTypes(db, filePath, packageId, knownPackages, toplevel)](#module_Loader API_ Loader APIs..processAtomicTypes) ⇒
+    * [~processNonAtomicTypes(db, filePath, packageId, knownPackages, toplevel, featureClusters)](#module_Loader API_ Loader APIs..processNonAtomicTypes) ⇒
+    * [~processSubItems(db, filePath, packageId, knownPackages, toplevel, featureClusters, context, collectedStructItems)](#module_Loader API_ Loader APIs..processSubItems) ⇒
+    * [~processParsedZclData(db, argument, previouslyKnownPackages, context, collectedStructItems)](#module_Loader API_ Loader APIs..processParsedZclData) ⇒
+    * [~parseSingleZclFile(db, packageId, file, context, collectedStructItems)](#module_Loader API_ Loader APIs..parseSingleZclFile) ⇒
     * [~isCrcMismatchOrPackageDoesNotExist(db, packageId, files)](#module_Loader API_ Loader APIs..isCrcMismatchOrPackageDoesNotExist) ⇒
     * [~parseZclFiles(db, packageId, zclFiles, context)](#module_Loader API_ Loader APIs..parseZclFiles) ⇒
     * [~parseManufacturerData(db, ctx)](#module_Loader API_ Loader APIs..parseManufacturerData) ⇒
@@ -21976,7 +22060,7 @@ This module provides the APIs for new data model loading
     * [~loadZcl(db, metadataFile)](#module_Loader API_ Loader APIs..loadZcl) ⇒
     * [~loadIndividualFile(db, filePath, sessionId)](#module_Loader API_ Loader APIs..loadIndividualFile)
     * [~qualifyZclFile(db, info, parentPackageId, isCustom)](#module_Loader API_ Loader APIs..qualifyZclFile) ⇒
-    * [~processZclPostLoading(db)](#module_Loader API_ Loader APIs..processZclPostLoading) ⇒
+    * [~processZclPostLoading(db, packageId)](#module_Loader API_ Loader APIs..processZclPostLoading) ⇒
     * [~getDiscriminatorMap(db, packageIds)](#module_Loader API_ Loader APIs..getDiscriminatorMap) ⇒
 
 <a name="module_Loader API_ Loader APIs..collectDataFromLibraryXml"></a>
@@ -23200,9 +23284,79 @@ Finally, it inserts all prepared device types into the database.
 | data | <code>Array</code> | The array of device types to be processed. |
 | context | <code>\*</code> | Additional context that might be required for processing. |
 
+<a name="module_Loader API_ Loader APIs..processDataTypes"></a>
+
+### Loader API: Loader APIs~processDataTypes(db, filePath, packageId, knownPackages, toplevel) ⇒
+Process promises for loading the data types
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of data types  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processAtomicTypes"></a>
+
+### Loader API: Loader APIs~processAtomicTypes(db, filePath, packageId, knownPackages, toplevel) ⇒
+Processes promises for loading individual tables per data type for
+atomics/baseline types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of atomic/baseline processing.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processNonAtomicTypes"></a>
+
+### Loader API: Loader APIs~processNonAtomicTypes(db, filePath, packageId, knownPackages, toplevel, featureClusters) ⇒
+Processes promises for loading individual tables per data type for no-atomic
+and inherited types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of non-atomic/inherited data type processing.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+| featureClusters | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processSubItems"></a>
+
+### Loader API: Loader APIs~processSubItems(db, filePath, packageId, knownPackages, toplevel, featureClusters, context, collectedStructItems) ⇒
+Processes promises for loading items within a bitmap, struct, and enum data types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of processing sub items within a bitmap, enum and structs.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+| featureClusters | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
+
 <a name="module_Loader API_ Loader APIs..processParsedZclData"></a>
 
-### Loader API: Loader APIs~processParsedZclData(db, argument) ⇒
+### Loader API: Loader APIs~processParsedZclData(db, argument, previouslyKnownPackages, context, collectedStructItems) ⇒
 After XML parser is done with the barebones parsing, this function
 branches the individual toplevel tags.
 
@@ -23213,10 +23367,13 @@ branches the individual toplevel tags.
 | --- | --- |
 | db | <code>\*</code> | 
 | argument | <code>\*</code> | 
+| previouslyKnownPackages | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..parseSingleZclFile"></a>
 
-### Loader API: Loader APIs~parseSingleZclFile(db, packageId, file) ⇒
+### Loader API: Loader APIs~parseSingleZclFile(db, packageId, file, context, collectedStructItems) ⇒
 This function is used for parsing each individual ZCL file at a grouped zcl file package level.
 This should _not_ be used for custom XML addition due to custom xmls potentially relying on existing packges.
 
@@ -23228,6 +23385,8 @@ This should _not_ be used for custom XML addition due to custom xmls potentially
 | db | <code>\*</code> | 
 | packageId | <code>\*</code> | 
 | file | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..isCrcMismatchOrPackageDoesNotExist"></a>
 
@@ -23487,7 +23646,7 @@ Parse the boolean defaults inside options.
 
 ### Loader API: Loader APIs~loadIndividualSilabsFile(db, filePath) ⇒
 Parses a single file. This function is used specifically
-for adding a package through an existing session because of its reliance
+for adding a package through an existing ZAP session because of its reliance
 on relating the new XML content to the packages associated with that session.
 e.g. for ClusterExtensions.
 
@@ -23664,7 +23823,7 @@ If not, then it will resolve with {error}
 
 <a name="module_Loader API_ Loader APIs..processZclPostLoading"></a>
 
-### Loader API: Loader APIs~processZclPostLoading(db) ⇒
+### Loader API: Loader APIs~processZclPostLoading(db, packageId) ⇒
 Promises to perform a post loading step.
 
 **Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
@@ -23673,6 +23832,7 @@ Promises to perform a post loading step.
 | Param | Type |
 | --- | --- |
 | db | <code>\*</code> | 
+| packageId | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..getDiscriminatorMap"></a>
 
@@ -23780,8 +23940,12 @@ This module provides the APIs for ZCL/Data-Model loading.
     * [~processStructItems(db, filePath, packageIds, data)](#module_Loader API_ Loader APIs..processStructItems) ⇒
     * [~prepareDeviceType(deviceType)](#module_Loader API_ Loader APIs..prepareDeviceType) ⇒ <code>Object</code>
     * [~processDeviceTypes(db, filePath, packageId, data, context)](#module_Loader API_ Loader APIs..processDeviceTypes) ⇒ <code>Promise</code>
-    * [~processParsedZclData(db, argument)](#module_Loader API_ Loader APIs..processParsedZclData) ⇒
-    * [~parseSingleZclFile(db, packageId, file)](#module_Loader API_ Loader APIs..parseSingleZclFile) ⇒
+    * [~processDataTypes(db, filePath, packageId, knownPackages, toplevel)](#module_Loader API_ Loader APIs..processDataTypes) ⇒
+    * [~processAtomicTypes(db, filePath, packageId, knownPackages, toplevel)](#module_Loader API_ Loader APIs..processAtomicTypes) ⇒
+    * [~processNonAtomicTypes(db, filePath, packageId, knownPackages, toplevel, featureClusters)](#module_Loader API_ Loader APIs..processNonAtomicTypes) ⇒
+    * [~processSubItems(db, filePath, packageId, knownPackages, toplevel, featureClusters, context, collectedStructItems)](#module_Loader API_ Loader APIs..processSubItems) ⇒
+    * [~processParsedZclData(db, argument, previouslyKnownPackages, context, collectedStructItems)](#module_Loader API_ Loader APIs..processParsedZclData) ⇒
+    * [~parseSingleZclFile(db, packageId, file, context, collectedStructItems)](#module_Loader API_ Loader APIs..parseSingleZclFile) ⇒
     * [~isCrcMismatchOrPackageDoesNotExist(db, packageId, files)](#module_Loader API_ Loader APIs..isCrcMismatchOrPackageDoesNotExist) ⇒
     * [~parseZclFiles(db, packageId, zclFiles, context)](#module_Loader API_ Loader APIs..parseZclFiles) ⇒
     * [~parseManufacturerData(db, ctx)](#module_Loader API_ Loader APIs..parseManufacturerData) ⇒
@@ -23810,7 +23974,7 @@ This module provides the APIs for ZCL/Data-Model loading.
     * [~loadZcl(db, metadataFile)](#module_Loader API_ Loader APIs..loadZcl) ⇒
     * [~loadIndividualFile(db, filePath, sessionId)](#module_Loader API_ Loader APIs..loadIndividualFile)
     * [~qualifyZclFile(db, info, parentPackageId, isCustom)](#module_Loader API_ Loader APIs..qualifyZclFile) ⇒
-    * [~processZclPostLoading(db)](#module_Loader API_ Loader APIs..processZclPostLoading) ⇒
+    * [~processZclPostLoading(db, packageId)](#module_Loader API_ Loader APIs..processZclPostLoading) ⇒
     * [~getDiscriminatorMap(db, packageIds)](#module_Loader API_ Loader APIs..getDiscriminatorMap) ⇒
 
 <a name="module_Loader API_ Loader APIs..collectDataFromLibraryXml"></a>
@@ -25034,9 +25198,79 @@ Finally, it inserts all prepared device types into the database.
 | data | <code>Array</code> | The array of device types to be processed. |
 | context | <code>\*</code> | Additional context that might be required for processing. |
 
+<a name="module_Loader API_ Loader APIs..processDataTypes"></a>
+
+### Loader API: Loader APIs~processDataTypes(db, filePath, packageId, knownPackages, toplevel) ⇒
+Process promises for loading the data types
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of data types  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processAtomicTypes"></a>
+
+### Loader API: Loader APIs~processAtomicTypes(db, filePath, packageId, knownPackages, toplevel) ⇒
+Processes promises for loading individual tables per data type for
+atomics/baseline types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of atomic/baseline processing.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processNonAtomicTypes"></a>
+
+### Loader API: Loader APIs~processNonAtomicTypes(db, filePath, packageId, knownPackages, toplevel, featureClusters) ⇒
+Processes promises for loading individual tables per data type for no-atomic
+and inherited types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of non-atomic/inherited data type processing.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+| featureClusters | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processSubItems"></a>
+
+### Loader API: Loader APIs~processSubItems(db, filePath, packageId, knownPackages, toplevel, featureClusters, context, collectedStructItems) ⇒
+Processes promises for loading items within a bitmap, struct, and enum data types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of processing sub items within a bitmap, enum and structs.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+| featureClusters | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
+
 <a name="module_Loader API_ Loader APIs..processParsedZclData"></a>
 
-### Loader API: Loader APIs~processParsedZclData(db, argument) ⇒
+### Loader API: Loader APIs~processParsedZclData(db, argument, previouslyKnownPackages, context, collectedStructItems) ⇒
 After XML parser is done with the barebones parsing, this function
 branches the individual toplevel tags.
 
@@ -25047,10 +25281,13 @@ branches the individual toplevel tags.
 | --- | --- |
 | db | <code>\*</code> | 
 | argument | <code>\*</code> | 
+| previouslyKnownPackages | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..parseSingleZclFile"></a>
 
-### Loader API: Loader APIs~parseSingleZclFile(db, packageId, file) ⇒
+### Loader API: Loader APIs~parseSingleZclFile(db, packageId, file, context, collectedStructItems) ⇒
 This function is used for parsing each individual ZCL file at a grouped zcl file package level.
 This should _not_ be used for custom XML addition due to custom xmls potentially relying on existing packges.
 
@@ -25062,6 +25299,8 @@ This should _not_ be used for custom XML addition due to custom xmls potentially
 | db | <code>\*</code> | 
 | packageId | <code>\*</code> | 
 | file | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..isCrcMismatchOrPackageDoesNotExist"></a>
 
@@ -25321,7 +25560,7 @@ Parse the boolean defaults inside options.
 
 ### Loader API: Loader APIs~loadIndividualSilabsFile(db, filePath) ⇒
 Parses a single file. This function is used specifically
-for adding a package through an existing session because of its reliance
+for adding a package through an existing ZAP session because of its reliance
 on relating the new XML content to the packages associated with that session.
 e.g. for ClusterExtensions.
 
@@ -25498,7 +25737,7 @@ If not, then it will resolve with {error}
 
 <a name="module_Loader API_ Loader APIs..processZclPostLoading"></a>
 
-### Loader API: Loader APIs~processZclPostLoading(db) ⇒
+### Loader API: Loader APIs~processZclPostLoading(db, packageId) ⇒
 Promises to perform a post loading step.
 
 **Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
@@ -25507,6 +25746,7 @@ Promises to perform a post loading step.
 | Param | Type |
 | --- | --- |
 | db | <code>\*</code> | 
+| packageId | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..getDiscriminatorMap"></a>
 
@@ -25614,8 +25854,12 @@ This module provides the APIs for for common functionality related to loading.
     * [~processStructItems(db, filePath, packageIds, data)](#module_Loader API_ Loader APIs..processStructItems) ⇒
     * [~prepareDeviceType(deviceType)](#module_Loader API_ Loader APIs..prepareDeviceType) ⇒ <code>Object</code>
     * [~processDeviceTypes(db, filePath, packageId, data, context)](#module_Loader API_ Loader APIs..processDeviceTypes) ⇒ <code>Promise</code>
-    * [~processParsedZclData(db, argument)](#module_Loader API_ Loader APIs..processParsedZclData) ⇒
-    * [~parseSingleZclFile(db, packageId, file)](#module_Loader API_ Loader APIs..parseSingleZclFile) ⇒
+    * [~processDataTypes(db, filePath, packageId, knownPackages, toplevel)](#module_Loader API_ Loader APIs..processDataTypes) ⇒
+    * [~processAtomicTypes(db, filePath, packageId, knownPackages, toplevel)](#module_Loader API_ Loader APIs..processAtomicTypes) ⇒
+    * [~processNonAtomicTypes(db, filePath, packageId, knownPackages, toplevel, featureClusters)](#module_Loader API_ Loader APIs..processNonAtomicTypes) ⇒
+    * [~processSubItems(db, filePath, packageId, knownPackages, toplevel, featureClusters, context, collectedStructItems)](#module_Loader API_ Loader APIs..processSubItems) ⇒
+    * [~processParsedZclData(db, argument, previouslyKnownPackages, context, collectedStructItems)](#module_Loader API_ Loader APIs..processParsedZclData) ⇒
+    * [~parseSingleZclFile(db, packageId, file, context, collectedStructItems)](#module_Loader API_ Loader APIs..parseSingleZclFile) ⇒
     * [~isCrcMismatchOrPackageDoesNotExist(db, packageId, files)](#module_Loader API_ Loader APIs..isCrcMismatchOrPackageDoesNotExist) ⇒
     * [~parseZclFiles(db, packageId, zclFiles, context)](#module_Loader API_ Loader APIs..parseZclFiles) ⇒
     * [~parseManufacturerData(db, ctx)](#module_Loader API_ Loader APIs..parseManufacturerData) ⇒
@@ -25644,7 +25888,7 @@ This module provides the APIs for for common functionality related to loading.
     * [~loadZcl(db, metadataFile)](#module_Loader API_ Loader APIs..loadZcl) ⇒
     * [~loadIndividualFile(db, filePath, sessionId)](#module_Loader API_ Loader APIs..loadIndividualFile)
     * [~qualifyZclFile(db, info, parentPackageId, isCustom)](#module_Loader API_ Loader APIs..qualifyZclFile) ⇒
-    * [~processZclPostLoading(db)](#module_Loader API_ Loader APIs..processZclPostLoading) ⇒
+    * [~processZclPostLoading(db, packageId)](#module_Loader API_ Loader APIs..processZclPostLoading) ⇒
     * [~getDiscriminatorMap(db, packageIds)](#module_Loader API_ Loader APIs..getDiscriminatorMap) ⇒
 
 <a name="module_Loader API_ Loader APIs..collectDataFromLibraryXml"></a>
@@ -26868,9 +27112,79 @@ Finally, it inserts all prepared device types into the database.
 | data | <code>Array</code> | The array of device types to be processed. |
 | context | <code>\*</code> | Additional context that might be required for processing. |
 
+<a name="module_Loader API_ Loader APIs..processDataTypes"></a>
+
+### Loader API: Loader APIs~processDataTypes(db, filePath, packageId, knownPackages, toplevel) ⇒
+Process promises for loading the data types
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of data types  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processAtomicTypes"></a>
+
+### Loader API: Loader APIs~processAtomicTypes(db, filePath, packageId, knownPackages, toplevel) ⇒
+Processes promises for loading individual tables per data type for
+atomics/baseline types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of atomic/baseline processing.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processNonAtomicTypes"></a>
+
+### Loader API: Loader APIs~processNonAtomicTypes(db, filePath, packageId, knownPackages, toplevel, featureClusters) ⇒
+Processes promises for loading individual tables per data type for no-atomic
+and inherited types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of non-atomic/inherited data type processing.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+| featureClusters | <code>\*</code> | 
+
+<a name="module_Loader API_ Loader APIs..processSubItems"></a>
+
+### Loader API: Loader APIs~processSubItems(db, filePath, packageId, knownPackages, toplevel, featureClusters, context, collectedStructItems) ⇒
+Processes promises for loading items within a bitmap, struct, and enum data types.
+
+**Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
+**Returns**: Promise of processing sub items within a bitmap, enum and structs.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| filePath | <code>\*</code> | 
+| packageId | <code>\*</code> | 
+| knownPackages | <code>\*</code> | 
+| toplevel | <code>\*</code> | 
+| featureClusters | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
+
 <a name="module_Loader API_ Loader APIs..processParsedZclData"></a>
 
-### Loader API: Loader APIs~processParsedZclData(db, argument) ⇒
+### Loader API: Loader APIs~processParsedZclData(db, argument, previouslyKnownPackages, context, collectedStructItems) ⇒
 After XML parser is done with the barebones parsing, this function
 branches the individual toplevel tags.
 
@@ -26881,10 +27195,13 @@ branches the individual toplevel tags.
 | --- | --- |
 | db | <code>\*</code> | 
 | argument | <code>\*</code> | 
+| previouslyKnownPackages | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..parseSingleZclFile"></a>
 
-### Loader API: Loader APIs~parseSingleZclFile(db, packageId, file) ⇒
+### Loader API: Loader APIs~parseSingleZclFile(db, packageId, file, context, collectedStructItems) ⇒
 This function is used for parsing each individual ZCL file at a grouped zcl file package level.
 This should _not_ be used for custom XML addition due to custom xmls potentially relying on existing packges.
 
@@ -26896,6 +27213,8 @@ This should _not_ be used for custom XML addition due to custom xmls potentially
 | db | <code>\*</code> | 
 | packageId | <code>\*</code> | 
 | file | <code>\*</code> | 
+| context | <code>\*</code> | 
+| collectedStructItems | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..isCrcMismatchOrPackageDoesNotExist"></a>
 
@@ -27155,7 +27474,7 @@ Parse the boolean defaults inside options.
 
 ### Loader API: Loader APIs~loadIndividualSilabsFile(db, filePath) ⇒
 Parses a single file. This function is used specifically
-for adding a package through an existing session because of its reliance
+for adding a package through an existing ZAP session because of its reliance
 on relating the new XML content to the packages associated with that session.
 e.g. for ClusterExtensions.
 
@@ -27332,7 +27651,7 @@ If not, then it will resolve with {error}
 
 <a name="module_Loader API_ Loader APIs..processZclPostLoading"></a>
 
-### Loader API: Loader APIs~processZclPostLoading(db) ⇒
+### Loader API: Loader APIs~processZclPostLoading(db, packageId) ⇒
 Promises to perform a post loading step.
 
 **Kind**: inner method of [<code>Loader API: Loader APIs</code>](#module_Loader API_ Loader APIs)  
@@ -27341,6 +27660,7 @@ Promises to perform a post loading step.
 | Param | Type |
 | --- | --- |
 | db | <code>\*</code> | 
+| packageId | <code>\*</code> | 
 
 <a name="module_Loader API_ Loader APIs..getDiscriminatorMap"></a>
 

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -1968,14 +1968,14 @@ async function processSubItems(
   context,
   collectedStructItems
 ) {
-  let subItemPrmosies = []
+  let subItemPromises = []
   if (dbEnum.zclType.enum in toplevel) {
-    subItemPrmosies.push(
+    subItemPromises.push(
       processEnumItems(db, filePath, packageId, knownPackages, toplevel.enum)
     )
   }
   if (dbEnum.zclType.bitmap in toplevel) {
-    subItemPrmosies.push(
+    subItemPromises.push(
       processBitmapFields(
         db,
         filePath,
@@ -1988,12 +1988,12 @@ async function processSubItems(
   // Treating features in a cluster as a bitmap
   if (featureClusters && featureClusters.length > 0) {
     featureClusters.forEach((fc) => {
-      subItemPrmosies.push(
+      subItemPromises.push(
         processBitmapFields(db, filePath, packageId, knownPackages, fc)
       )
     })
   }
-  // Delaying the loading of struct items into collecedStructItems instead of
+  // Delaying the loading of struct items into collectedStructItems instead of
   // processing them with other subitems. This is because the struct items are
   // dependent on types which could span across multiple xml files.
   if (dbEnum.zclType.struct in toplevel) {
@@ -2005,7 +2005,7 @@ async function processSubItems(
       context
     ])
   }
-  return Promise.all(subItemPrmosies)
+  return Promise.all(subItemPromises)
 }
 
 /**

--- a/src-electron/zcl/zcl-loader.js
+++ b/src-electron/zcl/zcl-loader.js
@@ -377,6 +377,7 @@ async function qualifyZclFile(
  * Promises to perform a post loading step.
  *
  * @param {*} db
+ * @param {*} packageId
  * @returns Promise to deal with the post-loading cleanup.
  */
 async function processZclPostLoading(db, packageId) {

--- a/test/custom-matter-xml.test.js
+++ b/test/custom-matter-xml.test.js
@@ -387,6 +387,20 @@ test(
       { disableDeprecationWarnings: true }
     )
 
+    // Testing custom xml cluster extension data types
+    // Testing cluster extension from an xml file in zcl.json
+    // Note: When cluster extensions are added to standard xml files in zcl.json
+    // then all content needs to come under <clusterExtensions> so that they are
+    // postprocessed onece all the other data has been loaded.
+    let simpleText = genResult.content['simple-test.h']
+    expect(simpleText).not.toBeNull()
+    expect(simpleText).toContain(
+      'Struct name: AdditionalInfoStruct, Struct Item Name: SystemMode, Struct Item Type: SystemModeEnum'
+    )
+    expect(simpleText).toContain(
+      'Command name: customCommandForAdditionalInfoStruct, Command Argument Name: arg1, Command Argument Type: AdditionalInfoStruct'
+    )
+
     let sdkExt = genResult.content['sdk-ext.txt']
     expect(sdkExt).not.toBeNull()
     expect(sdkExt).toContain(

--- a/test/gen-matter-1.test.js
+++ b/test/gen-matter-1.test.js
@@ -181,7 +181,7 @@ test(
     )
     expect(simpleTest).toContain('ExternalAddon : 72')
     expect(simpleTest).toContain('ExternalAddon : 784')
-    expect(simpleTest).toContain('ExternalAddon : 248')
+    expect(simpleTest).toContain('ExternalAddon : 249')
     expect(simpleTest).toContain('ExternalAddon : 60')
     expect(simpleTest).toContain(
       'ExternalAddon : This is example of test external addon helper.'

--- a/test/gen-template/matter/simple-test.zapt
+++ b/test/gen-template/matter/simple-test.zapt
@@ -26,3 +26,19 @@ Base type for {{name}} : {{baseType}}
 {{/if}}
 {{/zcl_atomics}}
 
+// Extract cluster extension struct type(See custom-xml-in-zcl-json.xml)
+// Also using that as a command argument type
+{{#zcl_structs}}
+    {{#zcl_struct_items_by_struct_and_cluster_name ./name "Thermostat"}}
+    Struct name: {{../name}}, Struct Item Name: {{./name}}, Struct Item Type: {{./type}}
+    {{/zcl_struct_items_by_struct_and_cluster_name}}
+{{/zcl_structs}}
+
+{{#zcl_commands}}
+    {{#if (is_equal ./name "customCommandForAdditionalInfoStruct")}}
+        {{#zcl_command_arguments}}
+            Command name: {{../name}}, Command Argument Name: {{name}}, Command Argument Type: {{type}}
+        {{/zcl_command_arguments}}
+    {{/if}}
+{{/zcl_commands}}
+

--- a/test/resource/custom-cluster/custom-xml-in-zcl-json.xml
+++ b/test/resource/custom-cluster/custom-xml-in-zcl-json.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2025 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<configurator>
+  <domain name="CHIP"/>
+
+  <!--
+    These are test global items (no cluster attached) for testing only.
+    Their usage is defined for UnitTestCluster only.
+  -->
+  
+  <struct name="AdditionalInfoStruct">
+    <cluster code="0x0201"/>
+    <item name="SystemMode" type="SystemModeEnum"/>
+  </struct>
+    <!-- Commands -->
+  <clusterExtension code="0x0201">
+    <command source="client" code="0x00" name="customCommandForAdditionalInfoStruct" optional="true" manufacturerCode="0x212D">
+        <description>
+            Command that takes two uint8 arguments and returns their sum.
+        </description>
+        <arg name="arg1" type="AdditionalInfoStruct"/>
+        <arg name="arg2" type="INT8U"/>
+    </command>
+
+  </clusterExtension>
+  
+
+</configurator>

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -189,8 +189,8 @@ exports.totalDotDotEnumItems = 637
 
 exports.totalMatterClusters = 72
 exports.totalMatterDeviceTypes = 119
-exports.totalMatterCommandArgs = 597
-exports.totalMatterCommands = 248
+exports.totalMatterCommandArgs = 599
+exports.totalMatterCommands = 249
 exports.totalMatterAttributes = 784
 exports.totalMatterTags = 17
 exports.totalMatterEvents = 60

--- a/zcl-builtin/matter/data-model/chip/thermostat-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/thermostat-cluster.xml
@@ -17,6 +17,19 @@ limitations under the License.
 <configurator>
   <domain name="HVAC"/>
 
+  <enum name="SystemModeEnum" type="enum8">
+    <cluster code="0x0201"/>
+    <item name="Off" value="0x00"/>
+    <item name="Auto" value="0x01"/>
+    <item name="Cool" value="0x03"/>
+    <item name="Heat" value="0x04"/>
+    <item name="EmergencyHeat" value="0x05"/>
+    <item name="Precooling" value="0x06"/>
+    <item name="FanOnly" value="0x07"/>
+    <item name="Dry" value="0x08"/>
+    <item name="Sleep" value="0x09"/>
+  </enum>
+
   <bitmap name="ThermostatFeature" type="BITMAP32">
     <cluster code="0x0201"/>
     <field name="Heating" mask="0x1"/>

--- a/zcl-builtin/matter/zcl.json
+++ b/zcl-builtin/matter/zcl.json
@@ -93,7 +93,8 @@
     "types/color-control.xml",
     "types/door-lock.xml",
     "types/occupancy-sensing.xml",
-    "types/thermostat-user-interface-configuration.xml"
+    "types/thermostat-user-interface-configuration.xml",
+    "../../test/resource/custom-cluster/custom-xml-in-zcl-json.xml"
   ],
   "manufacturersXml": "data-model/manufacturers.xml",
   "options": {


### PR DESCRIPTION
- Updated processClusterExtensions which is part of the delayed promises to load custom data types within clusterExtensions tag.
- Now users can define custom data types within clusterExtensions referring to other data types within standard xml.
- Added Unit tests for the same
- Github: ZAP#1529