### PR TITLE
Cleaning up loadPartial to make sure they are registered properly before generation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7770,9 +7770,9 @@ Get endpoint type events from the given endpoint type ID.
     * [~produceContent(hb, metaInfo, db, sessionId, singlePkg, overridePath:)](#module_JS API_ generator logic..produceContent) ⇒
     * [~wrapOverridable(originalFn, overrideFn)](#module_JS API_ generator logic..wrapOverridable) ⇒
     * [~loadOverridable(path)](#module_JS API_ generator logic..loadOverridable)
-    * [~loadPartial(path)](#module_JS API_ generator logic..loadPartial)
+    * [~loadPartial(hb, name, data)](#module_JS API_ generator logic..loadPartial)
     * [~helperWrapper(wrappedHelper)](#module_JS API_ generator logic..helperWrapper) ⇒
-    * [~loadHelper(helpers)](#module_JS API_ generator logic..loadHelper)
+    * [~loadHelper(hb, helpers, context)](#module_JS API_ generator logic..loadHelper)
     * [~allBuiltInHelpers()](#module_JS API_ generator logic..allBuiltInHelpers) ⇒
     * [~findHelperPackageByAlias(alias)](#module_JS API_ generator logic..findHelperPackageByAlias) ⇒
     * [~initializeBuiltInHelpersForPackage()](#module_JS API_ generator logic..initializeBuiltInHelpersForPackage)
@@ -8126,14 +8126,16 @@ This function is responsible to load the overridable function container.
 
 <a name="module_JS API_ generator logic..loadPartial"></a>
 
-### JS API: generator logic~loadPartial(path)
+### JS API: generator logic~loadPartial(hb, name, data)
 Function that loads the partials.
 
 **Kind**: inner method of [<code>JS API: generator logic</code>](#module_JS API_ generator logic)  
 
 | Param | Type |
 | --- | --- |
-| path | <code>\*</code> | 
+| hb | <code>\*</code> | 
+| name | <code>\*</code> | 
+| data | <code>\*</code> | 
 
 <a name="module_JS API_ generator logic..helperWrapper"></a>
 
@@ -8147,14 +8149,16 @@ Function that loads the partials.
 
 <a name="module_JS API_ generator logic..loadHelper"></a>
 
-### JS API: generator logic~loadHelper(helpers)
+### JS API: generator logic~loadHelper(hb, helpers, context)
 Function that loads the helpers.
 
 **Kind**: inner method of [<code>JS API: generator logic</code>](#module_JS API_ generator logic)  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| helpers | <code>\*</code> | a string path if value is passed through CLI,                      the nativeRequire() is leverage the native js function instead                      of webpack's special sauce.                      a required() module if invoked by backend js code.                      this is required to force webpack to resolve the included files                      as path will be difference after being packed for production. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| hb | <code>\*</code> |  |  |
+| helpers | <code>\*</code> |  | a string path if value is passed through CLI,                      the nativeRequire() is leverage the native js function instead                      of webpack's special sauce.                      a required() module if invoked by backend js code.                      this is required to force webpack to resolve the included files                      as path will be difference after being packed for production. |
+| context | <code>\*</code> | <code></code> |  |
 
 <a name="module_JS API_ generator logic..allBuiltInHelpers"></a>
 
@@ -13104,9 +13108,9 @@ This module contains the API for templating. For more detailed instructions, rea
     * [~produceContent(hb, metaInfo, db, sessionId, singlePkg, overridePath:)](#module_JS API_ generator logic..produceContent) ⇒
     * [~wrapOverridable(originalFn, overrideFn)](#module_JS API_ generator logic..wrapOverridable) ⇒
     * [~loadOverridable(path)](#module_JS API_ generator logic..loadOverridable)
-    * [~loadPartial(path)](#module_JS API_ generator logic..loadPartial)
+    * [~loadPartial(hb, name, data)](#module_JS API_ generator logic..loadPartial)
     * [~helperWrapper(wrappedHelper)](#module_JS API_ generator logic..helperWrapper) ⇒
-    * [~loadHelper(helpers)](#module_JS API_ generator logic..loadHelper)
+    * [~loadHelper(hb, helpers, context)](#module_JS API_ generator logic..loadHelper)
     * [~allBuiltInHelpers()](#module_JS API_ generator logic..allBuiltInHelpers) ⇒
     * [~findHelperPackageByAlias(alias)](#module_JS API_ generator logic..findHelperPackageByAlias) ⇒
     * [~initializeBuiltInHelpersForPackage()](#module_JS API_ generator logic..initializeBuiltInHelpersForPackage)
@@ -13460,14 +13464,16 @@ This function is responsible to load the overridable function container.
 
 <a name="module_JS API_ generator logic..loadPartial"></a>
 
-### JS API: generator logic~loadPartial(path)
+### JS API: generator logic~loadPartial(hb, name, data)
 Function that loads the partials.
 
 **Kind**: inner method of [<code>JS API: generator logic</code>](#module_JS API_ generator logic)  
 
 | Param | Type |
 | --- | --- |
-| path | <code>\*</code> | 
+| hb | <code>\*</code> | 
+| name | <code>\*</code> | 
+| data | <code>\*</code> | 
 
 <a name="module_JS API_ generator logic..helperWrapper"></a>
 
@@ -13481,14 +13487,16 @@ Function that loads the partials.
 
 <a name="module_JS API_ generator logic..loadHelper"></a>
 
-### JS API: generator logic~loadHelper(helpers)
+### JS API: generator logic~loadHelper(hb, helpers, context)
 Function that loads the helpers.
 
 **Kind**: inner method of [<code>JS API: generator logic</code>](#module_JS API_ generator logic)  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| helpers | <code>\*</code> | a string path if value is passed through CLI,                      the nativeRequire() is leverage the native js function instead                      of webpack's special sauce.                      a required() module if invoked by backend js code.                      this is required to force webpack to resolve the included files                      as path will be difference after being packed for production. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| hb | <code>\*</code> |  |  |
+| helpers | <code>\*</code> |  | a string path if value is passed through CLI,                      the nativeRequire() is leverage the native js function instead                      of webpack's special sauce.                      a required() module if invoked by backend js code.                      this is required to force webpack to resolve the included files                      as path will be difference after being packed for production. |
+| context | <code>\*</code> | <code></code> |  |
 
 <a name="module_JS API_ generator logic..allBuiltInHelpers"></a>
 
@@ -13762,9 +13770,9 @@ Function wrapper that can be used when a helper is deprecated.
     * [~produceContent(hb, metaInfo, db, sessionId, singlePkg, overridePath:)](#module_JS API_ generator logic..produceContent) ⇒
     * [~wrapOverridable(originalFn, overrideFn)](#module_JS API_ generator logic..wrapOverridable) ⇒
     * [~loadOverridable(path)](#module_JS API_ generator logic..loadOverridable)
-    * [~loadPartial(path)](#module_JS API_ generator logic..loadPartial)
+    * [~loadPartial(hb, name, data)](#module_JS API_ generator logic..loadPartial)
     * [~helperWrapper(wrappedHelper)](#module_JS API_ generator logic..helperWrapper) ⇒
-    * [~loadHelper(helpers)](#module_JS API_ generator logic..loadHelper)
+    * [~loadHelper(hb, helpers, context)](#module_JS API_ generator logic..loadHelper)
     * [~allBuiltInHelpers()](#module_JS API_ generator logic..allBuiltInHelpers) ⇒
     * [~findHelperPackageByAlias(alias)](#module_JS API_ generator logic..findHelperPackageByAlias) ⇒
     * [~initializeBuiltInHelpersForPackage()](#module_JS API_ generator logic..initializeBuiltInHelpersForPackage)
@@ -14118,14 +14126,16 @@ This function is responsible to load the overridable function container.
 
 <a name="module_JS API_ generator logic..loadPartial"></a>
 
-### JS API: generator logic~loadPartial(path)
+### JS API: generator logic~loadPartial(hb, name, data)
 Function that loads the partials.
 
 **Kind**: inner method of [<code>JS API: generator logic</code>](#module_JS API_ generator logic)  
 
 | Param | Type |
 | --- | --- |
-| path | <code>\*</code> | 
+| hb | <code>\*</code> | 
+| name | <code>\*</code> | 
+| data | <code>\*</code> | 
 
 <a name="module_JS API_ generator logic..helperWrapper"></a>
 
@@ -14139,14 +14149,16 @@ Function that loads the partials.
 
 <a name="module_JS API_ generator logic..loadHelper"></a>
 
-### JS API: generator logic~loadHelper(helpers)
+### JS API: generator logic~loadHelper(hb, helpers, context)
 Function that loads the helpers.
 
 **Kind**: inner method of [<code>JS API: generator logic</code>](#module_JS API_ generator logic)  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| helpers | <code>\*</code> | a string path if value is passed through CLI,                      the nativeRequire() is leverage the native js function instead                      of webpack's special sauce.                      a required() module if invoked by backend js code.                      this is required to force webpack to resolve the included files                      as path will be difference after being packed for production. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| hb | <code>\*</code> |  |  |
+| helpers | <code>\*</code> |  | a string path if value is passed through CLI,                      the nativeRequire() is leverage the native js function instead                      of webpack's special sauce.                      a required() module if invoked by backend js code.                      this is required to force webpack to resolve the included files                      as path will be difference after being packed for production. |
+| context | <code>\*</code> | <code></code> |  |
 
 <a name="module_JS API_ generator logic..allBuiltInHelpers"></a>
 

--- a/src-electron/generator/generation-engine.js
+++ b/src-electron/generator/generation-engine.js
@@ -742,10 +742,15 @@ async function generateAllTemplates(
   })
 
   // Next load the partials
-  packages.forEach((singlePkg) => {
-    if (singlePkg.type == dbEnum.packageType.genPartial) {
-      templateEngine.loadPartial(hb, singlePkg.category, singlePkg.path)
-    }
+  const partialPackages = packages.filter(
+    (pkg) => pkg.type === dbEnum.packageType.genPartial
+  )
+  const partialDataArray = await Promise.all(
+    partialPackages.map((pkg) => fsPromise.readFile(pkg.path, 'utf8'))
+  )
+  partialDataArray.forEach((data, index) => {
+    const singlePkg = partialPackages[index]
+    templateEngine.loadPartial(hb, singlePkg.category, data)
   })
 
   // Let's collect the required list of helpers.

--- a/src-electron/generator/template-engine.js
+++ b/src-electron/generator/template-engine.js
@@ -284,12 +284,12 @@ function loadOverridable(overridePath) {
 
 /**
  * Function that loads the partials.
- *
- * @param {*} path
+ * @param {*} hb
+ * @param {*} name
+ * @param {*} data
  */
-async function loadPartial(hb, name, path) {
+function loadPartial(hb, name, data) {
   try {
-    let data = await fsPromise.readFile(path, 'utf8')
     hb.registerPartial(name, data)
   } catch (err) {
     console.log('Could not load partial ' + name + ': ' + err)
@@ -339,13 +339,14 @@ function helperWrapper(wrappedHelper) {
 }
 /**
  * Function that loads the helpers.
- *
+ * @param {*} hb
  * @param {*} helpers - a string path if value is passed through CLI,
  *                      the nativeRequire() is leverage the native js function instead
  *                      of webpack's special sauce.
  *                      a required() module if invoked by backend js code.
  *                      this is required to force webpack to resolve the included files
  *                      as path will be difference after being packed for production.
+ * @param {*} context
  */
 function loadHelper(hb, helpers, context = null) {
   // helper


### PR DESCRIPTION
- The partialFile loading await fsPromise.readFile(singlePkg.path, 'utf8'); is now done before registering the partial.
- We are hitting a use case intermittently where the partial is not loaded and generation is triggered. Believe that this was happening due to partial file loading and registering happening asynchronously(Not always before generation).
- JIRA: ZAPP-1623