### PR TITLE
Fixing endpoint config generation for string type attributes

### DIFF
--- a/src-electron/util/types.js
+++ b/src-electron/util/types.js
@@ -169,7 +169,7 @@ function longTypeDefaultValue(size, type, value) {
   let v = ''
   if (value == null || value.length == 0) {
     v = '0x00, '.repeat(size)
-  } else if (isNaN(value)) {
+  } else if (isString(type)) {
     // String Value
     if (isOneBytePrefixedString(type)) {
       v = bin.stringToOneByteLengthPrefixCBytes(value, size).content

--- a/test/gen-matter-3-1.test.js
+++ b/test/gen-matter-3-1.test.js
@@ -368,6 +368,9 @@ test(
     expect(endpointType1.deviceTypeRef[1]).toEqual(
       endpointType2.deviceTypeRef[0]
     )
+
+    // Testing number values for string type attributes under GENERATED_DEFAULTS(helper-endpointconfig.js)
+    expect(ept).toMatch(/\/\* 17 - Description, \*\/\\\n.*2, '7', '7',/)
   },
   testUtil.timeout.long()
 )

--- a/test/resource/multiple-device-types-per-endpoint.zap
+++ b/test/resource/multiple-device-types-per-endpoint.zap
@@ -6971,7 +6971,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "B2",
+              "defaultValue": "77",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,


### PR DESCRIPTION
Generating correctly for string type attributes which have numbers only as their default values when using helper-endpointconfig.js

Github: ZAP#1504