### PR TITLE
Fix endianness issue when the hex value length is odd

### DIFF
--- a/.github/workflows/matter.yml
+++ b/.github/workflows/matter.yml
@@ -192,7 +192,7 @@ jobs:
 
     # CHIP container required because clang-format version needs to match
     container:
-      image: connectedhomeip/chip-build:0.6.11
+      image: ghcr.io/project-chip/chip-build:125
 
     steps:
       - uses: actions/download-artifact@v4

--- a/src-electron/generator/helper-c.js
+++ b/src-electron/generator/helper-c.js
@@ -69,7 +69,14 @@ function asHex(rawValue, padding, nullValue) {
     return `0x${value.slice(2).toUpperCase()}`
   } else {
     let val = parseInt(value)
-    return `0x${val.toString(16).padStart(padding, '0').toUpperCase()}`
+    let paddingLength = padding
+    if (!paddingLength) {
+      paddingLength =
+        val.toString(16).length % 2 === 0
+          ? val.toString(16).length
+          : val.toString(16).length + 1
+    }
+    return `0x${val.toString(16).padStart(paddingLength, '0').toUpperCase()}`
   }
 }
 

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -479,6 +479,28 @@ test(
 )
 
 test(
+  'Generated Macro for 4 byte integer little endian',
+  () => {
+    let options = { hash: { endian: 'little' } }
+    return zclHelper
+      .as_generated_default_macro('1600', 4, options)
+      .then((res) => expect(res).toBe('0x40, 0x06,  0x00, 0x00,'))
+  },
+  testUtil.timeout.short()
+)
+
+test(
+  'Generated Macro for 4 byte integer big endian',
+  () => {
+    let options = { hash: { endian: 'big' } }
+    return zclHelper
+      .as_generated_default_macro('1600', 4, options)
+      .then((res) => expect(res).toBe('0x00, 0x00,  0x06, 0x40,'))
+  },
+  testUtil.timeout.short()
+)
+
+test(
   'Generated Macro for string',
   () => {
     let options = { hash: { endian: 'big' } }


### PR DESCRIPTION
- See the unit test to understand the issue here where 1600 should not be 0x640 but 0x0640 for proper endian conversion
- Added unit tests
- JIRA: ZAPP-1610