### PR TITLE
Timeout generation with an error if the template generation is taking forever

### DIFF
--- a/src-electron/generator/generation-engine.js
+++ b/src-electron/generator/generation-engine.js
@@ -810,6 +810,11 @@ async function generateAllTemplates(
     await Promise.all(templates)
   }
 
+  if (genResult.hasErrors) {
+    for (const [key, value] of Object.entries(genResult.errors)) {
+      console.error(`${key}: ${value}`)
+    }
+  }
   genResult.partial = false
   return genResult
 }
@@ -852,6 +857,9 @@ async function generateSingleTemplate(
       options
     )
     for (let result of resultArray) {
+      if (!result.content) {
+        console.error(`No content generated for ${result.key}`)
+      }
       genResult.content[result.key] = result.content
       genResult.stats[result.key] = result.stats
     }

--- a/src-electron/generator/template-engine.js
+++ b/src-electron/generator/template-engine.js
@@ -191,7 +191,36 @@ async function produceContent(
   if (options.initialContext != null) {
     Object.assign(context, options.initialContext)
   }
-  let content = await template(context)
+  let content
+  // Render the template but if it does not render within 30s, then throw an
+  // error instead of just hanging forever.
+  try {
+    // Attempt to render the template
+    content = await Promise.race([
+      template(context),
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error('Template rendering timed out')),
+          30000
+        )
+      )
+    ])
+  } catch (error) {
+    // Log the error and throw it
+    notification.setNotification(
+      db,
+      'ERROR',
+      `Error during template rendering of ${singleTemplatePkg.path}: ` +
+        error.message,
+      sessionId,
+      1
+    )
+    console.error(
+      `Error during template rendering of ${singleTemplatePkg.path}: `,
+      error
+    )
+    throw error
+  }
   return [
     {
       key:
@@ -283,6 +312,14 @@ function helperWrapper(wrappedHelper) {
       }
     }
     try {
+      // Check each argument
+      for (const arg of args) {
+        if (arg instanceof Promise) {
+          throw new Error(
+            'Promises are not allowed as arguments in Handlebars helpers.'
+          )
+        }
+      }
       return wrappedHelper.call(this, ...args)
     } catch (err) {
       let thrownObject


### PR DESCRIPTION
- In template-engine.js, produceContent function, timing out the handlebars template handler if it takes more than a certain amount of time for generation because this can lead to ZAP just hanging forever.
- Also throwing errors when there is no content generated out of a generation template file
- Github: ZAP#792