### PR TITLE
Show warning and disable toggling for device type features with disabled cluster

### DIFF
--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -220,6 +220,7 @@ exports.packageMatch = {
 
 exports.deviceTypeFeature = {
   name: {
+    status: 'status',
     enabled: 'enabled',
     deviceType: 'deviceType',
     cluster: 'cluster',
@@ -231,6 +232,7 @@ exports.deviceTypeFeature = {
     description: 'description'
   },
   label: {
+    status: '',
     enabled: 'Enabled',
     deviceType: 'Device Type',
     cluster: 'Cluster',


### PR DESCRIPTION
For device type features whose associated cluster is disabled:
- Disallow user from toggling the feature.
- Display a warning icon with a tooltip next to the disabled feature.
- The tooltip explains why the feature is disabled and instructs user to enable the associated cluster in order to allow toggling.

JIRA: ZAPP-1552