### PR TITLE
Add Confirmation Dialog on Device Type Feature Toggle and Disable Toggling when Related Cluster is Disabled

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -15038,7 +15038,8 @@ HTTP GET: device type features
 <a name="module_REST API_ user data..httpPostCheckConformOnFeatureUpdate"></a>
 
 ### REST API: user data~httpPostCheckConformOnFeatureUpdate(db) ⇒
-HTTP POST: elements to be updated after toggle a device type feature
+HTTP POST: elements to be updated after toggle a device type feature.
+Set related warnings if user confirmed the change or change is disabled.
 
 **Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
 **Returns**: callback for the express uri registration  
@@ -16373,7 +16374,8 @@ HTTP GET: device type features
 <a name="module_REST API_ user data..httpPostCheckConformOnFeatureUpdate"></a>
 
 ### REST API: user data~httpPostCheckConformOnFeatureUpdate(db) ⇒
-HTTP POST: elements to be updated after toggle a device type feature
+HTTP POST: elements to be updated after toggle a device type feature.
+Set related warnings if user confirmed the change or change is disabled.
 
 **Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
 **Returns**: callback for the express uri registration  

--- a/src-electron/db/query-config.js
+++ b/src-electron/db/query-config.js
@@ -230,7 +230,7 @@ async function insertOrUpdateAttributeState(
       )
     // only set featureMap bit to 1 for mandatory features
     let featureMapBitsToBeEnabled = featuresOnEndpointTypeAndCluster
-      .filter((f) => f.conformance == 'M')
+      .filter((f) => f.conformance == dbEnum.conformance.mandatory)
       .map((f) => f.featureBit)
     featureMapBitsToBeEnabled.forEach(
       (featureBit) =>

--- a/src-electron/validation/conformance-checker.js
+++ b/src-electron/validation/conformance-checker.js
@@ -26,6 +26,7 @@ const conformEvaluator = require('./conformance-expression-evaluator')
 const queryFeature = require('../db/query-feature')
 const querySessionNotice = require('../db/query-session-notification')
 const queryEndpointType = require('../db/query-endpoint-type')
+const dbEnum = require('../../src-shared/db-enum')
 
 /**
  *
@@ -37,7 +38,11 @@ const queryEndpointType = require('../db/query-endpoint-type')
 function filterRelatedDescElements(elements, featureCode) {
   return elements.filter((element) => {
     let terms = element.conformance.match(/[A-Za-z][A-Za-z0-9_]*/g)
-    return terms && terms.includes('desc') && terms.includes(featureCode)
+    return (
+      terms &&
+      terms.includes(dbEnum.conformance.desc) &&
+      terms.includes(featureCode)
+    )
   })
 }
 

--- a/src-electron/validation/conformance-expression-evaluator.js
+++ b/src-electron/validation/conformance-expression-evaluator.js
@@ -21,6 +21,8 @@
  * @module Validation API: Evaluate conformance expressions
  */
 
+const dbEnum = require('../../src-shared/db-enum')
+
 /**
  * Evaluate the value of a boolean conformance expression that includes terms and operators.
  * A term can be an attribute, command, event, feature, or conformance abbreviation.
@@ -75,8 +77,8 @@ function evaluateConformanceExpression(expression, elementMap) {
   // if any term is desc, the conformance is too complex to parse
   for (let part of parts) {
     let terms = part.match(/[A-Za-z][A-Za-z0-9_]*/g)
