### PR TITLE
Switch Mac ARM64 package to use zap-cli x64 binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "pkg:linux": "npx pkg -t node18-linux-x64,node18-linux-arm64 --public --no-bytecode --output dist/zap-linux --compress GZip --options max-old-space-size=4096 .",
     "pkg-use-local-fork": "node ../pkg/lib-es5/bin.js -t node18-linux-x64 --output dist/zap-linux --compress GZip --options max-old-space-size=4096 .",
     "pkg:win": "npx pkg -t node18-win-x64,node18-win-arm64 --public --no-bytecode --output dist/zap-win --compress GZip --options max-old-space-size=4096 .",
-    "pkg:mac": "npx pkg -t node18-macos-x64,node18-macos-arm64 --output dist/zap-macos --compress GZip --options max-old-space-size=4096 .",
+    "pkg:mac": "npx pkg -t node18-macos-x64 --output dist/zap-macos --compress GZip --options max-old-space-size=4096 .",
     "dist": "node src-script/build-release-package.js --output dist/release",
     "dist:mac": "node src-script/build-release-package.js --platform m --output dist/release",
     "dist:win": "node src-script/build-release-package.js --platform w --output dist/release",

--- a/src-script/after-all-artifacts.js
+++ b/src-script/after-all-artifacts.js
@@ -37,13 +37,18 @@ exports.default = async function (buildResult) {
           ? 'win'
           : null
 
-    const arch = zipPath.includes('arm64') ? 'arm64' : 'x64'
+    let arch = zipPath.includes('arm64') ? 'arm64' : 'x64'
 
     if (!platform) continue
 
     // Compose zap-cli binary name
-    const cliName =
+    let cliName =
       platform === 'win' ? `zap-win-${arch}.exe` : `zap-${platform}-${arch}`
+
+    // MacOS doesn't have an arm64 binary yet
+    if (platform === 'macos') {
+      cliName = `zap-macos`
+    }
 
     const cliPath = path.join(buildResult.outDir, '../dist', cliName)
 


### PR DESCRIPTION
Temporary, while issues with mac arm64 zap-cli are figured out