### PR TITLE
Allow cluster specific and generic data types with the same name in the XML

### DIFF
--- a/src-electron/db/query-loader.js
+++ b/src-electron/db/query-loader.js
@@ -203,10 +203,16 @@ SELECT
   DATA_TYPE.DATA_TYPE_ID
 FROM
   DATA_TYPE
+LEFT JOIN
+  DATA_TYPE_CLUSTER
+ON
+  DATA_TYPE.DATA_TYPE_ID = DATA_TYPE_CLUSTER.DATA_TYPE_REF
 WHERE
   DATA_TYPE.NAME = ?
 AND
-  DATA_TYPE.DISCRIMINATOR_REF = ?`
+  DATA_TYPE.DISCRIMINATOR_REF = ?
+AND
+  DATA_TYPE_CLUSTER.CLUSTER_CODE IS NULL`
 
 /**
  * Transforms the array of attributes in a certain format and returns it.
@@ -1821,6 +1827,8 @@ INNER JOIN
   DATA_TYPE
 ON
   ENUM.ENUM_ID = DATA_TYPE.DATA_TYPE_ID
+LEFT JOIN
+  DATA_TYPE_CLUSTER ON DATA_TYPE.DATA_TYPE_ID = DATA_TYPE_CLUSTER.DATA_TYPE_REF
 WHERE
   DATA_TYPE.PACKAGE_REF = ?
 AND
@@ -1836,6 +1844,8 @@ AND
                                   PACKAGE_REF
                                 IN
                                   (${dbApi.toInClause(knownPackages)}))
+AND
+  DATA_TYPE_CLUSTER.CLUSTER_CODE IS NULL
 `
 
   return dbApi.dbMultiInsert(
@@ -2041,6 +2051,8 @@ async function insertBitmapFields(db, packageId, knownPackages, data) {
        DATA_TYPE
      ON
        BITMAP.BITMAP_ID = DATA_TYPE.DATA_TYPE_ID
+     LEFT JOIN
+       DATA_TYPE_CLUSTER ON DATA_TYPE.DATA_TYPE_ID = DATA_TYPE_CLUSTER.DATA_TYPE_REF
      WHERE
        DATA_TYPE.PACKAGE_REF = ?
      AND
@@ -2055,6 +2067,8 @@ async function insertBitmapFields(db, packageId, knownPackages, data) {
                                       AND
                                         PACKAGE_REF
                                       IN (${dbApi.toInClause(knownPackages)}))
+     AND
+       DATA_TYPE_CLUSTER.CLUSTER_CODE IS NULL
   `
 
   return dbApi.dbMultiInsert(
@@ -2241,6 +2255,8 @@ async function insertStructItems(db, packageIds, data) {
        STRUCT
      INNER JOIN
        DATA_TYPE ON STRUCT.STRUCT_ID = DATA_TYPE.DATA_TYPE_ID
+     LEFT JOIN
+       DATA_TYPE_CLUSTER ON DATA_TYPE.DATA_TYPE_ID = DATA_TYPE_CLUSTER.DATA_TYPE_REF
      WHERE
        DATA_TYPE.PACKAGE_REF
      IN
@@ -2258,6 +2274,8 @@ async function insertStructItems(db, packageIds, data) {
                                         PACKAGE_REF
                                       IN
                                         (${dbApi.toInClause(packageIds)}))
+     AND
+       DATA_TYPE_CLUSTER.CLUSTER_CODE IS NULL
   `
 
   return dbApi.dbMultiInsert(

--- a/src-electron/generator/matter/controller/python/templates/helper.js
+++ b/src-electron/generator/matter/controller/python/templates/helper.js
@@ -82,9 +82,11 @@ async function as_underlying_python_zcl_type(type, clusterId, options) {
   if (type && type.toLowerCase() == 'boolean') {
     return 'bool';
   } else if (
-    dataType.discriminatorName.toLowerCase() == dbEnum.zclType.bitmap ||
-    dataType.discriminatorName.toLowerCase() == dbEnum.zclType.enum ||
-    dataType.discriminatorName.toLowerCase() == dbEnum.zclType.number
+    dataType &&
+    dataType.discriminatorName &&
+    (dataType.discriminatorName.toLowerCase() == dbEnum.zclType.bitmap ||
+      dataType.discriminatorName.toLowerCase() == dbEnum.zclType.enum ||
+      dataType.discriminatorName.toLowerCase() == dbEnum.zclType.number)
   ) {
     // Do not know on why this is the case but returning nothing for floats
     // and this is done for compatibility with asPythonType.

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -1651,7 +1651,7 @@ async function processStructItems(db, filePath, packageIds, data, context) {
     ) {
       structItems.push({
         structName: si.$.name,
-        structClusterCode: si.cluster ? parseInt(si.clusterCode) : null,
+        structClusterCode: si.cluster ? si.cluster : null,
         name: context.fabricHandling.indexFieldName,
         type: context.fabricHandling.indexType,
         fieldIdentifier: context.fabricHandling.indexFieldId,

--- a/zcl-builtin/matter/data-model/chip/binding-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/binding-cluster.xml
@@ -23,6 +23,7 @@ limitations under the License.
     <item fieldId="2" name="Group" type="GROUP_ID" optional="true"/>
     <item fieldId="3" name="Endpoint" type="ENDPOINT_NO" optional="true"/>
     <item fieldId="4" name="Cluster" type="CLUSTER_ID" optional="true"/>
+    <item fieldId="0xFE" name="FabricIndex" type="FABRIC_IDX"/>
   </struct>
 
   <cluster>

--- a/zcl-builtin/matter/data-model/chip/binding-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/binding-cluster.xml
@@ -23,7 +23,6 @@ limitations under the License.
     <item fieldId="2" name="Group" type="GROUP_ID" optional="true"/>
     <item fieldId="3" name="Endpoint" type="ENDPOINT_NO" optional="true"/>
     <item fieldId="4" name="Cluster" type="CLUSTER_ID" optional="true"/>
-    <item fieldId="0xFE" name="FabricIndex" type="FABRIC_IDX"/>
   </struct>
 
   <cluster>

--- a/zcl-builtin/matter/data-model/chip/descriptor-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/descriptor-cluster.xml
@@ -17,6 +17,13 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
 
+  <struct name="SemanticTagStruct">
+    <item name="MfgCode" type="vendor_id" isNullable="true"/>
+    <item name="NamespaceID" type="enum8"/>
+    <item name="Tag" type="enum8"/>
+    <item name="Label" type="char_string" isNullable="true" optional="true"/>
+  </struct>
+
   <struct name="DeviceTypeStruct">
     <cluster code="0x001d"/>
     <item name="DeviceType" type="DEVTYPE_ID"/>


### PR DESCRIPTION
- This solves the issue of loading a same named generic and cluster specific data type.
- The issue was with the generic data type type searches not checking if their cluster reference does not exist and thus getting the cluster specific data type instead. Now that check is added and duplicates issue is resolved
- Ran into another ZAP generation issue while running zap_regen_all.py and fixed that error in helper.js
- Github: ZAP#1540