-    if (terms && terms.includes('desc')) {
-      return 'desc'
+    if (terms && terms.includes(dbEnum.conformance.desc)) {
+      return dbEnum.conformance.desc
     }
   }
   for (let part of parts) {
@@ -91,13 +93,16 @@ function evaluateConformanceExpression(expression, elementMap) {
       }
     } else {
       part = part.trim()
-      if (part == 'M') {
+      if (part == dbEnum.conformance.mandatory) {
         return 'mandatory'
-      } else if (part == 'O') {
+      } else if (part == dbEnum.conformance.optional) {
         return 'optional'
-      } else if (part == 'D' || part == 'X') {
+      } else if (
+        part == dbEnum.conformance.deprecated ||
+        part == dbEnum.conformance.disallowed
+      ) {
         return 'notSupported'
-      } else if (part == 'P') {
+      } else if (part == dbEnum.conformance.provisional) {
         return 'provisional'
       } else {
         // Evaluate the part with parentheses if needed
@@ -123,7 +128,7 @@ function evaluateConformanceExpression(expression, elementMap) {
 function checkMissingTerms(expression, elementMap) {
   let terms = expression.match(/[A-Za-z][A-Za-z0-9_]*/g)
   let missingTerms = []
-  let abbreviations = ['M', 'O', 'P', 'D', 'X']
+  let abbreviations = Object.values(dbEnum.conformance)
   for (let term of terms) {
     if (!(term in elementMap) && !abbreviations.includes(term)) {
       missingTerms.push(term)

--- a/src-electron/validation/conformance-xml-parser.js
+++ b/src-electron/validation/conformance-xml-parser.js
@@ -92,7 +92,7 @@ function parseConformanceRecursively(operand, depth = 0, parentJoinChar = '') {
     if (insideTerm && Object.keys(insideTerm).toString() != '$') {
       return parseConformanceRecursively(operand.mandatoryConform[0], depth + 1)
     } else {
-      return 'M'
+      return dbEnum.conformance.mandatory
     }
   } else if (operand.optionalConform) {
     let insideTerm = operand.optionalConform[0]
@@ -101,7 +101,7 @@ function parseConformanceRecursively(operand, depth = 0, parentJoinChar = '') {
     if (insideTerm && Object.keys(insideTerm).toString() != '$') {
       return `[${parseConformanceRecursively(operand.optionalConform[0], depth + 1)}]`
     } else {
-      return 'O'
+      return dbEnum.conformance.optional
     }
   } else if (operand.otherwiseConform) {
     return Object.entries(operand.otherwiseConform[0])
@@ -142,11 +142,11 @@ function parseConformanceRecursively(operand, depth = 0, parentJoinChar = '') {
       })
       .join(` ${joinChar} `)
   } else if (operand.provisionalConform) {
-    return 'P'
+    return dbEnum.conformance.provisional
   } else if (operand.disallowConform) {
-    return 'X'
+    return dbEnum.conformance.disallowed
   } else if (operand.deprecateConform) {
-    return 'D'
+    return dbEnum.conformance.deprecated
   } else {
     // reach base level terms, return the name directly
     for (const term of baseLevelTerms) {
@@ -155,7 +155,7 @@ function parseConformanceRecursively(operand, depth = 0, parentJoinChar = '') {
       }
     }
     // reaching here means the term is too complex to parse
-    return 'desc'
+    return dbEnum.conformance.desc
   }
 }
 

--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -220,6 +220,7 @@ exports.packageMatch = {
 
 exports.feature = {
   name: {
+    status: 'status',
     enabled: 'enabled',
     deviceType: 'deviceType',
     cluster: 'cluster',
@@ -231,6 +232,7 @@ exports.feature = {
     description: 'description'
   },
   label: {
+    status: '',
     enabled: 'Enabled',
     deviceType: 'Device Type',
     cluster: 'Cluster',

--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -258,3 +258,8 @@ exports.conformance = {
   provisional: 'P',
   desc: 'desc'
 }
+
+exports.clusterSide = {
+  client: 'client',
+  server: 'server'
+}

--- a/src/components/ZclDeviceTypeFeatureManager.vue
+++ b/src/components/ZclDeviceTypeFeatureManager.vue
@@ -88,16 +88,11 @@ limitations under the License.
             </q-tr>
           </template>
         </q-table>
-        <q-dialog v-model="showDialog">
+        <q-dialog v-model="showDialog" :persistent="!noElementsToUpdate">
           <q-card>
             <q-card-section>
               <div class="row items-center">
-                <div class="text-h6 col">Updated Elements</div>
-                <div class="col-1 text-right">
-                  <q-btn dense flat icon="close" v-close-popup>
-                    <q-tooltip>Close</q-tooltip>
-                  </q-btn>
-                </div>
+                <div class="text-h6 col">Elements to be updated</div>
               </div>
               <div v-if="attributesToUpdate.length > 0">
                 <div
@@ -108,7 +103,9 @@ limitations under the License.
                 </div>
                 <ul>
                   <li
-                    v-for="(attribute, index) in attributesToUpdate"
+                    v-for="(attribute, index) in processElementsForDialog(
+                      attributesToUpdate
+                    )"
                     :key="'attribute' + index"
                     style="margin-bottom: 10px"
                   >
@@ -125,7 +122,9 @@ limitations under the License.
                 </div>
                 <ul>
                   <li
-                    v-for="(command, index) in commandsToUpdate"
+                    v-for="(command, index) in processElementsForDialog(
+                      commandsToUpdate
+                    )"
                     :key="'command' + index"
                     style="margin-bottom: 10px"
                   >
@@ -142,7 +141,9 @@ limitations under the License.
                 </div>
                 <ul>
                   <li
-                    v-for="(event, index) in eventsToUpdate"
+                    v-for="(event, index) in processElementsForDialog(
+                      eventsToUpdate
+                    )"
                     :key="'event' + index"
                     style="margin-bottom: 10px"
                   >
@@ -156,6 +157,23 @@ limitations under the License.
                 </div>
               </div>
             </q-card-section>
+            <q-card-actions class="row justify-between">
+              <q-btn
+                flat
+                :label="noElementsToUpdate ? 'Close' : 'Cancel Updates'"
+                color="primary"
+                v-close-popup
+              />
+              <q-btn
+                v-if="!noElementsToUpdate"
+                flat
+                label="Confirm Updates"
+                color="primary"
+                @click="
+                  confirmFeatureUpdate(selectedFeature, updatedEnabledFeatures)
+                "
+              />
+            </q-card-actions>
           </q-card>
         </q-dialog>
       </div>
@@ -195,15 +213,139 @@ export default {
       return conformance == 'X' || conformance == 'D'
     },
     onToggleDeviceTypeFeature(featureData, inclusionList) {
-      /* when conformance is not properly handled and change is disabled,
-        do not set featureMap attribute */
-      let disabled = this.updateElementsAndSetWarnings(
-        featureData,
-        inclusionList
-      )
-      if (!disabled) {
-        this.setFeatureMapAttribute(featureData)
+      let featureMap = this.buildFeatureMap(featureData, inclusionList)
+      this.$serverPost(restApi.uri.checkConformOnFeatureUpdate, {
+        featureData: featureData,
+        featureMap: featureMap,
+        endpointId: this.endpointId[this.selectedEndpointId],
+        changeConfirmed: false
+      }).then((res) => {
+        // store backend response and frontend data for reuse if updates are confirmed
+        let {
+          attributesToUpdate,
+          commandsToUpdate,
+          eventsToUpdate,
+          displayWarning,
+          warningMessage,
+          disableChange
+        } = res.data
+
+        Object.assign(this, {
+          attributesToUpdate,
+          commandsToUpdate,
+          eventsToUpdate,
+          displayWarning,
+          warningMessage,
+          disableChange
+        })
+
+        this.selectedFeature = featureData
+        this.updatedEnabledFeatures = inclusionList
+
+        // if change disabled, display warning and do not show confirm dialog
+        if (this.disableChange) {
+          if (this.displayWarning) {
+            this.displayPopUpWarnings(this.warningMessage)
+          }
+        } else {
+          this.showDialog = true
+        }
+      })
+    },
+    confirmFeatureUpdate(featureData, inclusionList) {
+      let featureMap = this.buildFeatureMap(featureData, inclusionList)
+      this.$store
+        .dispatch('zap/setRequiredElements', {
+          featureMap: featureMap,
+          deviceTypeClusterId: featureData.deviceTypeClusterId,
+          endpointTypeClusterId: featureData.endpointTypeClusterId
+        })
+        .then(() => {
+          // toggle attributes, commands, and events for correct conformance,
+          // and set their conformance warnings
+          this.attributesToUpdate.forEach((attribute) => {
+            let editContext = {
+              action: 'boolean',
+              endpointTypeIdList: this.endpointTypeIdList,
+              selectedEndpoint: this.selectedEndpointTypeId,
+              id: attribute.id,
+              value: attribute.value,
+              listType: 'selectedAttributes',
+              clusterRef: attribute.clusterRef,
+              attributeSide: attribute.side,
+              reportMinInterval: attribute.reportMinInterval,
+              reportMaxInterval: attribute.reportMaxInterval
+            }
+            this.setRequiredElementNotifications(
+              attribute,
+              attribute.value,
+              'attributes'
+            )
+            this.$store.dispatch('zap/updateSelectedAttribute', editContext)
+          })
+          this.commandsToUpdate.forEach((command) => {
+            let listType =
+              command.source == 'client' ? 'selectedIn' : 'selectedOut'
+            let editContext = {
+              action: 'boolean',
+              endpointTypeIdList: this.endpointTypeIdList,
+              id: command.id,
+              value: command.value,
+              listType: listType,
+              clusterRef: command.clusterRef,
+              commandSide: command.source
+            }
+            this.setRequiredElementNotifications(
+              command,
+              command.value,
+              'commands'
+            )
+            this.$store.dispatch('zap/updateSelectedCommands', editContext)
+          })
+          this.eventsToUpdate.forEach((event) => {
+            let editContext = {
+              action: 'boolean',
+              endpointTypeId: this.selectedEndpointTypeId,
+              id: event.id,
+              value: event.value,
+              listType: 'selectedEvents',
+              clusterRef: event.clusterRef,
+              eventSide: event.side
+            }
+            this.setRequiredElementNotifications(event, event.value, 'events')
+            this.$store.dispatch('zap/updateSelectedEvents', editContext)
+          })
+
+          // update enabled device type features
+          let added = this.featureIsEnabled(featureData, inclusionList)
+          let hashedVal = this.hashDeviceTypeClusterIdFeatureId(
+            featureData.deviceTypeClusterId,
+            featureData.featureId
+          )
+          this.$store.commit('zap/updateInclusionList', {
+            id: hashedVal,
+            added: added,
+            listType: 'enabledDeviceTypeFeatures',
+            view: 'featureView'
+          })
+        })
+
+      // set notifications and pop-up warnings for the updated feature
+      this.$serverPost(restApi.uri.checkConformOnFeatureUpdate, {
+        featureData: featureData,
+        featureMap: featureMap,
+        endpointId: this.endpointId[this.selectedEndpointId],
+        changeConfirmed: true
+      })
+      if (this.displayWarning) {
+        this.displayPopUpWarnings(this.warningMessage)
       }
+
+      // update featureMap attribute value for the updated cluster
+      this.setFeatureMapAttribute(featureData)
+
+      // close the dialog
+      this.showDialog = false
     },
     setFeatureMapAttribute(featureData) {
       let featureMapAttributeId = featureData.featureMapAttributeId
@@ -220,150 +362,45 @@ export default {
         featureMapValue: newValue
       })
     },
-    updateElementsAndSetWarnings(featureData, inclusionList) {
+    processElementsForDialog(elementData) {
+      return (elementData || [])
+        .map((item) =>
+          item.value ? 'enabled ' + item.name : 'disabled ' + item.name
+        )
+        .sort(
+          // sort enabled elements before disabled ones
+          (a, b) => {
+            let aIsEnabled = a.includes('enabled')
+            let bIsEnabled = b.includes('enabled')
+            if (aIsEnabled && !bIsEnabled) return -1
+            if (!aIsEnabled && bIsEnabled) return 1
+            return 0
+          }
+        )
+    },
+    displayPopUpWarnings(warningMessage) {
+      if (!Array.isArray(warningMessage)) {
+        warningMessage = [warningMessage]
+      }
+      for (let warning of warningMessage) {
+        Notify.create({
+          message: warning,
+          type: 'warning',
+          classes: 'custom-notification notification-warning',
+          position: 'top',
+          html: true
+        })
+      }
+    },
+    buildFeatureMap(featureData, inclusionList) {
       let featureMap = {}
       this.deviceTypeFeatures.forEach((feature) => {
-        if (feature.deviceTypeClusterId == featureData.deviceTypeClusterId) {
+        if (feature.deviceTypeClusterId === featureData.deviceTypeClusterId) {
           let enabled = this.featureIsEnabled(feature, inclusionList)
           featureMap[feature.code] = enabled ? 1 : 0
         }
       })
-      this.$serverPost(restApi.uri.checkConformOnFeatureUpdate, {
-        featureData: featureData,
-        featureMap: featureMap,
-        endpointId: this.endpointId[this.selectedEndpointId]
-      }).then((res) => {
-        let {
-          attributesToUpdate,
-          commandsToUpdate,
-          eventsToUpdate,
-          displayWarning,
-          warningMessage,
-          disableChange
-        } = res.data
-
-        // show popup warning message
-        if (displayWarning) {
-          if (!Array.isArray(warningMessage)) {
-            warningMessage = [warningMessage]
-          }
-          for (let message of warningMessage) {
-            Notify.create({
-              message: message,
-              type: 'warning',
-              classes: 'custom-notification notification-warning',
-              position: 'top',
-              html: true
-            })
-          }
-        }
-
-        // if disableChange is true, the case is too complex to handle
-        // throw warnings and skip the following actions
-        if (disableChange) {
-          return disableChange
-        }
-
-        this.$store
-          .dispatch('zap/setRequiredElements', {
-            featureMap: featureMap,
-            deviceTypeClusterId: featureData.deviceTypeClusterId,
-            endpointTypeClusterId: featureData.endpointTypeClusterId
-          })
-          .then(() => {
-            // toggle attributes, commands, and events for correct conformance,
-            // and set their conformance notifications
-            attributesToUpdate.forEach((attribute) => {
-              let editContext = {
-                action: 'boolean',
-                endpointTypeIdList: this.endpointTypeIdList,
-                selectedEndpoint: this.selectedEndpointTypeId,
-                id: attribute.id,
-                value: attribute.value,
-                listType: 'selectedAttributes',
-                clusterRef: attribute.clusterRef,
-                attributeSide: attribute.side,
-                reportMinInterval: attribute.reportMinInterval,
-                reportMaxInterval: attribute.reportMaxInterval
-              }
-              this.setRequiredElementNotifications(
-                attribute,
-                attribute.value,
-                'attributes'
-              )
-              this.$store.dispatch('zap/updateSelectedAttribute', editContext)
-            })
-            commandsToUpdate.forEach((command) => {
-              let listType =
-                command.source == 'client' ? 'selectedIn' : 'selectedOut'
-              let editContext = {
-                action: 'boolean',
-                endpointTypeIdList: this.endpointTypeIdList,
-                id: command.id,
-                value: command.value,
-                listType: listType,
-                clusterRef: command.clusterRef,
-                commandSide: command.source
-              }
-              this.setRequiredElementNotifications(
-                command,
-                command.value,
-                'commands'
-              )
-              this.$store.dispatch('zap/updateSelectedCommands', editContext)
-            })
-            eventsToUpdate.forEach((event) => {
-              let editContext = {
-                action: 'boolean',
-                endpointTypeId: this.selectedEndpointTypeId,
-                id: event.id,
-                value: event.value,
-                listType: 'selectedEvents',
-                clusterRef: event.clusterRef,
-                eventSide: event.side
-              }
-              this.setRequiredElementNotifications(event, event.value, 'events')
-              this.$store.dispatch('zap/updateSelectedEvents', editContext)
-            })
-
-            // prepare messages and show dialog
-            this.attributesToUpdate = attributesToUpdate
-              .map((attribute) =>
-                attribute.value
-                  ? 'enabled ' + attribute.name
-                  : 'disabled ' + attribute.name
-              )
-              .sort((a, b) => (a.includes('enabled') ? -1 : 1))
-            this.commandsToUpdate = commandsToUpdate
-              .map((command) =>
-                command.value
-                  ? 'enabled ' + command.name
-                  : 'disabled ' + command.name
-              )
-              .sort((a, b) => (a.includes('enabled') ? -1 : 1))
-            this.eventsToUpdate = eventsToUpdate
-              .map((event) =>
-                event.value ? 'enabled ' + event.name : 'disabled ' + event.name
-              )
-              .sort((a, b) => (a.includes('enabled') ? -1 : 1))
-            this.showDialog = true
-
-            // update enabled device type features
-            let added = this.featureIsEnabled(featureData, inclusionList)
-            let hashedVal = this.hashDeviceTypeClusterIdFeatureId(
-              featureData.deviceTypeClusterId,
-              featureData.featureId
-            )
-            this.$store.commit('zap/updateInclusionList', {
-              id: hashedVal,
-              added: added,
-              listType: 'enabledDeviceTypeFeatures',
-              view: 'featureView'
-            })
-          })
-
-        return disableChange
-      })
+      return featureMap
     },
     featureIsEnabled(featureData, inclusionList) {
       return inclusionList.includes(
@@ -395,6 +432,11 @@ export default {
       attributesToUpdate: [],
       commandsToUpdate: [],
       eventsToUpdate: [],
+      disableChange: false,
+      displayWarning: false,
+      warningMessage: '',
+      selectedFeature: {},
+      updatedEnabledFeatures: [],
       columns: [
         {
           name: dbEnum.feature.name.enabled,

--- a/src/components/ZclEventManager.vue
+++ b/src/components/ZclEventManager.vue
@@ -116,6 +116,7 @@ import * as Util from '../util/util.js'
 import EditableAttributesMixin from '../util/editable-attributes-mixin.js'
 import uiOptions from '../util/ui-options'
 import CommonMixin from '../util/common-mixin'
+import dbEnum from '../../src-shared/db-enum'
 
 export default {
   name: 'ZclEventManager',
@@ -179,7 +180,8 @@ export default {
             !this.isEventSelected(row.id)) ||
             (this.eventsNotSupportedByConform[row.id] &&
               this.isEventSelected(row.id)))) ||
-        (row.conformance == 'M' && !this.isEventSelected(row.id))
+        (row.conformance == dbEnum.conformance.mandatory &&
+          !this.isEventSelected(row.id))
       )
     },
     getEventWarning(row) {
@@ -198,7 +200,10 @@ export default {
       ) {
         warnings.push(this.eventsNotSupportedByConform[row.id])
       }
-      if (row.conformance == 'M' && !this.isEventSelected(row.id)) {
+      if (
+        row.conformance == dbEnum.conformance.mandatory &&
+        !this.isEventSelected(row.id)
+      ) {
         warnings.push(this.defaultWarning)
       }
       return warnings


### PR DESCRIPTION
- Added a confirmation dialog when user toggles a device type feature. After viewing the list of elements to be updated, user can choose to proceed with the change or cancel it.
- Disabled toggling of a device type feature if its associated cluster is disabled, and displayed warnings to inform user which cluster is missing.

ZAPP-1549, ZAPP-1552