### PR TITLE
Fix Matter helpers to do the right thing with global enums/bitmaps.

### DIFF
--- a/src-electron/generator/matter/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src-electron/generator/matter/app/zap-templates/common/ClusterTestGeneration.js
@@ -1454,6 +1454,9 @@ function chip_tests_iterate_constraints(constraints, options) {
  * @returns data type as String
  */
 async function asTestType(type, isList) {
+  // NOTE: This is not used on current Matter tip, so the fact that it does not
+  // cluster-scope type names is not an issue.
+
   if (isList) {
     return 'list';
   }


### PR DESCRIPTION
NOTE: the Matter generation changes here are somewhat expected, because some of the new template changes in Matter are buggy until https://github.com/project-chip/connectedhomeip/pull/38733 merges.  There should be no compat impact here for Matter bits from older Matter releases.