### PR TITLE
Support touppercamelcase in iterator for split templates

### DIFF
--- a/docs/sdk-integration.md
+++ b/docs/sdk-integration.md
@@ -12,7 +12,7 @@ This body of code can then use the ZAP tool to gain:
 
 To gain these abilities, the SDK should provide data to zap. The data required is:
 
-- **ZCL metafiles**: these are the metafiles that provide information about the ZCL specification to zap tool. Examples of this (and currently supported) are Silicon Labs XML ZCL metadata or the Zigbee official XML format of the ZCL metafiles. Examples of these metafiles are available from the Zigbee website (<http://zigbee.org>).
+- **ZCL metafiles**: these are the metafiles that provide information about the ZCL specification to zap tool. Examples of this (and currently supported) are Silicon Labs XML ZCL metadata or the Zigbee official XML format of the ZCL metafiles. Examples of these metafiles are available from the Zigbee website (http://zigbee.org).
 
   The ZAP project itself provides examples as well, see the `zcl-builtin/` directory. These are used internally for unit testing, but they are also packaged with the application as examples. They can be a good starting point for SDK developers, but ultimately it's the responsibility of SDK developers to provide the accurate XML packages for their SDK, and let ZAP know where they can be loaded from on the local hard drive.
 

--- a/docs/sdk-integration.md
+++ b/docs/sdk-integration.md
@@ -12,7 +12,7 @@ This body of code can then use the ZAP tool to gain:
 
 To gain these abilities, the SDK should provide data to zap. The data required is:
 
-- **ZCL metafiles**: these are the metafiles that provide information about the ZCL specification to zap tool. Examples of this (and currently supported) are Silicon Labs XML ZCL metadata or the Zigbee official XML format of the ZCL metafiles. Examples of these metafiles are available from the Zigbee website (http://zigbee.org).
+- **ZCL metafiles**: these are the metafiles that provide information about the ZCL specification to zap tool. Examples of this (and currently supported) are Silicon Labs XML ZCL metadata or the Zigbee official XML format of the ZCL metafiles. Examples of these metafiles are available from the Zigbee website (<http://zigbee.org>).
 
   The ZAP project itself provides examples as well, see the `zcl-builtin/` directory. These are used internally for unit testing, but they are also packaged with the application as examples. They can be a good starting point for SDK developers, but ultimately it's the responsibility of SDK developers to provide the accurate XML packages for their SDK, and let ZAP know where they can be loaded from on the local hard drive.
 
@@ -82,7 +82,7 @@ The `templates` key contained in the `gen-templates.json` file above, is an arra
 
 The _replacement pattern_ inside the output key, comes handy when iterator key is used and defines how each generated file will be named. Replacement patterns are in a format of `{key}` or `{key:modifier}`. The `key` can be any usual key that the iterated object provides. For example, if you iterate over cluster, these can be `code`, `name`, `description`, `define` and all the usual keys that a cluster supports. So if your output contains `{code}` then this pattern will be replaced by the actual cluster code.
 
-The modifier can be one of the following: `hexuppercase`, `hexlowercase`, `tolowercase`, `touppercase`, `tocamelcase`, `tosnakecase` or `tosnakecaseallcaps`.
+The modifier can be one of the following: `hexuppercase`, `hexlowercase`, `tolowercase`, `touppercase`, `tocamelcase`, `touppercamelcase`, `tosnakecase` or `tosnakecaseallcaps`.
 
 ## Templates key: options
 

--- a/src-electron/util/util.js
+++ b/src-electron/util/util.js
@@ -100,7 +100,7 @@ async function ensurePackagesAndPopulateSessionOptions(
     if (selectedZclPropertyPackage && selectedZclPropertyPackage.length > 1) {
       console.log(
         `Multiple zcl.properties selected, using them for a multiprotocol configuration: ` +
-        JSON.stringify(selectedZclPropertyPackage)
+          JSON.stringify(selectedZclPropertyPackage)
       )
       for (let i = 0; i < selectedZclPropertyPackage.length; i++) {
         promises.push(
@@ -217,7 +217,7 @@ async function ensurePackagesAndPopulateSessionOptions(
     if (selectedGenTemplatePackages && selectedGenTemplatePackages.length > 1) {
       console.log(
         `Multiple generation templates selected, using them for a multiprotocol configuration: ` +
-        JSON.stringify(selectedGenTemplatePackages)
+          JSON.stringify(selectedGenTemplatePackages)
       )
       for (let i = 0; i < selectedGenTemplatePackages.length; i++) {
         promises.push(
@@ -451,9 +451,11 @@ function matchFeatureLevel(featureLevel, requirementSource = null) {
   if (featureLevel > env.zapVersion().featureLevel) {
     return {
       match: false,
-      message: `${requirementSource == null ? 'File' : requirementSource
-        } requires feature level ${featureLevel}, we only have ${env.zapVersion().featureLevel
-        }. Latest ZAP release can be found in https://github.com/project-chip/zap/releases. Please upgrade your zap!`
+      message: `${
+        requirementSource == null ? 'File' : requirementSource
+      } requires feature level ${featureLevel}, we only have ${
+        env.zapVersion().featureLevel
+      }. Latest ZAP release can be found in https://github.com/project-chip/zap/releases. Please upgrade your zap!`
     }
   } else {
     return { match: true }
@@ -653,7 +655,7 @@ function createAbsolutePath(relativePath, relativity, zapFilePath) {
       if (relativePath.indexOf('$') !== -1) {
         throw new Error(
           'resolveEnvVars: unable to resolve environment variables completely: ' +
-          relativePath
+            relativePath
         )
       }
   }

--- a/src-electron/util/util.js
+++ b/src-electron/util/util.js
@@ -100,7 +100,7 @@ async function ensurePackagesAndPopulateSessionOptions(
     if (selectedZclPropertyPackage && selectedZclPropertyPackage.length > 1) {
       console.log(
         `Multiple zcl.properties selected, using them for a multiprotocol configuration: ` +
-          JSON.stringify(selectedZclPropertyPackage)
+        JSON.stringify(selectedZclPropertyPackage)
       )
       for (let i = 0; i < selectedZclPropertyPackage.length; i++) {
         promises.push(
@@ -217,7 +217,7 @@ async function ensurePackagesAndPopulateSessionOptions(
     if (selectedGenTemplatePackages && selectedGenTemplatePackages.length > 1) {
       console.log(
         `Multiple generation templates selected, using them for a multiprotocol configuration: ` +
-          JSON.stringify(selectedGenTemplatePackages)
+        JSON.stringify(selectedGenTemplatePackages)
       )
       for (let i = 0; i < selectedGenTemplatePackages.length; i++) {
         promises.push(
@@ -451,11 +451,9 @@ function matchFeatureLevel(featureLevel, requirementSource = null) {
   if (featureLevel > env.zapVersion().featureLevel) {
     return {
       match: false,
-      message: `${
-        requirementSource == null ? 'File' : requirementSource
-      } requires feature level ${featureLevel}, we only have ${
-        env.zapVersion().featureLevel
-      }. Latest ZAP release can be found in https://github.com/project-chip/zap/releases. Please upgrade your zap!`
+      message: `${requirementSource == null ? 'File' : requirementSource
+        } requires feature level ${featureLevel}, we only have ${env.zapVersion().featureLevel
+        }. Latest ZAP release can be found in https://github.com/project-chip/zap/releases. Please upgrade your zap!`
     }
   } else {
     return { match: true }
@@ -655,7 +653,7 @@ function createAbsolutePath(relativePath, relativity, zapFilePath) {
       if (relativePath.indexOf('$') !== -1) {
         throw new Error(
           'resolveEnvVars: unable to resolve environment variables completely: ' +
-            relativePath
+          relativePath
         )
       }
   }
@@ -929,6 +927,10 @@ function patternFormat(pattern, data) {
     out = out.replace(
       `{${key}:tocamelcase}`,
       string.toCamelCase(value.toString())
+    )
+    out = out.replace(
+      `{${key}:touppercamelcase}`,
+      string.toCamelCase(value.toString(), /* firstLower = */ false)
     )
     out = out.replace(
       `{${key}:tosnakecase}`,

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -47,13 +47,13 @@ test(
     )
     expect(
       util2.patternFormat(
-        '{a:tocamelcase} {b:tosnakecase} {b:tosnakecaseallcaps}',
+        '{a:tocamelcase} {b:tosnakecase} {b:tosnakecaseallcaps} {a:touppercamelcase} {b:touppercamelcase}',
         {
           a: 'some string',
           b: 'another string'
         }
       )
-    ).toEqual('someString another_string ANOTHER_STRING')
+    ).toEqual('someString another_string ANOTHER_STRING SomeString AnotherString')
   },
   timeout.short()
 )


### PR DESCRIPTION
Supports the `touppercamelcase` in addition to `tocamelcase` in the iterator for creating split templates.

This is to prepare for project-chip/connectedhomeip#38207