### PR TITLE
Cluster Feature Page - Display Feature Info

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3655,6 +3655,8 @@ This module provides queries for features.
 
 * [DB API: feature related queries](#module_DB API_ feature related queries)
     * [~getFeaturesByDeviceTypeRefs(db, deviceTypeRefs, endpointTypeRef)](#module_DB API_ feature related queries..getFeaturesByDeviceTypeRefs) ⇒
+    * [~selectAllFeatures(db, packageIds)](#module_DB API_ feature related queries..selectAllFeatures) ⇒
+    * [~selectFeaturesByClusterId(db, clusterId)](#module_DB API_ feature related queries..selectFeaturesByClusterId) ⇒
     * [~checkIfConformanceDataExist(db)](#module_DB API_ feature related queries..checkIfConformanceDataExist) ⇒
 
 <a name="module_DB API_ feature related queries..getFeaturesByDeviceTypeRefs"></a>
@@ -3674,6 +3676,32 @@ with associated device type, cluster, and featureMap attribute details
 | db | <code>\*</code> | 
 | deviceTypeRefs | <code>\*</code> | 
 | endpointTypeRef | <code>\*</code> | 
+
+<a name="module_DB API_ feature related queries..selectAllFeatures"></a>
+
+### DB API: feature related queries~selectAllFeatures(db, packageIds) ⇒
+Retrieves all features from given package ids.
+
+**Kind**: inner method of [<code>DB API: feature related queries</code>](#module_DB API_ feature related queries)  
+**Returns**: promise of an array of features  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
+<a name="module_DB API_ feature related queries..selectFeaturesByClusterId"></a>
+
+### DB API: feature related queries~selectFeaturesByClusterId(db, clusterId) ⇒
+Retrieves features for a given cluster Id.
+
+**Kind**: inner method of [<code>DB API: feature related queries</code>](#module_DB API_ feature related queries)  
+**Returns**: promise of an array of features in the cluster  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| clusterId | <code>\*</code> | 
 
 <a name="module_DB API_ feature related queries..checkIfConformanceDataExist"></a>
 
@@ -14418,6 +14446,7 @@ This module provides the API to access zcl specific information.
     * [~httpGetDeviceTypeFeatures(db)](#module_REST API_ user data..httpGetDeviceTypeFeatures) ⇒
     * [~httpPostCheckConformOnFeatureUpdate(db)](#module_REST API_ user data..httpPostCheckConformOnFeatureUpdate) ⇒
     * [~httpGetRequiredElements(db)](#module_REST API_ user data..httpGetRequiredElements) ⇒
+    * [~httpGetFeatureMapValue(db)](#module_REST API_ user data..httpGetFeatureMapValue)
     * [~httpGetSessionNotifications(db)](#module_REST API_ user data..httpGetSessionNotifications) ⇒
     * [~httpDeleteSessionNotification(db)](#module_REST API_ user data..httpDeleteSessionNotification) ⇒
     * [~httpGetPackageNotifications(db)](#module_REST API_ user data..httpGetPackageNotifications) ⇒
@@ -14522,6 +14551,17 @@ HTTP GET: required and unsupported cluster elements based on conformance
 
 **Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
 **Returns**: callback for the express uri registration  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+
+<a name="module_REST API_ user data..httpGetFeatureMapValue"></a>
+
+### REST API: user data~httpGetFeatureMapValue(db)
+HTTP GET: the value of feature map attribute in an endpoint type cluster
+
+**Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
 
 | Param | Type |
 | --- | --- |
@@ -15625,7 +15665,7 @@ This module provides the REST API to the static zcl queries.
 * [REST API: static zcl functions](#module_REST API_ static zcl functions)
     * [~zclEntityQuery(selectAllFunction, selectByIdFunction)](#module_REST API_ static zcl functions..zclEntityQuery) ⇒
     * [~returnZclEntitiesForClusterId(db, clusterId, packageId)](#module_REST API_ static zcl functions..returnZclEntitiesForClusterId) ⇒
-    * [~mergeZclClusterAttributeCommandEventData(accumulated, currentValue)](#module_REST API_ static zcl functions..mergeZclClusterAttributeCommandEventData) ⇒
+    * [~mergeZclClusterAttributeCommandEventFeatureData(accumulated, currentValue)](#module_REST API_ static zcl functions..mergeZclClusterAttributeCommandEventFeatureData) ⇒
     * [~reduceAndConcatenateZclEntity(db, id, packageIdArray, zclQueryCallback, mergeFunction, defaultValue)](#module_REST API_ static zcl functions..reduceAndConcatenateZclEntity) ⇒
     * [~parseForZclData(db, entity, id, packageIdArray)](#module_REST API_ static zcl functions..parseForZclData) ⇒
     * [~httpGetZclEntity(app)](#module_REST API_ static zcl functions..httpGetZclEntity)
@@ -15649,7 +15689,7 @@ each of the different ZCL entities.
 <a name="module_REST API_ static zcl functions..returnZclEntitiesForClusterId"></a>
 
 ### REST API: static zcl functions~returnZclEntitiesForClusterId(db, clusterId, packageId) ⇒
-For the CLUSTER path, we have special handling to also sideload attributes and commands relevant to that cluster.
+For the CLUSTER path, we have special handling to also sideload attributes, commands, events, and features relevant to that cluster.
 
 **Kind**: inner method of [<code>REST API: static zcl functions</code>](#module_REST API_ static zcl functions)  
 **Returns**: zcl entities  
@@ -15660,9 +15700,9 @@ For the CLUSTER path, we have special handling to also sideload attributes and c
 | clusterId | <code>\*</code> | 
 | packageId | <code>\*</code> | 
 
-<a name="module_REST API_ static zcl functions..mergeZclClusterAttributeCommandEventData"></a>
+<a name="module_REST API_ static zcl functions..mergeZclClusterAttributeCommandEventFeatureData"></a>
 
-### REST API: static zcl functions~mergeZclClusterAttributeCommandEventData(accumulated, currentValue) ⇒
+### REST API: static zcl functions~mergeZclClusterAttributeCommandEventFeatureData(accumulated, currentValue) ⇒
 This is the special merge function used for the CLUSTER path
 
 **Kind**: inner method of [<code>REST API: static zcl functions</code>](#module_REST API_ static zcl functions)  
@@ -15693,7 +15733,7 @@ This maps over each packageId, and runs the query callback.
 <a name="module_REST API_ static zcl functions..parseForZclData"></a>
 
 ### REST API: static zcl functions~parseForZclData(db, entity, id, packageIdArray) ⇒
-Get entity details absed on given information.
+Get entity details based on given information.
 
 **Kind**: inner method of [<code>REST API: static zcl functions</code>](#module_REST API_ static zcl functions)  
 **Returns**: Promise of entity details  
@@ -15741,6 +15781,7 @@ This module provides the REST API to the user specific data.
     * [~httpGetDeviceTypeFeatures(db)](#module_REST API_ user data..httpGetDeviceTypeFeatures) ⇒
     * [~httpPostCheckConformOnFeatureUpdate(db)](#module_REST API_ user data..httpPostCheckConformOnFeatureUpdate) ⇒
     * [~httpGetRequiredElements(db)](#module_REST API_ user data..httpGetRequiredElements) ⇒
+    * [~httpGetFeatureMapValue(db)](#module_REST API_ user data..httpGetFeatureMapValue)
     * [~httpGetSessionNotifications(db)](#module_REST API_ user data..httpGetSessionNotifications) ⇒
     * [~httpDeleteSessionNotification(db)](#module_REST API_ user data..httpDeleteSessionNotification) ⇒
     * [~httpGetPackageNotifications(db)](#module_REST API_ user data..httpGetPackageNotifications) ⇒
@@ -15845,6 +15886,17 @@ HTTP GET: required and unsupported cluster elements based on conformance
 
 **Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
 **Returns**: callback for the express uri registration  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+
+<a name="module_REST API_ user data..httpGetFeatureMapValue"></a>
+
+### REST API: user data~httpGetFeatureMapValue(db)
+HTTP GET: the value of feature map attribute in an endpoint type cluster
+
+**Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
 
 | Param | Type |
 | --- | --- |

--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -271,7 +271,7 @@ exports.map = {
     }
   },
 
-  feature: (x) => {
+  clusterFeature: (x) => {
     if (x == null) return undefined
     return {
       id: x.FEATURE_ID,

--- a/src-electron/db/db-mapping.js
+++ b/src-electron/db/db-mapping.js
@@ -271,6 +271,20 @@ exports.map = {
     }
   },
 
+  feature: (x) => {
+    if (x == null) return undefined
+    return {
+      id: x.FEATURE_ID,
+      name: x.NAME,
+      code: x.CODE,
+      bit: x.BIT,
+      description: x.DESCRIPTION,
+      conformance: x.CONFORMANCE,
+      packageRef: x.PACKAGE_REF,
+      clusterId: x.CLUSTER_REF
+    }
+  },
+
   domain: (x) => {
     if (x == null) return undefined
     return {

--- a/src-electron/db/query-feature.js
+++ b/src-electron/db/query-feature.js
@@ -22,6 +22,7 @@
  */
 const dbApi = require('./db-api')
 const dbMapping = require('./db-mapping')
+const dbEnum = require('../../src-shared/db-enum.js')
 
 /**
  * Get all device type features associated with a list of device type refs and an endpoint.
@@ -95,9 +96,9 @@ async function getFeaturesByDeviceTypeRefs(
     AND
 			ETC.ENDPOINT_TYPE_REF = ?
     AND
-			A.NAME = 'FeatureMap'
+      A.NAME = '${dbEnum.featureMapAttribute.name}'
     AND
-			A.CODE = 65532
+      A.CODE = ${dbEnum.featureMapAttribute.code}
     AND
 			(
 				(DC.INCLUDE_SERVER = 1 AND ETC.SIDE = 'server')
@@ -107,7 +108,7 @@ async function getFeaturesByDeviceTypeRefs(
     ORDER BY
 			D.DEVICE_TYPE_ID,
 			DC.CLUSTER_REF,
-			F.FEATURE_ID
+			F.BIT
     `,
     arg
   )
@@ -165,10 +166,10 @@ async function selectAllFeatures(db, packageIds) {
       F.PACKAGE_REF in (${dbApi.toInClause(packageIds)})
     ORDER BY
       C.CODE,
-      F.FEATURE_ID
+      F.BIT
     `
   )
-  return rows.map(dbMapping.map.feature)
+  return rows.map(dbMapping.map.clusterFeature)
 }
 
 /**
@@ -196,11 +197,11 @@ async function selectFeaturesByClusterId(db, clusterId) {
     WHERE
       CLUSTER_REF = ?
     ORDER BY
-      FEATURE_ID
+      BIT
     `,
     [clusterId]
   )
-  return rows.map(dbMapping.map.feature)
+  return rows.map(dbMapping.map.clusterFeature)
 }
 
 /**

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -174,6 +174,25 @@ function httpGetRequiredElements(db) {
 }
 
 /**
+ * HTTP GET: the value of feature map attribute in an endpoint type cluster
+ *
+ * @param {*} db
+ */
+function httpGetFeatureMapValue(db) {
+  return async (request, response) => {
+    let { attributeId, clusterId, endpointTypeId } = request.query
+    let featureMapAttribute = await queryZcl.selectEndpointTypeAttribute(
+      db,
+      endpointTypeId,
+      attributeId,
+      clusterId
+    )
+    let featureMapValue = parseInt(featureMapAttribute.defaultValue) || 0
+    response.status(StatusCodes.OK).json(featureMapValue)
+  }
+}
+
+/**
  * HTTP GET: session get notifications
  *
  * @param {*} db
@@ -1292,6 +1311,10 @@ exports.get = [
   {
     uri: restApi.uri.requiredElements,
     callback: httpGetRequiredElements
+  },
+  {
+    uri: restApi.uri.featureMapValue,
+    callback: httpGetFeatureMapValue
   }
 ]
 

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -187,7 +187,9 @@ function httpGetFeatureMapValue(db) {
       attributeId,
       clusterId
     )
-    let featureMapValue = parseInt(featureMapAttribute.defaultValue) || 0
+    let featureMapValue = featureMapAttribute.defaultValue
+      ? parseInt(featureMapAttribute.defaultValue)
+      : 0
     response.status(StatusCodes.OK).json(featureMapValue)
   }
 }

--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -221,7 +221,6 @@ exports.packageMatch = {
 exports.feature = {
   name: {
     enabled: 'enabled',
-    featureId: 'featureId',
     deviceType: 'deviceType',
     cluster: 'cluster',
     clusterSide: 'clusterSide',
@@ -233,7 +232,6 @@ exports.feature = {
   },
   label: {
     enabled: 'Enabled',
-    featureId: 'Feature ID',
     deviceType: 'Device Type',
     cluster: 'Cluster',
     clusterSide: 'Cluster Side',
@@ -243,4 +241,9 @@ exports.feature = {
     bit: 'Bit',
     description: 'Description'
   }
+}
+
+exports.featureMapAttribute = {
+  name: 'FeatureMap',
+  code: 65532
 }

--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -218,9 +218,10 @@ exports.packageMatch = {
   ignore: 'ignore' // This mechanism will completely ignore the use of packages in the .zap file.
 }
 
-exports.deviceTypeFeature = {
+exports.feature = {
   name: {
     enabled: 'enabled',
+    featureId: 'featureId',
     deviceType: 'deviceType',
     cluster: 'cluster',
     clusterSide: 'clusterSide',
@@ -232,6 +233,7 @@ exports.deviceTypeFeature = {
   },
   label: {
     enabled: 'Enabled',
+    featureId: 'Feature ID',
     deviceType: 'Device Type',
     cluster: 'Cluster',
     clusterSide: 'Cluster Side',

--- a/src-shared/rest-api.js
+++ b/src-shared/rest-api.js
@@ -37,6 +37,7 @@ const uri = {
   packageNotificationById: '/packageNotificationById/:packageId',
   updateNotificationToSeen: '/updateNotificationToSeen',
   updateBitOfFeatureMapAttribute: '/updateBitOfFeatureMapAttribute',
+  featureMapValue: '/featureMapValue',
   conformDataExists: '/conformDataExists',
   requiredElementWarning: '/requiredElementWarning',
   deleteSessionNotification: '/deleteSessionNotification',

--- a/src/components/ZclClusterFeatureManager.vue
+++ b/src/components/ZclClusterFeatureManager.vue
@@ -28,16 +28,6 @@ limitations under the License.
         separator="horizontal"
         id="ZclAttributeManager"
       >
-        <template v-slot:top>
-          <div class="row items-center q-pb-lg q-pt-sm q-pl-sm">
-            <div class="col-auto text-bold q-mr-md">
-              Server FeatureMap Attribute Value:
-            </div>
-            <div class="col-2">
-              <q-input v-model="featureMapValue" dense outlined disable />
-            </div>
-          </div>
-        </template>
         <template v-slot:header="props">
           <q-tr :props="props">
             <q-th v-for="col in props.cols" :key="col.name" :props="props">

--- a/src/components/ZclClusterFeatureManager.vue
+++ b/src/components/ZclClusterFeatureManager.vue
@@ -1,0 +1,190 @@
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div>
+    <div v-if="featureData.length > 0">
+      <q-table
+        class="my-sticky-header-table"
+        :rows="featureData"
+        :columns="columns"
+        row-key="<b>name</b>"
+        dense
+        flat
+        v-model:pagination="pagination"
+        separator="horizontal"
+        id="ZclAttributeManager"
+      >
+        <template v-slot:top>
+          <div class="row items-center q-pb-lg q-pt-sm q-pl-sm">
+            <div class="col-auto text-bold q-mr-md">
+              Server FeatureMap Attribute Value:
+            </div>
+            <div class="col-2">
+              <q-input v-model="featureMapValue" dense outlined disable />
+            </div>
+          </div>
+        </template>
+        <template v-slot:header="props">
+          <q-tr :props="props">
+            <q-th v-for="col in props.cols" :key="col.name" :props="props">
+              {{ col.label }}
+            </q-th>
+          </q-tr>
+        </template>
+        <template v-slot:body="props">
+          <q-tr :props="props" class="table_body">
+            <q-td key="enabled" :props="props" auto-width>
+              <q-toggle
+                :disable="isToggleDisabled(props.row.conformance)"
+                class="q-mt-xs v-step-14"
+                v-model="enabledFeatures"
+                :val="props.row.id"
+                indeterminate-value="false"
+                keep-color
+              />
+            </q-td>
+            <q-td key="featureName" :props="props" auto-width>
+              {{ props.row.name }}
+            </q-td>
+            <q-td key="code" :props="props" auto-width>
+              {{ props.row.code }}
+            </q-td>
+            <q-td key="conformance" :props="props" auto-width>
+              {{ props.row.conformance }}
+            </q-td>
+            <q-td key="bit" :props="props" auto-width>
+              {{ props.row.bit }}
+            </q-td>
+            <q-td key="description" :props="props" auto-width>
+              {{ props.row.description }}
+            </q-td>
+          </q-tr>
+        </template>
+      </q-table>
+    </div>
+    <div v-else><br />{{ noFeaturesMessage }}</div>
+  </div>
+</template>
+
+<script>
+import EditableAttributesMixin from '../util/editable-attributes-mixin.js'
+import uiOptions from '../util/ui-options'
+import CommonMixin from '../util/common-mixin'
+import dbEnum from '../../src-shared/db-enum'
+
+export default {
+  name: 'ZclClusterFeatureManager',
+  mixins: [EditableAttributesMixin, uiOptions, CommonMixin],
+  computed: {
+    featureData() {
+      return this.$store.state.zap.features
+        .filter((feature) => {
+          return this.individualClusterFilterString == ''
+            ? true
+            : feature.name
+                .toLowerCase()
+                .includes(this.individualClusterFilterString.toLowerCase())
+        })
+        .map((feature) => {
+          // override feature conformance from device type features if available
+          const matchingDeviceTypeFeature = this.deviceTypeFeatures.find(
+            (deviceTypeFeature) =>
+              deviceTypeFeature.featureId === feature.id &&
+              deviceTypeFeature.clusterRef === feature.clusterId
+          )
+          if (matchingDeviceTypeFeature) {
+            feature.conformance = matchingDeviceTypeFeature.conformance
+          }
+          return feature
+        })
+    },
+    featureMapValue() {
+      return this.$store.state.zap.featureMapValue
+    },
+    enabledFeatures() {
+      return this.featureData
+        .filter((feature) => {
+          return this.getEnabledBitsFromFeatureMapValue(
+            this.featureMapValue
+          ).includes(feature.bit)
+        })
+        .map((feature) => feature.id)
+    }
+  },
+  methods: {
+    isToggleDisabled(conformance) {
+      // disable toggling features for now, will support in future PR
+      return true
+    },
+    getEnabledBitsFromFeatureMapValue(featureMapValue) {
+      let enabledBits = []
+      for (let i = 0; i < 32; i++) {
+        if ((featureMapValue & (1 << i)) != 0) {
+          enabledBits.push(i)
+        }
+      }
+      return enabledBits
+    }
+  },
+  data() {
+    return {
+      noFeaturesMessage: 'No features available for this cluster.',
+      pagination: {
+        rowsPerPage: 0
+      },
+      columns: [
+        {
+          name: dbEnum.feature.name.enabled,
+          required: true,
+          label: dbEnum.feature.label.enabled,
+          align: 'left'
+        },
+        {
+          name: dbEnum.feature.name.featureName,
+          required: true,
+          label: dbEnum.feature.label.featureName,
+          align: 'left'
+        },
+        {
+          name: dbEnum.feature.name.code,
+          required: true,
+          label: dbEnum.feature.label.code,
+          align: 'left'
+        },
+        {
+          name: dbEnum.feature.name.conformance,
+          required: true,
+          label: dbEnum.feature.label.conformance,
+          align: 'left'
+        },
+        {
+          name: dbEnum.feature.name.bit,
+          required: true,
+          label: dbEnum.feature.label.bit,
+          align: 'left'
+        },
+        {
+          name: dbEnum.feature.name.description,
+          required: false,
+          label: dbEnum.feature.label.description,
+          align: 'left'
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/src/components/ZclClusterView.vue
+++ b/src/components/ZclClusterView.vue
@@ -98,6 +98,11 @@ limitations under the License.
                 />
                 <q-tab name="commands" label="Commands" class="v-step-12" />
                 <q-tab name="events" label="Events" v-show="enableEventsTab" />
+                <q-tab
+                  name="features"
+                  label="Features"
+                  v-show="enableFeaturesTab"
+                />
               </q-tabs>
               <div
                 class="col column linear-border-wrap"
@@ -115,6 +120,9 @@ limitations under the License.
                 <div class="col column" v-show="tab == 'events'">
                   <ZclEventManager />
                 </div>
+                <div class="col column" v-show="tab == 'features'">
+                  <ZclClusterFeatureManager />
+                </div>
               </div>
             </div>
           </div>
@@ -128,14 +136,16 @@ import ZclAttributeManager from './ZclAttributeManager.vue'
 import ZclAttributeReportingManager from './ZclAttributeReportingManager.vue'
 import ZclCommandManager from './ZclCommandManager.vue'
 import ZclEventManager from './ZclEventManager.vue'
+import ZclClusterFeatureManager from './ZclClusterFeatureManager.vue'
 import EditableAttributesMixin from '../util/editable-attributes-mixin'
 import CommonMixin from '../util/common-mixin'
+import uiOptions from '../util/ui-options'
 
 import * as dbEnum from '../../src-shared/db-enum.js'
 
 export default {
   name: 'ZclClusterView',
-  mixins: [CommonMixin, EditableAttributesMixin],
+  mixins: [CommonMixin, EditableAttributesMixin, uiOptions],
   computed: {
     isClusterDocumentationAvailable() {
       return (
@@ -199,6 +209,14 @@ export default {
         return this.category === dbEnum.helperCategory.matter
       }
     },
+    enableFeaturesTab: {
+      get() {
+        return (
+          this.category === dbEnum.helperCategory.matter &&
+          this.conformDataExists
+        )
+      }
+    },
     enableAttributeReportingTab: {
       get() {
         return this.category === dbEnum.helperCategory.zigbee
@@ -240,7 +258,8 @@ export default {
     ZclCommandManager,
     ZclAttributeManager,
     ZclAttributeReportingManager,
-    ZclEventManager
+    ZclEventManager,
+    ZclClusterFeatureManager
   }
 }
 </script>

--- a/src/components/ZclClusterView.vue
+++ b/src/components/ZclClusterView.vue
@@ -81,29 +81,43 @@ limitations under the License.
               </div>
             </div>
             <div class="col column">
-              <q-tabs
-                v-model="tab"
-                dense
-                align="left"
-                active-bg-color="primary"
-                indicator-color="primary"
-                class="q-pl-lg"
-              >
-                <q-tab name="attributes" label="Attributes" class="v-step-10" />
-                <q-tab
-                  name="reporting"
-                  label="Attribute Reporting"
-                  class="v-step-11"
-                  v-show="enableAttributeReportingTab"
-                />
-                <q-tab name="commands" label="Commands" class="v-step-12" />
-                <q-tab name="events" label="Events" v-show="enableEventsTab" />
-                <q-tab
-                  name="features"
-                  label="Features"
-                  v-show="enableFeaturesTab"
-                />
-              </q-tabs>
+              <div class="row items-center justify-between q-pl-lg">
+                <q-tabs
+                  v-model="tab"
+                  dense
+                  align="left"
+                  active-bg-color="primary"
+                  indicator-color="primary"
+                  class="q-pl-lg"
+                >
+                  <q-tab
+                    name="attributes"
+                    label="Attributes"
+                    class="v-step-10"
+                  />
+                  <q-tab
+                    name="reporting"
+                    label="Attribute Reporting"
+                    class="v-step-11"
+                    v-show="enableAttributeReportingTab"
+                  />
+                  <q-tab name="commands" label="Commands" class="v-step-12" />
+                  <q-tab
+                    name="events"
+                    label="Events"
+                    v-show="enableEventsTab"
+                  />
+                  <q-tab
+                    name="features"
+                    label="Features"
+                    v-show="enableFeaturesTab"
+                  />
+                </q-tabs>
+                <div class="text-right q-pr-lg" v-show="tab == 'features'">
+                  Server FeatureMap Attribute:
+                  <span class="text-bold">{{ featureMapValue }}</span>
+                </div>
+              </div>
               <div
                 class="col column linear-border-wrap"
                 v-show="Object.keys(selectedCluster).length > 0"

--- a/src/components/ZclDeviceTypeFeatureManager.vue
+++ b/src/components/ZclDeviceTypeFeatureManager.vue
@@ -26,6 +26,7 @@ limitations under the License.
     <div class="col column linear-border-wrap">
       <div v-if="deviceTypeFeatures.length > 0">
         <q-table
+          class="my-striped-table"
           :rows="deviceTypeFeatures"
           :columns="columns"
           flat
@@ -34,7 +35,7 @@ limitations under the License.
           id="ZclDeviceTypeFeatureManager"
         >
           <template v-slot:body="props">
-            <q-tr :props="props" class="table_body attribute_table_body">
+            <q-tr :props="props">
               <q-td key="enabled" :props="props" auto-width>
                 <q-toggle
                   :disable="isToggleDisabled(props.row.conformance)"
@@ -396,57 +397,57 @@ export default {
       eventsToUpdate: [],
       columns: [
         {
-          name: dbEnum.deviceTypeFeature.name.enabled,
+          name: dbEnum.feature.name.enabled,
           required: true,
-          label: dbEnum.deviceTypeFeature.label.enabled,
+          label: dbEnum.feature.label.enabled,
           align: 'left'
         },
         {
-          name: dbEnum.deviceTypeFeature.name.deviceType,
+          name: dbEnum.feature.name.deviceType,
           required: true,
-          label: dbEnum.deviceTypeFeature.label.deviceType,
+          label: dbEnum.feature.label.deviceType,
           align: 'left'
         },
         {
-          name: dbEnum.deviceTypeFeature.name.cluster,
+          name: dbEnum.feature.name.cluster,
           required: true,
-          label: dbEnum.deviceTypeFeature.label.cluster,
+          label: dbEnum.feature.label.cluster,
           align: 'left'
         },
         {
-          name: dbEnum.deviceTypeFeature.name.clusterSide,
+          name: dbEnum.feature.name.clusterSide,
           required: true,
-          label: dbEnum.deviceTypeFeature.label.clusterSide,
+          label: dbEnum.feature.label.clusterSide,
           align: 'left'
         },
         {
-          name: dbEnum.deviceTypeFeature.name.featureName,
+          name: dbEnum.feature.name.featureName,
           required: true,
-          label: dbEnum.deviceTypeFeature.label.featureName,
+          label: dbEnum.feature.label.featureName,
           align: 'left'
         },
         {
-          name: dbEnum.deviceTypeFeature.name.code,
+          name: dbEnum.feature.name.code,
           required: true,
-          label: dbEnum.deviceTypeFeature.label.code,
+          label: dbEnum.feature.label.code,
           align: 'left'
         },
         {
-          name: dbEnum.deviceTypeFeature.name.conformance,
+          name: dbEnum.feature.name.conformance,
           required: true,
-          label: dbEnum.deviceTypeFeature.label.conformance,
+          label: dbEnum.feature.label.conformance,
           align: 'left'
         },
         {
-          name: dbEnum.deviceTypeFeature.name.bit,
+          name: dbEnum.feature.name.bit,
           required: true,
-          label: dbEnum.deviceTypeFeature.label.bit,
+          label: dbEnum.feature.label.bit,
           align: 'left'
         },
         {
-          name: dbEnum.deviceTypeFeature.name.description,
+          name: dbEnum.feature.name.description,
           required: false,
-          label: dbEnum.deviceTypeFeature.label.description,
+          label: dbEnum.feature.label.description,
           align: 'left'
         }
       ]

--- a/src/components/ZclDomainClusterView.vue
+++ b/src/components/ZclDomainClusterView.vue
@@ -224,6 +224,7 @@ limitations under the License.
 import CommonMixin from '../util/common-mixin'
 import restApi from '../../src-shared/rest-api'
 import uiOptions from '../util/ui-options'
+import EditableAttributesMixin from '../util/editable-attributes-mixin.js'
 
 let ZclClusterRoleAction = {
   Add: 'add',
@@ -235,7 +236,7 @@ let ZclClusterRole = { server: 'server', client: 'client' }
 export default {
   name: 'ZclDomainClusterView',
   props: ['domainName', 'clusters'],
-  mixins: [CommonMixin, uiOptions],
+  mixins: [CommonMixin, uiOptions, EditableAttributesMixin],
   computed: {
     isInStandalone: {
       get() {
@@ -588,6 +589,17 @@ export default {
           this.selectedEndpointTypeId
         )
         this.$store.dispatch('zap/setLastSelectedDomain', this.domainName)
+        this.setFeatureMapAttribute(cluster)
+      })
+    },
+    setFeatureMapAttribute(cluster) {
+      let featureMapAttribute = this.relevantAttributeData.find(
+        (attribute) => attribute.name == 'FeatureMap' && attribute.code == 65532
+      )
+      this.$store.dispatch('zap/updateFeatureMapValue', {
+        attributeId: featureMapAttribute.id,
+        clusterId: cluster.id,
+        endpointTypeId: this.selectedEndpointTypeId
       })
     },
     ucLabel(id) {

--- a/src/components/ZclDomainClusterView.vue
+++ b/src/components/ZclDomainClusterView.vue
@@ -225,6 +225,7 @@ import CommonMixin from '../util/common-mixin'
 import restApi from '../../src-shared/rest-api'
 import uiOptions from '../util/ui-options'
 import EditableAttributesMixin from '../util/editable-attributes-mixin.js'
+import dbEnum from '../../src-shared/db-enum'
 
 let ZclClusterRoleAction = {
   Add: 'add',
@@ -594,7 +595,9 @@ export default {
     },
     setFeatureMapAttribute(cluster) {
       let featureMapAttribute = this.relevantAttributeData.find(
-        (attribute) => attribute.name == 'FeatureMap' && attribute.code == 65532
+        (attribute) =>
+          attribute.name == dbEnum.featureMapAttribute.name &&
+          attribute.code == dbEnum.featureMapAttribute.code
       )
       this.$store.dispatch('zap/updateFeatureMapValue', {
         attributeId: featureMapAttribute.id,

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -24,6 +24,13 @@
   color: black
     top: 48px
 
+.my-striped-table
+  tr:nth-child(odd)
+    background-color: #ffffff // White background for odd rows
+
+  tr:nth-child(even)
+    background-color: #eeeeee // Light gray background for even rows
+
 .body--dark .my-sticky-header-table
   thead tr:first-child th
     /* bg color is important for th; just specify one */

--- a/src/store/zap/actions.js
+++ b/src/store/zap/actions.js
@@ -93,6 +93,7 @@ export async function updateSelectedCluster(context, cluster) {
   updateAttributes(context, res.data.attributeData || [])
   updateCommands(context, res.data.commandData || [])
   updateEvents(context, res.data.eventData || [])
+  updateFeatures(context, res.data.featureData || [])
 }
 
 /**
@@ -120,6 +121,28 @@ export function updateCommands(context, commands) {
  */
 export function updateEvents(context, events) {
   context.commit('updateEvents', events)
+}
+
+/**
+ * Update the features for ZAP UI.
+ * @param {*} context
+ * @param {*} features
+ */
+export function updateFeatures(context, features) {
+  context.commit('updateFeatures', features)
+}
+
+/**
+ * Update the default value of feature map attribute for the updated cluster.
+ * @param {*} context
+ * @param {*} attributes
+ */
+export function updateFeatureMapValue(context, data) {
+  axiosRequests
+    .$serverGet(restApi.uri.featureMapValue, { params: data })
+    .then((response) => {
+      context.commit('updateFeatureMapValue', response.data)
+    })
 }
 
 /**

--- a/src/store/zap/mutations.js
+++ b/src/store/zap/mutations.js
@@ -190,6 +190,15 @@ export function updateAttributes(state, attributes) {
 }
 
 /**
+ * Update the default value of feature map attribute in the state.
+ * @param {*} state
+ * @param {*} attributes
+ */
+export function updateFeatureMapValue(state, value) {
+  state.featureMapValue = value
+}
+
+/**
  * Set the endpointTypeAttribute details in the state.
  * @param {*} state
  * @param {*} endpointTypeAttribute
@@ -423,6 +432,15 @@ export function updateCommands(state, commands) {
  */
 export function updateEvents(state, events) {
   state.events = events
+}
+
+/**
+ * Update features in the state
+ * @param {*} state
+ * @param {*} features
+ */
+export function updateFeatures(state, features) {
+  state.features = features
 }
 
 /**

--- a/src/store/zap/state.js
+++ b/src/store/zap/state.js
@@ -48,6 +48,8 @@ export default function () {
     attributes: [],
     commands: [],
     events: [],
+    features: [],
+    featureMapValue: 0,
     zclDeviceTypes: {},
     endpoints: [],
     genericOptions: {},

--- a/src/util/common-mixin.js
+++ b/src/util/common-mixin.js
@@ -145,6 +145,11 @@ export default {
         }, {})
       }
     },
+    featureMapValue: {
+      get() {
+        return this.$store.state.zap.featureMapValue
+      }
+    },
     enabledDeviceTypeFeatures: {
       get() {
         return this.$store.state.zap.featureView.enabledDeviceTypeFeatures

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -33,6 +33,7 @@ const testQuery = require('./test-query')
 const httpServer = require('../src-electron/server/http-server')
 const restApi = require('../src-shared/rest-api')
 const axios = require('axios')
+const dbEnum = require('../src-shared/db-enum')
 
 let db
 let ctx
@@ -489,7 +490,9 @@ test(
         onOffCluster.side
       )
     let featureMapAttribute = attributes.find(
-      (attribute) => attribute.name == 'FeatureMap' && attribute.code == 65532
+      (attribute) =>
+        attribute.name == dbEnum.featureMapAttribute.name &&
+        attribute.code == dbEnum.featureMapAttribute.code
     )
 
     let resp = await axiosInstance.get(restApi.uri.featureMapValue, {

--- a/test/test-query.js
+++ b/test/test-query.js
@@ -38,6 +38,7 @@ async function getAllEndpointTypeClusterState(db, endpointTypeId) {
     db,
     `
 SELECT
+  CLUSTER.CLUSTER_ID,
   CLUSTER.NAME,
   CLUSTER.CODE,
   CLUSTER.MANUFACTURER_CODE,
@@ -55,6 +56,7 @@ WHERE ENDPOINT_TYPE_CLUSTER.ENDPOINT_TYPE_REF = ?`,
 
   let result = rows.map((row) => {
     let obj = {
+      clusterId: row.CLUSTER_ID,
       endpointTypeClusterId: row.ENDPOINT_TYPE_CLUSTER_ID,
       clusterName: row.NAME,
       clusterCode: row.CODE,

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -27,6 +27,8 @@ function testServer(fileName) {
     testPort = 9075
   } else if (fileName.includes('server-session.test')) {
     testPort = 9076
+  } else if (fileName.includes('feature.test')) {
+    testPort = 9077
   } else {
     let msg = new Error(
       `You must manually assign a port for the given test file: ${fileName}`


### PR DESCRIPTION
- Implemented the Cluster Feature page to display feature details and enabled status based on cluster XML definitions.
(Note: Feature toggling is currently disabled and will be enabled in a future PR.)
- Displayed the FeatureMap Attribute Value on the top right corner of the page to assist with feature configuration.
- Added backend logic and REST APIs
- Added unit test for API getting featureMap attribute value

ZAPP-1547