### PR TITLE
Fix: Handling package paths in different drives than user home dir or zap file location

### DIFF
--- a/src-electron/importexport/export.js
+++ b/src-electron/importexport/export.js
@@ -136,6 +136,10 @@ async function exportSessionPackages(db, sessionId, zapProjectFileLocation) {
         pathRelativity = dbEnum.pathRelativity.relativeToZap
       }
     }
+    if (path.isAbsolute(relativePath) && /^[A-Z]:\\/.test(relativePath)) {
+      // Handling Windows path when package is on different drive than zapProjectFile or user home
+      pathRelativity = dbEnum.pathRelativity.absolute
+    }
     let ret = {
       pathRelativity: pathRelativity,
       path: relativePath,

--- a/src-electron/importexport/export.js
+++ b/src-electron/importexport/export.js
@@ -136,7 +136,7 @@ async function exportSessionPackages(db, sessionId, zapProjectFileLocation) {
         pathRelativity = dbEnum.pathRelativity.relativeToZap
       }
     }
-    if (path.isAbsolute(relativePath) && /^[A-Z]:\\/.test(relativePath)) {
+    if (path.isAbsolute(relativePath) && /^[A-Z]:\\/i.test(relativePath)) {
       // Handling Windows path when package is on different drive than zapProjectFile or user home
       pathRelativity = dbEnum.pathRelativity.absolute
     }

--- a/src-electron/importexport/import-json.js
+++ b/src-electron/importexport/import-json.js
@@ -737,6 +737,7 @@ async function importEvents(
  * @param {*} db
  * @param {*} packages
  * @param {*} zapFilePath
+ * @param {*} sessionId
  */
 async function validatePackagePathDrive(db, packages, zapFilePath, sessionId) {
   // If zap file path is not a windows path, skip check
@@ -756,7 +757,7 @@ async function validatePackagePathDrive(db, packages, zapFilePath, sessionId) {
         "Package path '" +
         packagePath +
         "' is on a different drive than the .zap file path. " +
-        'It is suggested to have all packages on the same drive as the .zap file.'
+        'It is recommended that all packages reside on the same drive as the .zap file.'
       querySessionNotice.setNotification(
         db,
         'WARNING',

--- a/src-electron/importexport/import-json.js
+++ b/src-electron/importexport/import-json.js
@@ -37,6 +37,7 @@ const queryCommand = require('../db/query-command.js')
 const conformChecker = require('../validation/conformance-checker.js')
 const zclLoader = require('../zcl/zcl-loader.js')
 const generationEngine = require('../generator/generation-engine')
+const path = require('path')
 
 /**
  * Resolves with a promise that imports session key values.
@@ -726,6 +727,45 @@ async function importEvents(
           throw err
         }
       }
+    }
+  }
+}
+
+/**
+ * Checks if any package path is on a different drive than the zap file path (Windows only)
+ * and sets appropriate warnings
+ * @param {*} db
+ * @param {*} packages
+ * @param {*} zapFilePath
+ */
+async function validatePackagePathDrive(db, packages, zapFilePath, sessionId) {
+  // If zap file path is not a windows path, skip check
+  if (!/^[A-Z]:/i.test(zapFilePath)) {
+    return
+  }
+
+  let zapDrive = zapFilePath.split(':')[0]
+  for (const pkg of packages) {
+    let packagePath = pkg.path
+    if (
+      packagePath &&
+      packagePath.split(':')[0] !== zapDrive &&
+      path.isAbsolute(packagePath)
+    ) {
+      let message =
+        "Package path '" +
+        packagePath +
+        "' is on a different drive than the .zap file path. " +
+        'It is suggested to have all packages on the same drive as the .zap file.'
+      querySessionNotice.setNotification(
+        db,
+        'WARNING',
+        message,
+        sessionId,
+        1,
+        0
+      )
+      env.logWarning(message)
     }
   }
 }
@@ -1691,6 +1731,14 @@ async function jsonDataLoader(
       pkg.type == dbEnum.packageType.zclProperties ||
       pkg.type == dbEnum.packageType.genTemplatesJson ||
       pkg.type == dbEnum.packageType.zclXmlStandalone
+  )
+
+  // checking if any packages are on a different drive than the zap file (Windows only)
+  await validatePackagePathDrive(
+    db,
+    allPartitionPackages,
+    state.filePath,
+    sessionId
   )
 
   // Loading all packages before custom xml to make sure clusterExtensions are


### PR DESCRIPTION
Relative paths don't exist across two different drives. On file import if package is in different drive than home dir or zap file location, package relativity will be changed to absolute for that package.


ZAPP-1087