### PR TITLE
When closing ZAP sometimes a system error shows up

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17714,7 +17714,7 @@ This mechanism takes care of:
 * [JS API: async reporting](#module_JS API_ async reporting)
     * [~sendDirtyFlagStatus(db, session)](#module_JS API_ async reporting..sendDirtyFlagStatus)
     * [~sendNotificationUpdate(db, session)](#module_JS API_ async reporting..sendNotificationUpdate)
-    * [~startAsyncReporting(db, intervalMs)](#module_JS API_ async reporting..startAsyncReporting)
+    * [~startAsyncReporting(db)](#module_JS API_ async reporting..startAsyncReporting)
     * [~stopAsyncReporting()](#module_JS API_ async reporting..stopAsyncReporting)
 
 <a name="module_JS API_ async reporting..sendDirtyFlagStatus"></a>
@@ -17743,7 +17743,7 @@ Sends a dirty flag status for a single session.
 
 <a name="module_JS API_ async reporting..startAsyncReporting"></a>
 
-### JS API: async reporting~startAsyncReporting(db, intervalMs)
+### JS API: async reporting~startAsyncReporting(db)
 Start the interval that will check and report dirty flags.
 
 **Kind**: inner method of [<code>JS API: async reporting</code>](#module_JS API_ async reporting)  
@@ -17751,7 +17751,6 @@ Start the interval that will check and report dirty flags.
 | Param | Type |
 | --- | --- |
 | db | <code>\*</code> | 
-| intervalMs | <code>\*</code> | 
 
 <a name="module_JS API_ async reporting..stopAsyncReporting"></a>
 

--- a/src-electron/db/db-api.js
+++ b/src-electron/db/db-api.js
@@ -26,6 +26,7 @@ const fs = require('fs')
 const fsp = fs.promises
 const env = require('../util/env')
 const util = require('../util/util.js')
+const asyncReporting = require('../util/async-reporting.js')
 const dbEnum = require('../../src-shared/db-enum.js')
 const dbCache = require('./db-cache')
 const dbMapping = require('./db-mapping.js')
@@ -355,6 +356,8 @@ async function dbMultiInsert(db, sql, arrayOfArrays) {
  * @returns A promise that resolves without an argument or rejects with error from the database closing.
  */
 async function closeDatabase(database) {
+  database._closed = true // Mark the database as closed
+  asyncReporting.stopAsyncReporting()
   dbCache.clear()
   return new Promise((resolve, reject) => {
     env.logSql('About to close database.')
@@ -372,6 +375,8 @@ async function closeDatabase(database) {
  * @param {*} database
  */
 function closeDatabaseSync(database) {
+  database._closed = true // Mark the database as closed
+  asyncReporting.stopAsyncReporting()
   dbCache.clear()
   env.logSql('About to close database.')
   database.close((err) => {


### PR DESCRIPTION
- Believe that this was being caused by asynchronous reporting that we do for dirty flag and session notification counts on a periodic interval. When we close ZAP some of these reporting events are running queries on a closed database and thus throw a bunch of errors. The changes here stop the asynchronous reporting events from running when the database has been closed.
- JIRA: ZAPP-1607