### PR TITLE
Resolve element optionality via both optional attribute and conformance

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17935,6 +17935,7 @@ Environment utilities for ZAP
     * [.logBrowser(msg, err)](#module_JS API_ Environment utilities.logBrowser)
     * [.logIpc(msg, err)](#module_JS API_ Environment utilities.logIpc)
     * [.logDebug(msg, err)](#module_JS API_ Environment utilities.logDebug)
+    * [.logWarningToFile(msg)](#module_JS API_ Environment utilities.logWarningToFile)
     * [.isMatchingVersion(versionsArray, providedVersion)](#module_JS API_ Environment utilities.isMatchingVersion) ⇒
     * [.versionsCheck()](#module_JS API_ Environment utilities.versionsCheck) ⇒
     * [.httpStaticContent()](#module_JS API_ Environment utilities.httpStaticContent) ⇒
@@ -18243,6 +18244,17 @@ Debug level message.
 | --- | --- |
 | msg | <code>\*</code> | 
 | err | <code>\*</code> | 
+
+<a name="module_JS API_ Environment utilities.logWarningToFile"></a>
+
+### JS API: Environment utilities.logWarningToFile(msg)
+Log Warning level message to zap.log file.
+
+**Kind**: static method of [<code>JS API: Environment utilities</code>](#module_JS API_ Environment utilities)  
+
+| Param | Type |
+| --- | --- |
+| msg | <code>\*</code> | 
 
 <a name="module_JS API_ Environment utilities.isMatchingVersion"></a>
 
@@ -20258,7 +20270,7 @@ This module provides utilities for parsing conformance data from XML into expres
 * [Validation API: Parse conformance data from XML](#module_Validation API_ Parse conformance data from XML)
     * [~parseConformanceFromXML(operand)](#module_Validation API_ Parse conformance data from XML..parseConformanceFromXML) ⇒
     * [~parseConformanceRecursively(operand, depth, parentJoinChar)](#module_Validation API_ Parse conformance data from XML..parseConformanceRecursively) ⇒
-    * [~getOptionalAttributeFromXML(element)](#module_Validation API_ Parse conformance data from XML..getOptionalAttributeFromXML) ⇒
+    * [~getOptionalAttributeFromXML(element, elementType)](#module_Validation API_ Parse conformance data from XML..getOptionalAttributeFromXML) ⇒
 
 <a name="module_Validation API_ Parse conformance data from XML..parseConformanceFromXML"></a>
 
@@ -20322,11 +20334,12 @@ When they appear, stop recursing and return the name inside directly
 
 <a name="module_Validation API_ Parse conformance data from XML..getOptionalAttributeFromXML"></a>
 
-### Validation API: Parse conformance data from XML~getOptionalAttributeFromXML(element) ⇒
+### Validation API: Parse conformance data from XML~getOptionalAttributeFromXML(element, elementType) ⇒
 if optional attribute is defined, return its value
 if optional attribute is undefined, check if the element conformance is mandatory
 if both optional attribute and conformance are undefined, return false
 Optional attribute takes precedence over conformance for backward compatibility on certain elements
+Log warnings to zap.log if both optional attribute and conformance are defined
 
 **Kind**: inner method of [<code>Validation API: Parse conformance data from XML</code>](#module_Validation API_ Parse conformance data from XML)  
 **Returns**: true if the element is optional, false if the element is mandatory  
@@ -20334,6 +20347,7 @@ Optional attribute takes precedence over conformance for backward compatibility 
 | Param | Type |
 | --- | --- |
 | element | <code>\*</code> | 
+| elementType | <code>\*</code> | 
 
 <a name="module_Validation API_ Validation APIs"></a>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -20175,6 +20175,7 @@ This module provides utilities for evaluating conformance expressions.
         * [~evaluateBooleanExpression(expr)](#module_Validation API_ Evaluate conformance expressions..evaluateConformanceExpression..evaluateBooleanExpression)
         * [~evaluateWithParentheses(expr)](#module_Validation API_ Evaluate conformance expressions..evaluateConformanceExpression..evaluateWithParentheses)
     * [~checkMissingTerms(expression, elementMap)](#module_Validation API_ Evaluate conformance expressions..checkMissingTerms) ⇒
+    * [~checkIfExpressionHasTerm(expression, term)](#module_Validation API_ Evaluate conformance expressions..checkIfExpressionHasTerm) ⇒
 
 <a name="module_Validation API_ Evaluate conformance expressions..evaluateConformanceExpression"></a>
 
@@ -20235,6 +20236,19 @@ If so, it means the conformance depends on terms with unknown values and changes
 | expression | <code>\*</code> | 
 | elementMap | <code>\*</code> | 
 
+<a name="module_Validation API_ Evaluate conformance expressions..checkIfExpressionHasTerm"></a>
+
+### Validation API: Evaluate conformance expressions~checkIfExpressionHasTerm(expression, term) ⇒
+Check if the expression contains a given term.
+
+**Kind**: inner method of [<code>Validation API: Evaluate conformance expressions</code>](#module_Validation API_ Evaluate conformance expressions)  
+**Returns**: true if the expression contains the term, false otherwise  
+
+| Param |
+| --- |
+| expression | 
+| term | 
+
 <a name="module_Validation API_ Parse conformance data from XML"></a>
 
 ## Validation API: Parse conformance data from XML
@@ -20244,6 +20258,7 @@ This module provides utilities for parsing conformance data from XML into expres
 * [Validation API: Parse conformance data from XML](#module_Validation API_ Parse conformance data from XML)
     * [~parseConformanceFromXML(operand)](#module_Validation API_ Parse conformance data from XML..parseConformanceFromXML) ⇒
     * [~parseConformanceRecursively(operand, depth, parentJoinChar)](#module_Validation API_ Parse conformance data from XML..parseConformanceRecursively) ⇒
+    * [~getOptionalAttributeFromXML(element)](#module_Validation API_ Parse conformance data from XML..getOptionalAttributeFromXML) ⇒
 
 <a name="module_Validation API_ Parse conformance data from XML..parseConformanceFromXML"></a>
 
@@ -20304,6 +20319,21 @@ When they appear, stop recursing and return the name inside directly
 | operand | <code>\*</code> |  | 
 | depth | <code>\*</code> | <code>0</code> | 
 | parentJoinChar | <code>\*</code> |  | 
+
+<a name="module_Validation API_ Parse conformance data from XML..getOptionalAttributeFromXML"></a>
+
+### Validation API: Parse conformance data from XML~getOptionalAttributeFromXML(element) ⇒
+if optional attribute is defined, return its value
+if optional attribute is undefined, check if the element conformance is mandatory
+if both optional attribute and conformance are undefined, return false
+Optional attribute takes precedence over conformance for backward compatibility on certain elements
+
+**Kind**: inner method of [<code>Validation API: Parse conformance data from XML</code>](#module_Validation API_ Parse conformance data from XML)  
+**Returns**: true if the element is optional, false if the element is mandatory  
+
+| Param | Type |
+| --- | --- |
+| element | <code>\*</code> | 
 
 <a name="module_Validation API_ Validation APIs"></a>
 

--- a/src-electron/util/env.js
+++ b/src-electron/util/env.js
@@ -198,7 +198,7 @@ let applicationStateDirectory = null
 
 let file_pino_logger = pino(
   pinoOptions,
-  pino.destination(path.join(appDirectory(), 'zap.log'))
+  pino.destination({ dest: path.join(appDirectory(), 'zap.log'), sync: true })
 )
 
 /**

--- a/src-electron/util/env.js
+++ b/src-electron/util/env.js
@@ -196,6 +196,11 @@ let httpStaticContentPath = path.join(__dirname, '../../../spa')
 let versionObject = null
 let applicationStateDirectory = null
 
+let file_pino_logger = pino(
+  pinoOptions,
+  pino.destination(path.join(appDirectory(), 'zap.log'))
+)
+
 /**
  * Set up the devlopment environment.
  */
@@ -522,6 +527,18 @@ export function logIpc(msg, err = null) {
  */
 export function logDebug(msg, err = null) {
   log('debug', msg, err)
+}
+
+/**
+ * Log Warning level message to zap.log file.
+ *
+ * @param {*} msg
+ */
+export function logWarningToFile(msg) {
+  let objectToLog = {
+    msg: msg
+  }
+  file_pino_logger.warn(objectToLog)
 }
 
 /**

--- a/src-electron/validation/conformance-expression-evaluator.js
+++ b/src-electron/validation/conformance-expression-evaluator.js
@@ -132,5 +132,18 @@ function checkMissingTerms(expression, elementMap) {
   return missingTerms
 }
 
+/**
+ * Check if the expression contains a given term.
+ *
+ * @param expression
+ * @param term
+ * @returns true if the expression contains the term, false otherwise
+ */
+function checkIfExpressionHasTerm(expression, term) {
+  let terms = expression.match(/[A-Za-z][A-Za-z0-9_]*/g)
+  return terms && terms.includes(term)
+}
+
 exports.evaluateConformanceExpression = evaluateConformanceExpression
 exports.checkMissingTerms = checkMissingTerms
+exports.checkIfExpressionHasTerm = checkIfExpressionHasTerm

--- a/src-electron/validation/conformance-xml-parser.js
+++ b/src-electron/validation/conformance-xml-parser.js
@@ -21,6 +21,9 @@
  * @module Validation API: Parse conformance data from XML
  */
 
+const dbEnum = require('../../src-shared/db-enum')
+const conformEvaluator = require('./conformance-expression-evaluator')
+
 /**
  * Parses conformance from XML data.
  * The conformance could come from features, attributes, commands, or events
@@ -155,4 +158,30 @@ function parseConformanceRecursively(operand, depth = 0, parentJoinChar = '') {
   }
 }
 
+/**
+ * if optional attribute is defined, return its value
+ * if optional attribute is undefined, check if the element conformance is mandatory
+ * if both optional attribute and conformance are undefined, return false
+ * Optional attribute takes precedence over conformance for backward compatibility on certain elements
+ *
+ * @param {*} element
+ * @returns true if the element is optional, false if the element is mandatory
+ */
+function getOptionalAttributeFromXML(element) {
+  if (element.$.optional) {
+    return element.$.optional == 'true'
+  } else {
+    let conformance = parseConformanceFromXML(element)
+    if (conformance) {
+      return !conformEvaluator.checkIfExpressionHasTerm(
+        conformance,
+        dbEnum.conformance.mandatory
+      )
+    } else {
+      return false
+    }
+  }
+}
+
 exports.parseConformanceFromXML = parseConformanceFromXML
+exports.getOptionalAttributeFromXML = getOptionalAttributeFromXML

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -506,7 +506,10 @@ function prepareCluster(cluster, context, isExtension = false) {
         name: command.$.name,
         description: command.description ? command.description[0].trim() : '',
         source: command.$.source,
-        isOptional: conformParser.getOptionalAttributeFromXML(command),
+        isOptional: conformParser.getOptionalAttributeFromXML(
+          command,
+          'command'
+        ),
         conformance: conformParser.parseConformanceFromXML(command),
         mustUseTimedInvoke: command.$.mustUseTimedInvoke == 'true',
         introducedIn: command.$.introducedIn,
@@ -567,7 +570,7 @@ function prepareCluster(cluster, context, isExtension = false) {
         conformance: conformParser.parseConformanceFromXML(event),
         priority: event.$.priority,
         description: event.description ? event.description[0].trim() : '',
-        isOptional: conformParser.getOptionalAttributeFromXML(event),
+        isOptional: conformParser.getOptionalAttributeFromXML(event, 'event'),
         isFabricSensitive: event.$.isFabricSensitive == 'true'
       }
       ev.access = extractAccessIntoArray(event)
@@ -685,7 +688,10 @@ function prepareCluster(cluster, context, isExtension = false) {
           : null,
         isWritable: attribute.$.writable == 'true',
         defaultValue: attribute.$.default,
-        isOptional: conformParser.getOptionalAttributeFromXML(attribute),
+        isOptional: conformParser.getOptionalAttributeFromXML(
+          attribute,
+          'attribute'
+        ),
         reportingPolicy: reportingPolicy,
         storagePolicy: storagePolicy,
         isSceneRequired:

--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -506,7 +506,7 @@ function prepareCluster(cluster, context, isExtension = false) {
         name: command.$.name,
         description: command.description ? command.description[0].trim() : '',
         source: command.$.source,
-        isOptional: command.$.optional == 'true' ? true : false,
+        isOptional: conformParser.getOptionalAttributeFromXML(command),
         conformance: conformParser.parseConformanceFromXML(command),
         mustUseTimedInvoke: command.$.mustUseTimedInvoke == 'true',
         introducedIn: command.$.introducedIn,
@@ -567,7 +567,7 @@ function prepareCluster(cluster, context, isExtension = false) {
         conformance: conformParser.parseConformanceFromXML(event),
         priority: event.$.priority,
         description: event.description ? event.description[0].trim() : '',
-        isOptional: event.$.optional == 'true',
+        isOptional: conformParser.getOptionalAttributeFromXML(event),
         isFabricSensitive: event.$.isFabricSensitive == 'true'
       }
       ev.access = extractAccessIntoArray(event)
@@ -685,7 +685,7 @@ function prepareCluster(cluster, context, isExtension = false) {
           : null,
         isWritable: attribute.$.writable == 'true',
         defaultValue: attribute.$.default,
-        isOptional: attribute.$.optional == 'true',
+        isOptional: conformParser.getOptionalAttributeFromXML(attribute),
         reportingPolicy: reportingPolicy,
         storagePolicy: storagePolicy,
         isSceneRequired:

--- a/src-shared/db-enum.js
+++ b/src-shared/db-enum.js
@@ -247,3 +247,12 @@ exports.featureMapAttribute = {
   name: 'FeatureMap',
   code: 65532
 }
+
+exports.conformance = {
+  mandatory: 'M',
+  optional: 'O',
+  disallowed: 'X',
+  deprecated: 'D',
+  provisional: 'P',
+  desc: 'desc'
+}

--- a/test/test-query.js
+++ b/test/test-query.js
@@ -255,6 +255,17 @@ WHERE
     .then((rows) => rows.map(dbMapping.map.cluster))
 }
 
+/**
+ *
+ * @param {*} elements
+ * @param {*} name
+ * @returns true if the element is optional, false if the element is mandatory
+ */
+function checkIfElementIsOptional(elements, name) {
+  let element = elements.find((element) => element.name == name)
+  return element ? element.isOptional : false
+}
+
 exports.getAllEndpointTypeClusterState = getAllEndpointTypeClusterState
 exports.selectCountFrom = selectCountFrom
 exports.getEndpointTypeAttributes = getEndpointTypeAttributes
@@ -263,3 +274,4 @@ exports.createSession = createSession
 exports.getAllSessionNotifications = getAllSessionNotifications
 exports.getAllNotificationMessages = getAllNotificationMessages
 exports.getAllSessionClusters = getAllSessionClusters
+exports.checkIfElementIsOptional = checkIfElementIsOptional

--- a/test/zcl-loader.test.js
+++ b/test/zcl-loader.test.js
@@ -689,18 +689,18 @@ test(
       expect(
         testQuery.checkIfElementIsOptional(commands, 'GetWeekDaySchedule')
       ).toBeTruthy()
-      // optional conformance, optional="true" -> optional
+      // mandatory conformance, optional attribute undefined -> mandatory
       expect(
-        testQuery.checkIfElementIsOptional(commands, 'UnlockWithTimeout')
-      ).toBeTruthy()
+        testQuery.checkIfElementIsOptional(commands, 'UnlockDoor')
+      ).toBeFalsy()
       // mandatoryConform to feature WDSCH, optional="true" -> optional
       expect(
         testQuery.checkIfElementIsOptional(commands, 'SetWeekDaySchedule')
       ).toBeTruthy()
-      // mandatory conformance, optional="true" -> optional as optional="true" takes precedence
+      // optional conformance, optional="false" -> mandatory as optional="false" takes precedence
       expect(
-        testQuery.checkIfElementIsOptional(commands, 'UnlockDoor')
-      ).toBeTruthy()
+        testQuery.checkIfElementIsOptional(commands, 'UnlockWithTimeout')
+      ).toBeFalsy()
 
       let events = await queryEvent.selectEventsByClusterId(
         db,
@@ -714,6 +714,10 @@ test(
       expect(
         testQuery.checkIfElementIsOptional(events, 'LockOperation')
       ).toBeTruthy()
+      // mandatory conformance, optional attribute undefined -> mandatory
+      expect(
+        testQuery.checkIfElementIsOptional(events, 'LockOperationError')
+      ).toBeFalsy()
       // mandatoryConform to feature DPS, optional="true" -> optional
       expect(
         testQuery.checkIfElementIsOptional(events, 'DoorStateChange')

--- a/test/zcl-loader.test.js
+++ b/test/zcl-loader.test.js
@@ -23,6 +23,7 @@ const dbEnum = require('../src-shared/db-enum')
 const queryZcl = require('../src-electron/db/query-zcl')
 const queryDeviceType = require('../src-electron/db/query-device-type')
 const queryCommand = require('../src-electron/db/query-command')
+const queryEvent = require('../src-electron/db/query-event')
 const queryPackage = require('../src-electron/db/query-package')
 const queryPackageNotification = require('../src-electron/db/query-package-notification')
 const zclLoader = require('../src-electron/zcl/zcl-loader')
@@ -594,14 +595,14 @@ test(
       let ctx = await zclLoader.loadZcl(db, env.builtinMatterZclMetafile())
       let packageId = ctx.packageId
 
-      let zclCluster = await queryZcl.selectClusterByCode(db, packageId, 0x001f)
+      let aclCluster = await queryZcl.selectClusterByCode(db, packageId, 0x001f)
 
       /* Verify that the ACL attribute, defined using the list type format `array="true" type="X"` in XML,
         is correctly parsed and stored in the database as an array of AccessControlEntryStruct. */
       let attributes = await dbApi.dbAll(
         db,
         "SELECT * FROM ATTRIBUTE WHERE CLUSTER_REF = ? AND CODE = 0x0000 AND NAME = 'ACL'",
-        [zclCluster.id]
+        [aclCluster.id]
       )
       expect(attributes.length).toBe(1)
       let aclAttribute = attributes[0]
@@ -617,6 +618,110 @@ test(
       expect(aclAttributeMapped.name).toBe('ACL')
       expect(aclAttributeMapped.entryType).toBe('AccessControlEntryStruct')
       expect(aclAttributeMapped.isArray).toBe(1)
+    } finally {
+      await dbApi.closeDatabase(db)
+    }
+  },
+  testUtil.timeout.long()
+)
+
+test(
+  'test loading IS_OPTIONAL column for Matter attributes, commands, and events',
+  async () => {
+    let db = await dbApi.initRamDatabase()
+    try {
+      await dbApi.loadSchema(db, env.schemaFile(), env.zapVersion())
+      let ctx = await zclLoader.loadZcl(db, env.builtinMatterZclMetafile())
+      let packageId = ctx.packageId
+
+      let doorLockCluster = await queryZcl.selectClusterByCode(
+        db,
+        packageId,
+        0x0101
+      )
+      let doorLockClusterId = doorLockCluster.id
+
+      let attributes =
+        await queryZcl.selectAttributesByClusterIdIncludingGlobal(
+          db,
+          doorLockClusterId,
+          [packageId]
+        )
+      // optional attribute undefined, conformance undefined -> mandatory
+      expect(
+        testQuery.checkIfElementIsOptional(attributes, 'ActuatorEnabled')
+      ).toBeFalsy()
+      // optional="true", conformance undefined -> optional
+      expect(
+        testQuery.checkIfElementIsOptional(attributes, 'DoorClosedEvents')
+      ).toBeTruthy()
+      // optional="false", conformance undefined -> mandatory
+      expect(
+        testQuery.checkIfElementIsOptional(attributes, 'LockType')
+      ).toBeFalsy()
+      // mandatory conformance, optional attribute undefined -> mandatory
+      expect(
+        testQuery.checkIfElementIsOptional(attributes, 'OperatingMode')
+      ).toBeFalsy()
+      // optionalConform to feature DPS, optional="true" -> optional
+      expect(
+        testQuery.checkIfElementIsOptional(attributes, 'DoorOpenEvents')
+      ).toBeTruthy()
+      // mandatory conformance, optional="true" -> optional as optional="true" takes precedence
+      expect(
+        testQuery.checkIfElementIsOptional(attributes, 'LockState')
+      ).toBeTruthy()
+      // mandatoryConform to feature DPS, optional="false" -> mandatory as optional="false" takes precedence
+      expect(
+        testQuery.checkIfElementIsOptional(attributes, 'DoorState')
+      ).toBeFalsy()
+
+      let commands = await queryCommand.selectCommandsByClusterId(
+        db,
+        doorLockClusterId,
+        [packageId]
+      )
+      // optional attribute undefined, conformance undefined -> mandatory
+      expect(
+        testQuery.checkIfElementIsOptional(commands, 'LockDoor')
+      ).toBeFalsy()
+      // optional="true", conformance undefined -> optional
+      expect(
+        testQuery.checkIfElementIsOptional(commands, 'GetWeekDaySchedule')
+      ).toBeTruthy()
+      // optional conformance, optional="true" -> optional
+      expect(
+        testQuery.checkIfElementIsOptional(commands, 'UnlockWithTimeout')
+      ).toBeTruthy()
+      // mandatoryConform to feature WDSCH, optional="true" -> optional
+      expect(
+        testQuery.checkIfElementIsOptional(commands, 'SetWeekDaySchedule')
+      ).toBeTruthy()
+      // mandatory conformance, optional="true" -> optional as optional="true" takes precedence
+      expect(
+        testQuery.checkIfElementIsOptional(commands, 'UnlockDoor')
+      ).toBeTruthy()
+
+      let events = await queryEvent.selectEventsByClusterId(
+        db,
+        doorLockClusterId
+      )
+      // optional attribute undefined, conformance undefined -> mandatory
+      expect(
+        testQuery.checkIfElementIsOptional(events, 'LockUserChange')
+      ).toBeFalsy()
+      // optional="true", conformance undefined -> optional
+      expect(
+        testQuery.checkIfElementIsOptional(events, 'LockOperation')
+      ).toBeTruthy()
+      // mandatoryConform to feature DPS, optional="true" -> optional
+      expect(
+        testQuery.checkIfElementIsOptional(events, 'DoorStateChange')
+      ).toBeTruthy()
+      // mandatory conformance, optional="true" -> optional as optional="true" takes precedence
+      expect(
+        testQuery.checkIfElementIsOptional(events, 'DoorLockAlarm')
+      ).toBeTruthy()
     } finally {
       await dbApi.closeDatabase(db)
     }

--- a/zcl-builtin/matter/data-model/chip/door-lock-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/door-lock-cluster.xml
@@ -67,16 +67,27 @@ limitations under the License.
             cluster itself. Those attributes/commands are marked with a special comment. -->
 
         <!-- Attributes -->
-        <attribute side="server" code="0" define="LOCK_STATE" type="DlLockState" min="0" max="2" isNullable="true" reportable="true" writable="false">LockState</attribute>
-        <attribute side="server" code="1" define="LOCK_TYPE" type="DlLockType" min="0" max="10" writable="false">LockType</attribute>
+        <attribute side="server" code="0" define="LOCK_STATE" type="DlLockState" min="0" max="2" isNullable="true" reportable="true" writable="false" optional="true">
+            <description>LockState</description>
+            <mandatoryConform/>
+        </attribute>
+        <attribute side="server" code="1" define="LOCK_TYPE" type="DlLockType" min="0" max="10" writable="false" optional="false">LockType</attribute>
         <attribute side="server" code="2" define="ACTUATOR_ENABLED" type="boolean" writable="false">ActuatorEnabled</attribute>
         <!-- Conformance feature DPS - for now optional -->
-        <attribute side="server" code="3" define="DOOR_STATE" type="DoorStateEnum" min="0" max="5" isNullable="true" reportable="true" optional="true">DoorState</attribute>
+        <attribute side="server" code="3" define="DOOR_STATE" type="DoorStateEnum" min="0" max="5" isNullable="true" reportable="true" optional="false">
+            <description>DoorState</description>
+            <mandatoryConform>
+                <feature name="DPS"/>
+            </mandatoryConform>
+        </attribute>
         <!-- Conformance feature [DPS] - for now optional -->
         <attribute side="server" code="4" define="DOOR_OPEN_EVENTS" type="INT32U" writable="true" optional="true">
             <description>DoorOpenEvents</description>
             <access op="read" role="view" />
             <access op="write" role="manage" />
+            <optionalConform>
+                <feature name="DPS"/>
+            </optionalConform>
         </attribute>
         <!-- Conformance feature [DPS] - for now optional -->
         <attribute side="server" code="5" define="DOOR_CLOSED_EVENTS" type="INT32U" writable="true" optional="true">
@@ -138,6 +149,7 @@ limitations under the License.
             <description>OperatingMode</description>
             <access op="read" role="view" />
             <access op="write" role="manage" />
+            <mandatoryConform/>
         </attribute>
         <attribute side="server" code="38" define="SUPPORTED_OPERATING_MODES" type="DlSupportedOperatingModes" min="0x0000" max="0xFFFF" default="0xFFF6" writable="false">SupportedOperatingModes</attribute>
         <attribute side="server" code="39" define="DEFAULT_CONFIGURATION_REGISTER" type="DlDefaultConfigurationRegister" min="0x0000" max="0xFFFF" reportable="true" default="0" writable="false" optional="true">DefaultConfigurationRegister</attribute>
@@ -204,10 +216,11 @@ limitations under the License.
             <!-- Conformance feature [COTA & PIN] - for now optional -->
             <arg name="PINCode" type="OCTET_STRING" optional="true" />
         </command>
-        <command source="client" code="1" name="UnlockDoor" mustUseTimedInvoke="true">
+        <command source="client" code="1" name="UnlockDoor" mustUseTimedInvoke="true" optional="true">
             <description>This command causes the lock device to unlock the door.</description>
             <!-- Conformance feature [COTA & PIN] - for now optional -->
             <arg name="PINCode" type="OCTET_STRING" optional="true" />
+            <mandatoryConform/>
         </command>
         <!-- Command Toggle with ID 2 is deprecated/disallowed -->
         <command source="client" code="3" name="UnlockWithTimeout" mustUseTimedInvoke="true" optional="true">
@@ -215,6 +228,7 @@ limitations under the License.
             <arg name="Timeout" type="INT16U" />
             <!-- Conformance feature [COTA & PIN] - for now optional -->
             <arg name="PINCode" type="OCTET_STRING" optional="true" />
+            <optionalConform/>
         </command>
         <!-- Conformance feature WDSCH - for now optional -->
         <command source="client" code="11" name="SetWeekDaySchedule" optional="true">
@@ -227,6 +241,9 @@ limitations under the License.
             <arg name="StartMinute" type="INT8U" />
             <arg name="EndHour" type="INT8U" />
             <arg name="EndMinute" type="INT8U" />
+            <mandatoryConform>
+                <feature name="WDSCH"/>
+            </mandatoryConform>
         </command>
         <!-- Conformance feature WDSCH - for now optional -->
         <command source="client" code="12" name="GetWeekDaySchedule" response="GetWeekDayScheduleResponse" optional="true">
@@ -396,16 +413,20 @@ limitations under the License.
 
 
         <!-- Events -->
-        <event side="server" code="0" name="DoorLockAlarm" priority="critical">
+        <event side="server" code="0" name="DoorLockAlarm" priority="critical" optional="true">
             <description>The door lock cluster provides several alarms which can be sent when there is a critical state on the door lock.</description>
             <field id="0" name="AlarmCode" type="AlarmCodeEnum" />
+            <mandatoryConform/>
         </event>
         <!-- Conformance feature DPS - for now optional -->
         <event side="server" code="1" name="DoorStateChange" priority="critical" optional="true">
             <description>The door lock server sends out a DoorStateChange event when the door lock door state changes.</description>
             <field id="0" name="DoorState" type="DoorStateEnum" />
+            <mandatoryConform>
+                <feature name="DPS"/>
+            </mandatoryConform>
         </event>
-        <event side="server" code="2" name="LockOperation" priority="critical">
+        <event side="server" code="2" name="LockOperation" priority="critical" optional="true">
             <description>The door lock server sends out a LockOperation event when the event is triggered by the various lock operation sources.</description>
             <field id="0" name="LockOperationType" type="LockOperationTypeEnum" />
             <field id="1" name="OperationSource" type="OperationSourceEnum" />

--- a/zcl-builtin/matter/data-model/chip/door-lock-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/door-lock-cluster.xml
@@ -216,14 +216,14 @@ limitations under the License.
             <!-- Conformance feature [COTA & PIN] - for now optional -->
             <arg name="PINCode" type="OCTET_STRING" optional="true" />
         </command>
-        <command source="client" code="1" name="UnlockDoor" mustUseTimedInvoke="true" optional="true">
+        <command source="client" code="1" name="UnlockDoor" mustUseTimedInvoke="true">
             <description>This command causes the lock device to unlock the door.</description>
             <!-- Conformance feature [COTA & PIN] - for now optional -->
             <arg name="PINCode" type="OCTET_STRING" optional="true" />
             <mandatoryConform/>
         </command>
         <!-- Command Toggle with ID 2 is deprecated/disallowed -->
-        <command source="client" code="3" name="UnlockWithTimeout" mustUseTimedInvoke="true" optional="true">
+        <command source="client" code="3" name="UnlockWithTimeout" mustUseTimedInvoke="true" optional="false">
             <description>This command causes the lock device to unlock the door with a timeout parameter.</description>
             <arg name="Timeout" type="INT16U" />
             <!-- Conformance feature [COTA & PIN] - for now optional -->
@@ -446,6 +446,7 @@ limitations under the License.
             <field id="5" name="SourceNode" type="NODE_ID" isNullable="true" />
             <!-- Conformance feature [USR] - for now optional -->
             <field id="6" name="Credentials" type="CredentialStruct" array="true" isNullable="true" optional="true" />
+            <mandatoryConform/>
         </event>
         <event side="server" code="4" name="LockUserChange" priority="info">
             <description>The door lock server sends out a LockUserChange event when a lock user, schedule, or credential change has occurred.</description>


### PR DESCRIPTION
ZAP XMLs currently declare optionality redundantly—via optional attribute and conformance tag.
This PR makes ZAP interpret either source and ready for removing optional attribute in the future.

Issue: #1526 
GHM_ZAP-477


- Extend optionality logic for attributes, commands, and events: an element is now treated as optional when either `optional="true"` or its conformance ≠ `'M'` (mandatory).
- Add unit tests covering all combinations of optional attribute and conformance definitions
- Update ZAP XMLs for testing purpose. The conformance data are obtained from CHIP ZAP XMLs

Let optional attribute takes precedence over conformance for backwards compatibility like the element below:
```
    <!-- ***NOTE***: UpTime attribute is mandatory starting at Rev >= 2, but because of backwards compatibility, has to be optional here.
         The device type config and cert tests (TC-DGGEN-1.1/2.1) ensure that it is present. -->
    <attribute side="server" code="0x02" name="UpTime" define="UP_TIME" type="int64u" optional="true">
      <mandatoryConform/>
    </attribute>
```