### PR TITLE
Allow user to edit a device type on an existing endpoint as a new endpoint config and not an overwrite on existing endpoint config

### DIFF
--- a/cypress/e2e/endpoints/edit-endpoint.cy.js
+++ b/cypress/e2e/endpoints/edit-endpoint.cy.js
@@ -6,7 +6,8 @@ Cypress.on('uncaught:exception', (err, runnable) => {
 })
 
 describe('Testing Editing endpoints', () => {
-  it('create a new endpoint', () => {
+  beforeEach(() => {
+    // Set up the base URL and create an endpoint before each test
     cy.fixture('baseurl').then((data) => {
       cy.visit(data.baseurl)
     })
@@ -15,25 +16,58 @@ describe('Testing Editing endpoints', () => {
       cy.addEndpoint(data.endpoint1)
     })
   })
-  it('edit endpoint', { retries: { runMode: 2, openMode: 2 } }, () => {
-    cy.get('[data-test="edit-endpoint"]').last().click()
 
+  it('create a new endpoint', () => {
+    // Verify the endpoint was created successfully
     cy.fixture('data').then((data) => {
-      cy.get('[data-test="select-endpoint-input"]')
-        .click()
-        .type(data.endpoint2.substring(0, 5), { force: true })
-      cy.wait(500)
-      cy.get('div').contains(data.endpoint2).click({ force: true })
+      cy.get('aside').children().should('contain', data.endpoint1)
     })
-    cy.get('[data-test="endpoint-title"]').click() // it makes sure that the previous input field has been unselected
-    cy.get('button').contains('Save').click()
   })
   it(
-    'Check if edit is successfull',
+    'edit endpoint -> Overwrite',
     { retries: { runMode: 2, openMode: 2 } },
     () => {
+      cy.get('[data-test="edit-endpoint"]').last().click()
+
+      cy.fixture('data').then((data) => {
+        cy.get('[data-test="select-endpoint-input"]')
+          .click()
+          .type(data.endpoint2.substring(0, 5), { force: true })
+        cy.wait(500)
+        cy.get('div').contains(data.endpoint2).click({ force: true })
+      })
+      cy.get('[data-test="endpoint-title"]').click() // it makes sure that the previous input field has been unselected
+      cy.get('button').contains('Save').click()
+      cy.wait(500)
+      // Test overwrite option
+      cy.get('button').contains('Overwrite').click()
+      // Verify the endpoint was updated successfully
       cy.fixture('data').then((data) => {
         cy.get('aside').children().should('contain', data.endpoint2)
+      })
+    }
+  )
+  it(
+    'edit endpoint -> delete and add',
+    { retries: { runMode: 2, openMode: 2 } },
+    () => {
+      cy.get('[data-test="edit-endpoint"]').last().click()
+
+      cy.fixture('data').then((data) => {
+        cy.get('[data-test="select-endpoint-input"]')
+          .click()
+          .type(data.endpoint3.substring(0, 5), { force: true })
+        cy.wait(500)
+        cy.get('div').contains(data.endpoint3).click({ force: true })
+      })
+      cy.get('[data-test="endpoint-title"]').click() // it makes sure that the previous input field has been unselected
+      cy.get('button').contains('Save').click()
+      cy.wait(500)
+      // Test delete and add option
+      cy.get('button').contains('Delete and Add').click()
+      // Verify the endpoint was updated successfully
+      cy.fixture('data').then((data) => {
+        cy.get('aside').children().should('contain', data.endpoint3)
       })
     }
   )

--- a/src/components/ZclEndpointCard.vue
+++ b/src/components/ZclEndpointCard.vue
@@ -45,7 +45,6 @@ limitations under the License.
             dense
             icon="o_edit"
             size="sm"
-            v-close-popup
             @click="modifyEndpointDialog = !modifyEndpointDialog"
             data-test="edit-endpoint"
           >
@@ -202,6 +201,7 @@ limitations under the License.
     <q-dialog
       v-model="modifyEndpointDialog"
       class="background-color:transparent"
+      persistent
     >
       <zcl-create-modify-endpoint
         v-bind:endpointReference="endpointReference"


### PR DESCRIPTION
- Currently when a user edits the device type on an endpoint configuration then the configuration is overwritten on top of the existing endpoint configuration.
- However the above can lead to non-compliant device type as per the protocol specification if the users are not careful.
- With this change a dialogue pops up when the user changes the device type to either edit on top of existing endpoint config or add as a new endpoint config.
- Added cypress tests to cover the same
- Github: ZAP#1125