### PR TITLE
Fixing the generation for Attribute Min Max used in endpoint_config.h

### DIFF
--- a/test/custom-matter-xml.test.js
+++ b/test/custom-matter-xml.test.js
@@ -443,7 +443,7 @@ test(
       ' /* Endpoint: 1, Cluster: Sample Custom Cluster (server) */ \\'
     )
     expect(endpointConfig).toContain(
-      '{ (uint16_t)0x0, (uint16_t)0x0, (uint16_t)0xFFFF }, /* Sample Mfg Specific Attribute 2 */ \\'
+      '{ (uint8_t)0x0, (uint8_t)0x0, (uint8_t)0xFF }, /* Sample Mfg Specific Attribute 2 */ \\'
     )
 
     let endpointOut = genResult.content['endpoints.out']
@@ -490,7 +490,7 @@ test(
       ' /* Endpoint: 1, Cluster: Sample Custom Cluster (server) */ \\'
     )
     expect(endpointConfig).not.toContain(
-      '{ (uint16_t)0x0, (uint16_t)0x0, (uint16_t)0xFFFF }, /* Sample Mfg Specific Attribute 2 */ \\'
+      '{ (uint8_t)0x0, (uint8_t)0x0, (uint8_t)0xFF }, /* Sample Mfg Specific Attribute 2 */ \\'
     )
 
     // create state from database and session to verify contents of .zap file

--- a/test/gen-matter-3-1.test.js
+++ b/test/gen-matter-3-1.test.js
@@ -126,12 +126,10 @@ test(
       `{ 0x00000005, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_EMPTY_DEFAULT() }, /* LastNetworkingStatus */`
     )
     expect(ept).toContain(
-      '{ (uint16_t)0xFF, (uint16_t)0x64, (uint16_t)0xFFFF }, /* BallastFactorAdjustment */'
+      '{ (uint8_t)0xFF, (uint8_t)0x64, (uint8_t)0xFF }, /* BallastFactorAdjustment */'
     )
     expect(ept).toContain(`6, 'C', 'o', 'f', 'f', 'e', 'e', \\`)
-    expect(ept).toContain(
-      '{ (uint16_t)-0x64, (uint16_t)-0x96, (uint16_t)0xC8 }'
-    )
+    expect(ept).toContain('{ (int16_t)-0x64, (int16_t)-0x96, (int16_t)0xC8 }')
     expect(ept).toContain('#define GENERATED_MIN_MAX_DEFAULT_COUNT 51')
     expect(ept).toContain('#define GENERATED_ATTRIBUTE_COUNT 739')
     expect(ept).toContain(`/* EventList (index=8) */ \\
@@ -238,12 +236,10 @@ test(
       '  { 0x00000000, ZAP_TYPE(TEMPERATURE), 2, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_SIMPLE_DEFAULT(0x8000) },'
     )
     expect(ept).toContain(
-      '{ (uint16_t)0xFF, (uint16_t)0x64, (uint16_t)0xFFFF }, /* BallastFactorAdjustment */'
+      '{ (uint8_t)0xFF, (uint8_t)0x64, (uint8_t)0xFF }, /* BallastFactorAdjustment */'
     )
     expect(ept).toContain(`6, 'C', 'o', 'f', 'f', 'e', 'e', \\`)
-    expect(ept).toContain(
-      '{ (uint16_t)-0x64, (uint16_t)-0x96, (uint16_t)0xC8 }'
-    )
+    expect(ept).toContain('{ (int16_t)-0x64, (int16_t)-0x96, (int16_t)0xC8 }')
     expect(ept).toContain('#define GENERATED_MIN_MAX_DEFAULT_COUNT 51')
     expect(ept).toContain('#define GENERATED_ATTRIBUTE_COUNT 739')
     expect(ept).toContain(`/* EventList (index=8) */ \\

--- a/test/resource/custom-cluster/matter-conflict.xml
+++ b/test/resource/custom-cluster/matter-conflict.xml
@@ -28,7 +28,7 @@ limitations under the License.
 </cluster>
 
 <clusterExtension code="0x0006">
-    <attribute side="server" code="0xFFF10000" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME_2" type="INT8U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">Sample Mfg Specific Attribute 2 Conflict</attribute>
+    <attribute side="server" code="0xFFF10000" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME_2" type="INT8U" min="0x0000" max="0xFF" writable="true" default="0x0000" optional="true">Sample Mfg Specific Attribute 2 Conflict</attribute>
         <command source="client" code="0xFFF100" name="SampleMfgSpecificOnWithTransition2Conflict" optional="true">
         <description>Client command that turns the device on with a transition given
         by the transition time in the Ember Sample transition time attribute.</description>

--- a/test/resource/custom-cluster/matter-custom.xml
+++ b/test/resource/custom-cluster/matter-custom.xml
@@ -52,7 +52,7 @@ limitations under the License.
 
   <!-- Use the cluster extension Extend the on/off cluster -->
 <clusterExtension code="0x0006">
-    <attribute side="server" code="0xFFF10000" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME_2" type="INT8U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">Sample Mfg Specific Attribute 2</attribute>
+    <attribute side="server" code="0xFFF10000" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME_2" type="INT8U" min="0x0000" max="0xFF" writable="true" default="0x0000" optional="true">Sample Mfg Specific Attribute 2</attribute>
     <attribute side="server" code="0xFFF10001" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME_4" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">Sample Mfg Specific Attribute 4</attribute>
     <command source="client" code="0xFFF100" name="SampleMfgSpecificOnWithTransition2">
         <description>Client command that turns the device on with a transition given

--- a/zcl-builtin/dotdot/BallastConfiguration.xml
+++ b/zcl-builtin/dotdot/BallastConfiguration.xml
@@ -43,7 +43,7 @@ applicable to this document can be found in the LICENSE.md file.
       <!-- PowerOnFadeTime is deprecated -->
       <attribute id="0013" name="PowerOnFadeTime" type="uint16" writable="true" max="65534" default="0" deprecated="true" />
       <attribute id="0014" name="IntrinsicBallastFactor" type="uint8" max="254" writable="true" />
-      <attribute id="0015" name="BallastFactorAdjustment" type="uint8" min="100" max="255" writable="true" default="255" />
+      <attribute id="0015" name="BallastFactorAdjustment" type="uint8" min="100" writable="true" default="255" />
       <!-- Lamp Information Attribute Set -->
       <attribute id="0020" name="LampQuantity" type="uint8" max="254" />
       <!-- Lamp Settings Attribute Set -->


### PR DESCRIPTION
- Fixing the generation of min and max values to be auto assumed and generated correctly when either min or max are mentioned instead of both min and max
- Also making sure we do not always typecase everything to (uint16_t) but instead typecast the values based on size and sign
- Github: ZAP #1615