### PR TITLE
Clean up helper when structs with same name exist as a global struct and a cluster specific one

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -886,8 +886,10 @@ This module provides cache for commonly used static database queries.
     * [~selectStructById(db, id)](#module_DB API_ zcl database access..selectStructById) ⇒
     * [~selectStructByName(db, name, packageIds)](#module_DB API_ zcl database access..selectStructByName) ⇒
     * [~selectStructByNameAndClusterId(db, name, clusterId, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterId) ⇒
+    * [~selectStructByNameAndClusterName(db, name, clusterName, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterName) ⇒
     * [~selectStructsWithClusterAssociation(db, packageIds, groupByStructName)](#module_DB API_ zcl database access..selectStructsWithClusterAssociation) ⇒
     * [~sqlQueryForDataTypeByNameAndClusterId(typeDiscriminator, clusterId, packageIds)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterId) ⇒
+    * [~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName) ⇒
     * [~selectClusterBitmaps(db, packageId, clusterId)](#module_DB API_ zcl database access..selectClusterBitmaps) ⇒
     * [~selectAllBitmapFieldsById(db, id)](#module_DB API_ zcl database access..selectAllBitmapFieldsById) ⇒
     * [~selectAllBitmapFields(db, packageId)](#module_DB API_ zcl database access..selectAllBitmapFields) ⇒
@@ -1222,6 +1224,22 @@ Select a struct matched by name and clusterId
 | clusterId | <code>\*</code> | 
 | packageIds | <code>\*</code> | 
 
+<a name="module_DB API_ zcl database access..selectStructByNameAndClusterName"></a>
+
+### DB API: zcl database access~selectStructByNameAndClusterName(db, name, clusterName, packageIds) ⇒
+Select a struct matched by name and cluster name
+Note: Use selectStructByNameAndClusterName but this was needed for backwards compatibility.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: struct information or undefined  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| name | <code>\*</code> | 
+| clusterName | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
 <a name="module_DB API_ zcl database access..selectStructsWithClusterAssociation"></a>
 
 ### DB API: zcl database access~selectStructsWithClusterAssociation(db, packageIds, groupByStructName) ⇒
@@ -1251,6 +1269,22 @@ Formulate a sqlite query string for a data type from the given cluster ID and pa
 | typeDiscriminator | <code>\*</code> |  | 
 | clusterId | <code>\*</code> | <code></code> | 
 | packageIds | <code>\*</code> |  | 
+
+<a name="module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName"></a>
+
+### DB API: zcl database access~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options) ⇒
+Formulate a sqlite query string for a data type from the given cluster name and package IDs.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: SQLite query string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| typeDiscriminator | <code>\*</code> |  |
+| name | <code>\*</code> | data type name |
+| clusterName | <code>\*</code> |  |
+| packageIds | <code>\*</code> |  |
+| options | <code>\*</code> |  |
 
 <a name="module_DB API_ zcl database access..selectClusterBitmaps"></a>
 
@@ -1690,8 +1724,10 @@ This module provides queries for atomic type queries.
     * [~selectStructById(db, id)](#module_DB API_ zcl database access..selectStructById) ⇒
     * [~selectStructByName(db, name, packageIds)](#module_DB API_ zcl database access..selectStructByName) ⇒
     * [~selectStructByNameAndClusterId(db, name, clusterId, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterId) ⇒
+    * [~selectStructByNameAndClusterName(db, name, clusterName, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterName) ⇒
     * [~selectStructsWithClusterAssociation(db, packageIds, groupByStructName)](#module_DB API_ zcl database access..selectStructsWithClusterAssociation) ⇒
     * [~sqlQueryForDataTypeByNameAndClusterId(typeDiscriminator, clusterId, packageIds)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterId) ⇒
+    * [~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName) ⇒
     * [~selectClusterBitmaps(db, packageId, clusterId)](#module_DB API_ zcl database access..selectClusterBitmaps) ⇒
     * [~selectAllBitmapFieldsById(db, id)](#module_DB API_ zcl database access..selectAllBitmapFieldsById) ⇒
     * [~selectAllBitmapFields(db, packageId)](#module_DB API_ zcl database access..selectAllBitmapFields) ⇒
@@ -2026,6 +2062,22 @@ Select a struct matched by name and clusterId
 | clusterId | <code>\*</code> | 
 | packageIds | <code>\*</code> | 
 
+<a name="module_DB API_ zcl database access..selectStructByNameAndClusterName"></a>
+
+### DB API: zcl database access~selectStructByNameAndClusterName(db, name, clusterName, packageIds) ⇒
+Select a struct matched by name and cluster name
+Note: Use selectStructByNameAndClusterName but this was needed for backwards compatibility.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: struct information or undefined  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| name | <code>\*</code> | 
+| clusterName | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
 <a name="module_DB API_ zcl database access..selectStructsWithClusterAssociation"></a>
 
 ### DB API: zcl database access~selectStructsWithClusterAssociation(db, packageIds, groupByStructName) ⇒
@@ -2055,6 +2107,22 @@ Formulate a sqlite query string for a data type from the given cluster ID and pa
 | typeDiscriminator | <code>\*</code> |  | 
 | clusterId | <code>\*</code> | <code></code> | 
 | packageIds | <code>\*</code> |  | 
+
+<a name="module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName"></a>
+
+### DB API: zcl database access~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options) ⇒
+Formulate a sqlite query string for a data type from the given cluster name and package IDs.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: SQLite query string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| typeDiscriminator | <code>\*</code> |  |
+| name | <code>\*</code> | data type name |
+| clusterName | <code>\*</code> |  |
+| packageIds | <code>\*</code> |  |
+| options | <code>\*</code> |  |
 
 <a name="module_DB API_ zcl database access..selectClusterBitmaps"></a>
 
@@ -2489,8 +2557,10 @@ This module provides queries for enums.
     * [~selectStructById(db, id)](#module_DB API_ zcl database access..selectStructById) ⇒
     * [~selectStructByName(db, name, packageIds)](#module_DB API_ zcl database access..selectStructByName) ⇒
     * [~selectStructByNameAndClusterId(db, name, clusterId, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterId) ⇒
+    * [~selectStructByNameAndClusterName(db, name, clusterName, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterName) ⇒
     * [~selectStructsWithClusterAssociation(db, packageIds, groupByStructName)](#module_DB API_ zcl database access..selectStructsWithClusterAssociation) ⇒
     * [~sqlQueryForDataTypeByNameAndClusterId(typeDiscriminator, clusterId, packageIds)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterId) ⇒
+    * [~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName) ⇒
     * [~selectClusterBitmaps(db, packageId, clusterId)](#module_DB API_ zcl database access..selectClusterBitmaps) ⇒
     * [~selectAllBitmapFieldsById(db, id)](#module_DB API_ zcl database access..selectAllBitmapFieldsById) ⇒
     * [~selectAllBitmapFields(db, packageId)](#module_DB API_ zcl database access..selectAllBitmapFields) ⇒
@@ -2825,6 +2895,22 @@ Select a struct matched by name and clusterId
 | clusterId | <code>\*</code> | 
 | packageIds | <code>\*</code> | 
 
+<a name="module_DB API_ zcl database access..selectStructByNameAndClusterName"></a>
+
+### DB API: zcl database access~selectStructByNameAndClusterName(db, name, clusterName, packageIds) ⇒
+Select a struct matched by name and cluster name
+Note: Use selectStructByNameAndClusterName but this was needed for backwards compatibility.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: struct information or undefined  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| name | <code>\*</code> | 
+| clusterName | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
 <a name="module_DB API_ zcl database access..selectStructsWithClusterAssociation"></a>
 
 ### DB API: zcl database access~selectStructsWithClusterAssociation(db, packageIds, groupByStructName) ⇒
@@ -2854,6 +2940,22 @@ Formulate a sqlite query string for a data type from the given cluster ID and pa
 | typeDiscriminator | <code>\*</code> |  | 
 | clusterId | <code>\*</code> | <code></code> | 
 | packageIds | <code>\*</code> |  | 
+
+<a name="module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName"></a>
+
+### DB API: zcl database access~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options) ⇒
+Formulate a sqlite query string for a data type from the given cluster name and package IDs.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: SQLite query string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| typeDiscriminator | <code>\*</code> |  |
+| name | <code>\*</code> | data type name |
+| clusterName | <code>\*</code> |  |
+| packageIds | <code>\*</code> |  |
+| options | <code>\*</code> |  |
 
 <a name="module_DB API_ zcl database access..selectClusterBitmaps"></a>
 
@@ -4567,8 +4669,10 @@ inside a single session. Things like:
     * [~selectStructById(db, id)](#module_DB API_ zcl database access..selectStructById) ⇒
     * [~selectStructByName(db, name, packageIds)](#module_DB API_ zcl database access..selectStructByName) ⇒
     * [~selectStructByNameAndClusterId(db, name, clusterId, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterId) ⇒
+    * [~selectStructByNameAndClusterName(db, name, clusterName, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterName) ⇒
     * [~selectStructsWithClusterAssociation(db, packageIds, groupByStructName)](#module_DB API_ zcl database access..selectStructsWithClusterAssociation) ⇒
     * [~sqlQueryForDataTypeByNameAndClusterId(typeDiscriminator, clusterId, packageIds)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterId) ⇒
+    * [~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName) ⇒
     * [~selectClusterBitmaps(db, packageId, clusterId)](#module_DB API_ zcl database access..selectClusterBitmaps) ⇒
     * [~selectAllBitmapFieldsById(db, id)](#module_DB API_ zcl database access..selectAllBitmapFieldsById) ⇒
     * [~selectAllBitmapFields(db, packageId)](#module_DB API_ zcl database access..selectAllBitmapFields) ⇒
@@ -4903,6 +5007,22 @@ Select a struct matched by name and clusterId
 | clusterId | <code>\*</code> | 
 | packageIds | <code>\*</code> | 
 
+<a name="module_DB API_ zcl database access..selectStructByNameAndClusterName"></a>
+
+### DB API: zcl database access~selectStructByNameAndClusterName(db, name, clusterName, packageIds) ⇒
+Select a struct matched by name and cluster name
+Note: Use selectStructByNameAndClusterName but this was needed for backwards compatibility.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: struct information or undefined  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| name | <code>\*</code> | 
+| clusterName | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
 <a name="module_DB API_ zcl database access..selectStructsWithClusterAssociation"></a>
 
 ### DB API: zcl database access~selectStructsWithClusterAssociation(db, packageIds, groupByStructName) ⇒
@@ -4932,6 +5052,22 @@ Formulate a sqlite query string for a data type from the given cluster ID and pa
 | typeDiscriminator | <code>\*</code> |  | 
 | clusterId | <code>\*</code> | <code></code> | 
 | packageIds | <code>\*</code> |  | 
+
+<a name="module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName"></a>
+
+### DB API: zcl database access~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options) ⇒
+Formulate a sqlite query string for a data type from the given cluster name and package IDs.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: SQLite query string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| typeDiscriminator | <code>\*</code> |  |
+| name | <code>\*</code> | data type name |
+| clusterName | <code>\*</code> |  |
+| packageIds | <code>\*</code> |  |
+| options | <code>\*</code> |  |
 
 <a name="module_DB API_ zcl database access..selectClusterBitmaps"></a>
 
@@ -5417,8 +5553,10 @@ This module provides queries for enums.
     * [~selectStructById(db, id)](#module_DB API_ zcl database access..selectStructById) ⇒
     * [~selectStructByName(db, name, packageIds)](#module_DB API_ zcl database access..selectStructByName) ⇒
     * [~selectStructByNameAndClusterId(db, name, clusterId, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterId) ⇒
+    * [~selectStructByNameAndClusterName(db, name, clusterName, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterName) ⇒
     * [~selectStructsWithClusterAssociation(db, packageIds, groupByStructName)](#module_DB API_ zcl database access..selectStructsWithClusterAssociation) ⇒
     * [~sqlQueryForDataTypeByNameAndClusterId(typeDiscriminator, clusterId, packageIds)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterId) ⇒
+    * [~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName) ⇒
     * [~selectClusterBitmaps(db, packageId, clusterId)](#module_DB API_ zcl database access..selectClusterBitmaps) ⇒
     * [~selectAllBitmapFieldsById(db, id)](#module_DB API_ zcl database access..selectAllBitmapFieldsById) ⇒
     * [~selectAllBitmapFields(db, packageId)](#module_DB API_ zcl database access..selectAllBitmapFields) ⇒
@@ -5753,6 +5891,22 @@ Select a struct matched by name and clusterId
 | clusterId | <code>\*</code> | 
 | packageIds | <code>\*</code> | 
 
+<a name="module_DB API_ zcl database access..selectStructByNameAndClusterName"></a>
+
+### DB API: zcl database access~selectStructByNameAndClusterName(db, name, clusterName, packageIds) ⇒
+Select a struct matched by name and cluster name
+Note: Use selectStructByNameAndClusterName but this was needed for backwards compatibility.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: struct information or undefined  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| name | <code>\*</code> | 
+| clusterName | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
 <a name="module_DB API_ zcl database access..selectStructsWithClusterAssociation"></a>
 
 ### DB API: zcl database access~selectStructsWithClusterAssociation(db, packageIds, groupByStructName) ⇒
@@ -5782,6 +5936,22 @@ Formulate a sqlite query string for a data type from the given cluster ID and pa
 | typeDiscriminator | <code>\*</code> |  | 
 | clusterId | <code>\*</code> | <code></code> | 
 | packageIds | <code>\*</code> |  | 
+
+<a name="module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName"></a>
+
+### DB API: zcl database access~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options) ⇒
+Formulate a sqlite query string for a data type from the given cluster name and package IDs.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: SQLite query string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| typeDiscriminator | <code>\*</code> |  |
+| name | <code>\*</code> | data type name |
+| clusterName | <code>\*</code> |  |
+| packageIds | <code>\*</code> |  |
+| options | <code>\*</code> |  |
 
 <a name="module_DB API_ zcl database access..selectClusterBitmaps"></a>
 
@@ -6212,8 +6382,10 @@ across different query files.
     * [~selectStructById(db, id)](#module_DB API_ zcl database access..selectStructById) ⇒
     * [~selectStructByName(db, name, packageIds)](#module_DB API_ zcl database access..selectStructByName) ⇒
     * [~selectStructByNameAndClusterId(db, name, clusterId, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterId) ⇒
+    * [~selectStructByNameAndClusterName(db, name, clusterName, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterName) ⇒
     * [~selectStructsWithClusterAssociation(db, packageIds, groupByStructName)](#module_DB API_ zcl database access..selectStructsWithClusterAssociation) ⇒
     * [~sqlQueryForDataTypeByNameAndClusterId(typeDiscriminator, clusterId, packageIds)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterId) ⇒
+    * [~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName) ⇒
     * [~selectClusterBitmaps(db, packageId, clusterId)](#module_DB API_ zcl database access..selectClusterBitmaps) ⇒
     * [~selectAllBitmapFieldsById(db, id)](#module_DB API_ zcl database access..selectAllBitmapFieldsById) ⇒
     * [~selectAllBitmapFields(db, packageId)](#module_DB API_ zcl database access..selectAllBitmapFields) ⇒
@@ -6548,6 +6720,22 @@ Select a struct matched by name and clusterId
 | clusterId | <code>\*</code> | 
 | packageIds | <code>\*</code> | 
 
+<a name="module_DB API_ zcl database access..selectStructByNameAndClusterName"></a>
+
+### DB API: zcl database access~selectStructByNameAndClusterName(db, name, clusterName, packageIds) ⇒
+Select a struct matched by name and cluster name
+Note: Use selectStructByNameAndClusterName but this was needed for backwards compatibility.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: struct information or undefined  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| name | <code>\*</code> | 
+| clusterName | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
 <a name="module_DB API_ zcl database access..selectStructsWithClusterAssociation"></a>
 
 ### DB API: zcl database access~selectStructsWithClusterAssociation(db, packageIds, groupByStructName) ⇒
@@ -6577,6 +6765,22 @@ Formulate a sqlite query string for a data type from the given cluster ID and pa
 | typeDiscriminator | <code>\*</code> |  | 
 | clusterId | <code>\*</code> | <code></code> | 
 | packageIds | <code>\*</code> |  | 
+
+<a name="module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName"></a>
+
+### DB API: zcl database access~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options) ⇒
+Formulate a sqlite query string for a data type from the given cluster name and package IDs.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: SQLite query string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| typeDiscriminator | <code>\*</code> |  |
+| name | <code>\*</code> | data type name |
+| clusterName | <code>\*</code> |  |
+| packageIds | <code>\*</code> |  |
+| options | <code>\*</code> |  |
 
 <a name="module_DB API_ zcl database access..selectClusterBitmaps"></a>
 
@@ -7006,8 +7210,10 @@ This module provides queries for ZCL static queries.
     * [~selectStructById(db, id)](#module_DB API_ zcl database access..selectStructById) ⇒
     * [~selectStructByName(db, name, packageIds)](#module_DB API_ zcl database access..selectStructByName) ⇒
     * [~selectStructByNameAndClusterId(db, name, clusterId, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterId) ⇒
+    * [~selectStructByNameAndClusterName(db, name, clusterName, packageIds)](#module_DB API_ zcl database access..selectStructByNameAndClusterName) ⇒
     * [~selectStructsWithClusterAssociation(db, packageIds, groupByStructName)](#module_DB API_ zcl database access..selectStructsWithClusterAssociation) ⇒
     * [~sqlQueryForDataTypeByNameAndClusterId(typeDiscriminator, clusterId, packageIds)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterId) ⇒
+    * [~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options)](#module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName) ⇒
     * [~selectClusterBitmaps(db, packageId, clusterId)](#module_DB API_ zcl database access..selectClusterBitmaps) ⇒
     * [~selectAllBitmapFieldsById(db, id)](#module_DB API_ zcl database access..selectAllBitmapFieldsById) ⇒
     * [~selectAllBitmapFields(db, packageId)](#module_DB API_ zcl database access..selectAllBitmapFields) ⇒
@@ -7342,6 +7548,22 @@ Select a struct matched by name and clusterId
 | clusterId | <code>\*</code> | 
 | packageIds | <code>\*</code> | 
 
+<a name="module_DB API_ zcl database access..selectStructByNameAndClusterName"></a>
+
+### DB API: zcl database access~selectStructByNameAndClusterName(db, name, clusterName, packageIds) ⇒
+Select a struct matched by name and cluster name
+Note: Use selectStructByNameAndClusterName but this was needed for backwards compatibility.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: struct information or undefined  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| name | <code>\*</code> | 
+| clusterName | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
 <a name="module_DB API_ zcl database access..selectStructsWithClusterAssociation"></a>
 
 ### DB API: zcl database access~selectStructsWithClusterAssociation(db, packageIds, groupByStructName) ⇒
@@ -7371,6 +7593,22 @@ Formulate a sqlite query string for a data type from the given cluster ID and pa
 | typeDiscriminator | <code>\*</code> |  | 
 | clusterId | <code>\*</code> | <code></code> | 
 | packageIds | <code>\*</code> |  | 
+
+<a name="module_DB API_ zcl database access..sqlQueryForDataTypeByNameAndClusterName"></a>
+
+### DB API: zcl database access~sqlQueryForDataTypeByNameAndClusterName(typeDiscriminator, name, clusterName, packageIds, options) ⇒
+Formulate a sqlite query string for a data type from the given cluster name and package IDs.
+
+**Kind**: inner method of [<code>DB API: zcl database access</code>](#module_DB API_ zcl database access)  
+**Returns**: SQLite query string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| typeDiscriminator | <code>\*</code> |  |
+| name | <code>\*</code> | data type name |
+| clusterName | <code>\*</code> |  |
+| packageIds | <code>\*</code> |  |
+| options | <code>\*</code> |  |
 
 <a name="module_DB API_ zcl database access..selectClusterBitmaps"></a>
 

--- a/src-electron/db/query-struct.js
+++ b/src-electron/db/query-struct.js
@@ -181,6 +181,10 @@ async function selectStructByNameAndClusterName(
     .then((rows) => rows.map(dbMapping.map.struct))
   if (res && res.length == 1) {
     return res[0]
+  } else if (res && res.length > 1) {
+    throw new Error(
+      `More than one struct ${name} exists with same name for ${clusterName} cluster.`
+    )
   } else {
     queryWithClusterName = queryUtil.sqlQueryForDataTypeByNameAndClusterName(
       dbEnum.zclType.struct,

--- a/src-electron/db/query-struct.js
+++ b/src-electron/db/query-struct.js
@@ -25,6 +25,7 @@ const dbApi = require('./db-api')
 const dbCache = require('./db-cache')
 const dbMapping = require('./db-mapping')
 const queryUtil = require('./query-util')
+const dbEnum = require('../../src-shared/db-enum.js')
 
 /**
  * Get all structs from a given package ID.
@@ -132,12 +133,12 @@ ORDER BY
  */
 async function selectStructByNameAndClusterId(db, name, clusterId, packageIds) {
   let queryWithoutClusterId = queryUtil.sqlQueryForDataTypeByNameAndClusterId(
-    'struct',
+    dbEnum.zclType.struct,
     null,
     packageIds
   )
   let queryWithClusterId = queryUtil.sqlQueryForDataTypeByNameAndClusterId(
-    'struct',
+    dbEnum.zclType.struct,
     clusterId,
     packageIds
   )
@@ -151,6 +152,44 @@ async function selectStructByNameAndClusterId(db, name, clusterId, packageIds) {
     return dbApi
       .dbGet(db, queryWithClusterId, [name, clusterId])
       .then(dbMapping.map.struct)
+  }
+}
+
+/**
+ * Select a struct matched by name and cluster name
+ * Note: Use selectStructByNameAndClusterName but this was needed for backwards compatibility.
+ * @param {*} db
+ * @param {*} name
+ * @param {*} clusterName
+ * @param {*} packageIds
+ * @returns struct information or undefined
+ */
+async function selectStructByNameAndClusterName(
+  db,
+  name,
+  clusterName,
+  packageIds
+) {
+  let queryWithClusterName = queryUtil.sqlQueryForDataTypeByNameAndClusterName(
+    dbEnum.zclType.struct,
+    name,
+    clusterName,
+    packageIds
+  )
+  let res = await dbApi
+    .dbAll(db, queryWithClusterName)
+    .then((rows) => rows.map(dbMapping.map.struct))
+  if (res && res.length == 1) {
+    return res[0]
+  } else {
+    queryWithClusterName = queryUtil.sqlQueryForDataTypeByNameAndClusterName(
+      dbEnum.zclType.struct,
+      name,
+      null, // Retrieving global data types since cluster specific ones were not found.
+      packageIds
+    )
+    res = await dbApi.dbGet(db, queryWithClusterName).then(dbMapping.map.struct)
+    return res
   }
 }
 
@@ -208,5 +247,6 @@ exports.selectStructByName = dbCache.cacheQuery(selectStructByName)
 exports.selectStructByNameAndClusterId = dbCache.cacheQuery(
   selectStructByNameAndClusterId
 )
+exports.selectStructByNameAndClusterName = selectStructByNameAndClusterName
 exports.selectStructsWithClusterAssociation =
   selectStructsWithClusterAssociation

--- a/src-electron/db/query-util.js
+++ b/src-electron/db/query-util.js
@@ -117,8 +117,7 @@ function sqlQueryForDataTypeByNameAndClusterName(
     DATA_TYPE.NAME AS NAME,
     ${numberExtensionString}
     ${typeTableName}.SIZE AS SIZE,
-    CLUSTER.NAME AS CLUSTER_NAME,
-    REPLACE(CLUSTER.NAME, ' ', '') AS CLUSTER_NAME_WITHOUT_SPACES
+    CLUSTER.NAME AS CLUSTER_NAME
   FROM ${typeTableName}
   INNER JOIN
     DATA_TYPE
@@ -139,7 +138,7 @@ function sqlQueryForDataTypeByNameAndClusterName(
 
   let whereClause = !options.ignoreClusterWhereClause
     ? clusterName
-      ? `AND (CLUSTER.NAME = '${clusterName}' OR CLUSTER_NAME_WITHOUT_SPACES = '${clusterName}')`
+      ? `AND CLUSTER.NAME = '${clusterName}'`
       : `AND CLUSTER.NAME IS NULL`
     : ``
 

--- a/src-electron/db/query-util.js
+++ b/src-electron/db/query-util.js
@@ -83,5 +83,71 @@ function sqlQueryForDataTypeByNameAndClusterId(
   return clusterId ? queryWithClusterId : queryWithoutClusterId
 }
 
+/**
+ * Formulate a sqlite query string for a data type from the given cluster name and package IDs.
+ * @param {*} typeDiscriminator
+ * @param {*} name data type name
+ * @param {*} clusterName
+ * @param {*} packageIds
+ * @param {*} options
+ * @returns SQLite query string
+ */
+function sqlQueryForDataTypeByNameAndClusterName(
+  typeDiscriminator,
+  name,
+  clusterName,
+  packageIds,
+  options = {}
+) {
+  let typeTableName = typeDiscriminator.toUpperCase()
+  let numberExtensionString =
+    typeDiscriminator == 'number' ? 'NUMBER.IS_SIGNED, ' : ''
+  let checkLowerCaseString =
+    typeDiscriminator != 'number' && typeDiscriminator != 'struct'
+      ? `OR DATA_TYPE.NAME = '${name}'`
+      : ''
+  let structExtensionString =
+    typeDiscriminator == 'struct'
+      ? 'STRUCT.IS_FABRIC_SCOPED, DATA_TYPE.DISCRIMINATOR_REF, '
+      : ''
+  let selectQueryString = `
+  SELECT
+    ${typeTableName}.${typeTableName}_ID,
+    ${structExtensionString}
+    DATA_TYPE.NAME AS NAME,
+    ${numberExtensionString}
+    ${typeTableName}.SIZE AS SIZE,
+    CLUSTER.NAME AS CLUSTER_NAME,
+    REPLACE(CLUSTER.NAME, ' ', '') AS CLUSTER_NAME_WITHOUT_SPACES
+  FROM ${typeTableName}
+  INNER JOIN
+    DATA_TYPE
+  ON
+    ${typeTableName}.${typeTableName}_ID = DATA_TYPE.DATA_TYPE_ID
+  LEFT JOIN
+    DATA_TYPE_CLUSTER
+  ON
+    DATA_TYPE_CLUSTER.DATA_TYPE_REF = ${typeTableName}.${typeTableName}_ID 
+  LEFT JOIN
+    CLUSTER
+  ON
+    DATA_TYPE_CLUSTER.CLUSTER_REF = CLUSTER.CLUSTER_ID
+  WHERE
+    (DATA_TYPE.NAME = '${name}' ${checkLowerCaseString})
+  AND
+    DATA_TYPE.PACKAGE_REF IN (${dbApi.toInClause(packageIds)}) `
+
+  let whereClause = !options.ignoreClusterWhereClause
+    ? clusterName
+      ? `AND (CLUSTER.NAME = '${clusterName}' OR CLUSTER_NAME_WITHOUT_SPACES = '${clusterName}')`
+      : `AND CLUSTER.NAME IS NULL`
+    : ``
+
+  let resultingQuery = selectQueryString + whereClause
+  return resultingQuery
+}
+
 exports.sqlQueryForDataTypeByNameAndClusterId =
   sqlQueryForDataTypeByNameAndClusterId
+exports.sqlQueryForDataTypeByNameAndClusterName =
+  sqlQueryForDataTypeByNameAndClusterName

--- a/src-electron/db/query-zcl.js
+++ b/src-electron/db/query-zcl.js
@@ -1332,6 +1332,8 @@ exports.selectStructById = queryStruct.selectStructById
 exports.selectStructByName = queryStruct.selectStructByName
 exports.selectStructByNameAndClusterId =
   queryStruct.selectStructByNameAndClusterId
+exports.selectStructByNameAndClusterName =
+  queryStruct.selectStructByNameAndClusterName
 
 exports.selectBitmapById = queryBitmap.selectBitmapById
 exports.selectAllBitmaps = queryBitmap.selectAllBitmaps

--- a/test/gen-matter-3-1.test.js
+++ b/test/gen-matter-3-1.test.js
@@ -29,6 +29,7 @@ const testUtil = require('./test-util')
 const queryEndpoint = require('../src-electron/db/query-endpoint')
 const queryEndpointType = require('../src-electron/db/query-endpoint-type')
 const queryConfig = require('../src-electron/db/query-config')
+const queryZcl = require('../src-electron/db/query-zcl')
 const queryDeviceType = require('../src-electron/db/query-device-type')
 const util = require('../src-electron/util/util')
 const testQuery = require('./test-query')
@@ -521,6 +522,21 @@ test(
       'SemanticTagStruct item 3 from Identify cluster: Label'
     )
     expect(ept).not.toContain('SemanticTagStruct item 4 from Identify cluster')
+
+    // Testing selectStructByNameAndClusterName for struct names
+    let globalStruct = await queryZcl.selectStructByNameAndClusterName(
+      db,
+      'SemanticTagStruct',
+      'Descriptor',
+      zclPackageId
+    )
+    let clusterStruct = await await queryZcl.selectStructByNameAndClusterName(
+      db,
+      'SemanticTagStruct',
+      'Mode Select',
+      zclPackageId
+    )
+    expect(globalStruct.id).not.toEqual(clusterStruct.id)
   },
   testUtil.timeout.long()
 )


### PR DESCRIPTION
- Add selectStructByNameAndClusterName because selectStructByNameAndClusterId could not be used for some of our existing helpers such as asObjectiveCClass.
- Update query-util.js to form the correct data type retrieval using data type name and cluster name: sqlQueryForDataTypeByNameAndClusterName
- Update asObjectiveCClass with selectStructByNameAndClusterName instead of selectStructByName
- Github: ZAP#1559