### PR TITLE
Changing the data type by name helpers to use data type name and cluster

### DIFF
--- a/apack.json
+++ b/apack.json
@@ -4,7 +4,7 @@
   "description": "Graphical configuration tool for application and libraries based on Zigbee Cluster Library.",
   "path": [".", "node_modules/.bin/", "ZAP.app/Contents/MacOS"],
   "requiredFeatureLevel": "apack.core:9",
-  "featureLevel": 107,
+  "featureLevel": 108,
   "uc.triggerExtension": "zap",
   "uc.sdkProvidedProperties": "zcl.matterZclJsonFile,zcl.matterTemplateJsonFile,zcl.zigbeeZclJsonFile,zcl.zigbeeTemplateJsonFile",
   "executable": {

--- a/docs/api.md
+++ b/docs/api.md
@@ -13449,6 +13449,7 @@ Available Options:
 - language: determines the output of the helper based on language
 for eg: (as_type_min_value language='c++') will give the output specific to
 the c++ language.
+- clusterId: The ID of the cluster the type belongs to
 Note: If language is not specified then helper throws an error.  
 
 | Param | Type |
@@ -13468,6 +13469,7 @@ Available Options:
 - language: determines the output of the helper based on language
 for eg: (as_type_max_value language='c++') will give the output specific to
 the c++ language.
+- clusterId: The ID of the cluster the type belongs to
 Note: If language is not specified then the helper returns size of type in
 bits.  
 
@@ -13495,10 +13497,10 @@ Returns the size of the zcl type if possible else returns -1
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: size of zcl type  
 
-| Param | Type |
-| --- | --- |
-| type | <code>\*</code> | 
-| options | <code>\*</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| type | <code>\*</code> |  |
+| options | <code>\*</code> | Available Options: - clusterId: The ID of the cluster the type belongs to |
 
 <a name="module_Templating API_ static zcl helpers..if_compare"></a>
 
@@ -18871,7 +18873,6 @@ Extract project name from the Studio project path
 ## JS API: type related utilities
 
 * [JS API: type related utilities](#module_JS API_ type related utilities)
-    * [~typeSize(db, zclPackageId, type)](#module_JS API_ type related utilities..typeSize)
     * [~typeSizeAttribute(db, zclPackageIds, at, [defaultValue])](#module_JS API_ type related utilities..typeSizeAttribute) ⇒
     * [~convertFloatToBigEndian(value, size)](#module_JS API_ type related utilities..convertFloatToBigEndian) ⇒
     * [~convertIntToBigEndian(value, size)](#module_JS API_ type related utilities..convertIntToBigEndian) ⇒
@@ -18883,23 +18884,11 @@ Extract project name from the Studio project path
     * [~isOneBytePrefixedString(type)](#module_JS API_ type related utilities..isOneBytePrefixedString) ⇒
     * [~isTwoBytePrefixedString(type)](#module_JS API_ type related utilities..isTwoBytePrefixedString) ⇒
     * [~nullStringDefaultValue(type)](#module_JS API_ type related utilities..nullStringDefaultValue) ⇒ <code>string</code>
+    * [~processZclTypeSignAndSize(db, dataType, type, packageIds, options, clusterId, clusterName)](#module_JS API_ type related utilities..processZclTypeSignAndSize) ⇒
     * [~getSignAndSizeOfZclType(type, context, options)](#module_JS API_ type related utilities..getSignAndSizeOfZclType) ⇒
+    * [~getSignAndSizeOfZclTypeAndClusterId(db, type, clusterId, packageIds, options)](#module_JS API_ type related utilities..getSignAndSizeOfZclTypeAndClusterId) ⇒ <code>size:&#x27;bits&#x27;</code>
     * [~intToHexString(n, byteCount)](#module_JS API_ type related utilities..intToHexString) ⇒
     * [~hexStringToInt(s)](#module_JS API_ type related utilities..hexStringToInt) ⇒
-
-<a name="module_JS API_ type related utilities..typeSize"></a>
-
-### JS API: type related utilities~typeSize(db, zclPackageId, type)
-This function resolves with the size of a given type.
--1 means that this size is variable.
-
-**Kind**: inner method of [<code>JS API: type related utilities</code>](#module_JS API_ type related utilities)  
-
-| Param | Type |
-| --- | --- |
-| db | <code>\*</code> | 
-| zclPackageId | <code>\*</code> | 
-| type | <code>\*</code> | 
 
 <a name="module_JS API_ type related utilities..typeSizeAttribute"></a>
 
@@ -19050,6 +19039,26 @@ does not need to be aware of these details.
 | --- | --- | --- |
 | type | <code>string</code> | The type of the string, which determines its null representation. |
 
+<a name="module_JS API_ type related utilities..processZclTypeSignAndSize"></a>
+
+### JS API: type related utilities~processZclTypeSignAndSize(db, dataType, type, packageIds, options, clusterId, clusterName) ⇒
+Common helper function to process ZCL type sign and size from a dataType object.
+This function handles the common logic for determining type signature and size
+regardless of whether the dataType was obtained globally or cluster-specifically.
+
+**Kind**: inner method of [<code>JS API: type related utilities</code>](#module_JS API_ type related utilities)  
+**Returns**: returns sign, size and info of zcl device type  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| db | <code>\*</code> |  | Database connection |
+| dataType | <code>\*</code> |  | The dataType object from the database |
+| type | <code>\*</code> |  | The type name (for error logging) |
+| packageIds | <code>\*</code> |  | Package IDs |
+| options | <code>\*</code> |  | Processing options |
+| clusterId | <code>\*</code> | <code></code> | Optional cluster ID for cluster-specific queries |
+| clusterName | <code>\*</code> | <code></code> | Optional cluster name for error logging |
+
 <a name="module_JS API_ type related utilities..getSignAndSizeOfZclType"></a>
 
 ### JS API: type related utilities~getSignAndSizeOfZclType(type, context, options) ⇒
@@ -19064,12 +19073,41 @@ Available Options:
 or bytes
 for eg: getSignAndSizeOfZclType('int8u' this size='bits') will return
 the size in bits which will be 8. If not mentioned then it will return the size
-in bytes i.e. 1 in this case.  
+in bytes i.e. 1 in this case.
+- noCeiling: If true, returns the exact size without rounding up to the nearest
+power of 2. If false or not provided, rounds up to the nearest power of 2.  
 
 | Param | Type |
 | --- | --- |
 | type | <code>\*</code> | 
 | context | <code>\*</code> | 
+| options | <code>\*</code> | 
+
+<a name="module_JS API_ type related utilities..getSignAndSizeOfZclTypeAndClusterId"></a>
+
+### JS API: type related utilities~getSignAndSizeOfZclTypeAndClusterId(db, type, clusterId, packageIds, options) ⇒ <code>size:&#x27;bits&#x27;</code>
+Given a zcl device type and cluster name returns its sign, size and zcl data type info stored
+in the database table. This function considers cluster-specific type definitions first, then
+falls back to the global getSignAndSizeOfZclType function.
+Note: Enums and Bitmaps are considered to be unsigned.
+
+**Kind**: inner method of [<code>JS API: type related utilities</code>](#module_JS API_ type related utilities)  
+**Returns**: <code>size:&#x27;bits&#x27;</code> - returns sign, size and info of zcl device type
+Available Options:
+- size: Determine whether to calculate the size of zcl device type in bits
+or bytes
+for eg: getSignAndSizeOfZclTypeAndClusterId('int8u', '1', packageIds, ) will return
+the size in bits which will be 8. If not mentioned then it will return the size
+in bytes i.e. 1 in this case.
+- noCeiling: If true, returns the exact size without rounding up to the nearest
+power of 2. If false or not provided, rounds up to the nearest power of 2.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| type | <code>\*</code> | 
+| clusterId | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
 | options | <code>\*</code> | 
 
 <a name="module_JS API_ type related utilities..intToHexString"></a>
@@ -19466,6 +19504,9 @@ This module provides the API to access various zcl utilities.
     * [~isStruct(db, struct_name, packageIds)](#module_REST API_ various zcl utilities..isStruct) ⇒
     * [~isEvent(db, event_name, packageId)](#module_REST API_ various zcl utilities..isEvent) ⇒
     * [~isBitmap(db, bitmap_name, packageIds)](#module_REST API_ various zcl utilities..isBitmap) ⇒
+    * [~isEnumWithCluster(db, enum_name, clusterId, packageIds)](#module_REST API_ various zcl utilities..isEnumWithCluster) ⇒
+    * [~isStructWithCluster(db, struct_name, clusterId, packageIds)](#module_REST API_ various zcl utilities..isStructWithCluster) ⇒
+    * [~isBitmapWithCluster(db, bitmap_name, clusterId, packageIds)](#module_REST API_ various zcl utilities..isBitmapWithCluster) ⇒
     * [~defaultMessageForTypeConversion(fromType, toType, noWarning)](#module_REST API_ various zcl utilities..defaultMessageForTypeConversion)
     * [~dataTypeHelper(type, options, packageIds, db, resolvedType, overridable)](#module_REST API_ various zcl utilities..dataTypeHelper) ⇒
     * [~asUnderlyingZclTypeWithPackageId(type, options, packageIds, currentInstance)](#module_REST API_ various zcl utilities..asUnderlyingZclTypeWithPackageId)
@@ -19712,6 +19753,51 @@ Local function that checks if a bitmap by the name exists
 | bitmap_name | <code>\*</code> | 
 | packageIds | <code>\*</code> | 
 
+<a name="module_REST API_ various zcl utilities..isEnumWithCluster"></a>
+
+### REST API: various zcl utilities~isEnumWithCluster(db, enum_name, clusterId, packageIds) ⇒
+Local function that checks if an enum by the name exists in a specific cluster
+
+**Kind**: inner method of [<code>REST API: various zcl utilities</code>](#module_REST API_ various zcl utilities)  
+**Returns**: Promise of content.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| enum_name | <code>\*</code> | 
+| clusterId | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
+<a name="module_REST API_ various zcl utilities..isStructWithCluster"></a>
+
+### REST API: various zcl utilities~isStructWithCluster(db, struct_name, clusterId, packageIds) ⇒
+Local function that checks if a struct by the name exists in a specific cluster
+
+**Kind**: inner method of [<code>REST API: various zcl utilities</code>](#module_REST API_ various zcl utilities)  
+**Returns**: Promise of content.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| struct_name | <code>\*</code> | 
+| clusterId | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
+<a name="module_REST API_ various zcl utilities..isBitmapWithCluster"></a>
+
+### REST API: various zcl utilities~isBitmapWithCluster(db, bitmap_name, clusterId, packageIds) ⇒
+Local function that checks if a bitmap by the name exists in a specific cluster
+
+**Kind**: inner method of [<code>REST API: various zcl utilities</code>](#module_REST API_ various zcl utilities)  
+**Returns**: Promise of content.  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| bitmap_name | <code>\*</code> | 
+| clusterId | <code>\*</code> | 
+| packageIds | <code>\*</code> | 
+
 <a name="module_REST API_ various zcl utilities..defaultMessageForTypeConversion"></a>
 
 ### REST API: various zcl utilities~defaultMessageForTypeConversion(fromType, toType, noWarning)
@@ -19824,7 +19910,7 @@ things were successful or not.
         * [~getTypeRange(typeSize, isSigned, isMin)](#module_Validation API_ Validation APIs..getTypeRange) ⇒
         * [~unsignedToSignedInteger(value, typeSize)](#module_Validation API_ Validation APIs..unsignedToSignedInteger) ⇒
         * [~getIntegerFromAttribute(attribute, typeSize, isSigned)](#module_Validation API_ Validation APIs..getIntegerFromAttribute) ⇒
-        * [~getIntegerAttributeSize(db, zapSessionId, attribType)](#module_Validation API_ Validation APIs..getIntegerAttributeSize) ⇒ <code>\*</code>
+        * [~getIntegerAttributeSize(db, zapSessionId, attribType, clusterRef)](#module_Validation API_ Validation APIs..getIntegerAttributeSize) ⇒ <code>\*</code>
         * [~checkAttributeBoundsInteger(attribute, endpointAttribute, db, zapSessionId)](#module_Validation API_ Validation APIs..checkAttributeBoundsInteger) ⇒
         * [~checkBoundsInteger(defaultValue, min, max)](#module_Validation API_ Validation APIs..checkBoundsInteger) ⇒
         * [~checkAttributeBoundsFloat(attribute, endpointAttribute)](#module_Validation API_ Validation APIs..checkAttributeBoundsFloat) ⇒
@@ -20091,7 +20177,7 @@ Shifts signed hexadecimals to their correct value.
 
 <a name="module_Validation API_ Validation APIs..getIntegerAttributeSize"></a>
 
-### Validation API: Validation APIs~getIntegerAttributeSize(db, zapSessionId, attribType) ⇒ <code>\*</code>
+### Validation API: Validation APIs~getIntegerAttributeSize(db, zapSessionId, attribType, clusterRef) ⇒ <code>\*</code>
 Returns information about an integer type.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
@@ -20102,6 +20188,7 @@ Returns information about an integer type.
 | db | <code>\*</code> | 
 | zapSessionId | <code>\*</code> | 
 | attribType | <code>\*</code> | 
+| clusterRef | <code>\*</code> | 
 
 <a name="module_Validation API_ Validation APIs..checkAttributeBoundsInteger"></a>
 
@@ -20635,7 +20722,7 @@ things were successful or not.
         * [~getTypeRange(typeSize, isSigned, isMin)](#module_Validation API_ Validation APIs..getTypeRange) ⇒
         * [~unsignedToSignedInteger(value, typeSize)](#module_Validation API_ Validation APIs..unsignedToSignedInteger) ⇒
         * [~getIntegerFromAttribute(attribute, typeSize, isSigned)](#module_Validation API_ Validation APIs..getIntegerFromAttribute) ⇒
-        * [~getIntegerAttributeSize(db, zapSessionId, attribType)](#module_Validation API_ Validation APIs..getIntegerAttributeSize) ⇒ <code>\*</code>
+        * [~getIntegerAttributeSize(db, zapSessionId, attribType, clusterRef)](#module_Validation API_ Validation APIs..getIntegerAttributeSize) ⇒ <code>\*</code>
         * [~checkAttributeBoundsInteger(attribute, endpointAttribute, db, zapSessionId)](#module_Validation API_ Validation APIs..checkAttributeBoundsInteger) ⇒
         * [~checkBoundsInteger(defaultValue, min, max)](#module_Validation API_ Validation APIs..checkBoundsInteger) ⇒
         * [~checkAttributeBoundsFloat(attribute, endpointAttribute)](#module_Validation API_ Validation APIs..checkAttributeBoundsFloat) ⇒
@@ -20902,7 +20989,7 @@ Shifts signed hexadecimals to their correct value.
 
 <a name="module_Validation API_ Validation APIs..getIntegerAttributeSize"></a>
 
-### Validation API: Validation APIs~getIntegerAttributeSize(db, zapSessionId, attribType) ⇒ <code>\*</code>
+### Validation API: Validation APIs~getIntegerAttributeSize(db, zapSessionId, attribType, clusterRef) ⇒ <code>\*</code>
 Returns information about an integer type.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
@@ -20913,6 +21000,7 @@ Returns information about an integer type.
 | db | <code>\*</code> | 
 | zapSessionId | <code>\*</code> | 
 | attribType | <code>\*</code> | 
+| clusterRef | <code>\*</code> | 
 
 <a name="module_Validation API_ Validation APIs..checkAttributeBoundsInteger"></a>
 

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -4560,6 +4560,7 @@ Available Options:
 - language: determines the output of the helper based on language
 for eg: (as_type_min_value language='c++') will give the output specific to
 the c++ language.
+- clusterId: The ID of the cluster the type belongs to
 Note: If language is not specified then helper throws an error.  
 
 | Param | Type |
@@ -4579,6 +4580,7 @@ Available Options:
 - language: determines the output of the helper based on language
 for eg: (as_type_max_value language='c++') will give the output specific to
 the c++ language.
+- clusterId: The ID of the cluster the type belongs to
 Note: If language is not specified then the helper returns size of type in
 bits.  
 
@@ -4606,10 +4608,10 @@ Returns the size of the zcl type if possible else returns -1
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: size of zcl type  
 
-| Param | Type |
-| --- | --- |
-| type | <code>\*</code> | 
-| options | <code>\*</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| type | <code>\*</code> |  |
+| options | <code>\*</code> | Available Options: - clusterId: The ID of the cluster the type belongs to |
 
 <a name="module_Templating API_ static zcl helpers..if_compare"></a>
 

--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -1055,11 +1055,13 @@ async function collectAttributes(
         let mask = []
         if ((a.min != null || a.max != null) && a.isWritable) {
           mask.push('min_max')
-          let type_size_and_sign = await types.getSignAndSizeOfZclType(
-            db,
-            a.type,
-            zclPackageIds
-          )
+          let type_size_and_sign =
+            await types.getSignAndSizeOfZclTypeAndClusterId(
+              db,
+              a.type,
+              c.id,
+              zclPackageIds
+            )
           let min, max
           if (a.min != null) {
             min = a.min

--- a/src-electron/generator/matter/app/zap-templates/common/ClustersHelper.js
+++ b/src-electron/generator/matter/app/zap-templates/common/ClustersHelper.js
@@ -45,6 +45,12 @@ function ensureState(condition, error) {
 function loadAtomics(packageIds) {
   const { db, sessionId } = this.global;
   const options = { hash: {} };
+  // Add clusterId if available in context
+  if (this.clusterId) {
+    options.hash.clusterId = this.clusterId;
+  } else if (this.clusterRef) {
+    options.hash.clusterId = this.clusterRef;
+  }
 
   const resolveZclTypes = (atomics) =>
     Promise.all(
@@ -325,7 +331,6 @@ function loadAttributes() {
       attributes.filter((attribute) => attribute.isIncluded)
     )
     .then((attributes) => attributes.sort((a, b) => a.code - b.code));
-  //.then(attributes => Promise.all(attributes.map(attribute => types.typeSizeAttribute(db, packageId, attribute))
 }
 
 async function loadAllEvents(packageIds) {

--- a/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
+++ b/src-electron/generator/matter/app/zap-templates/templates/app/helper.js
@@ -439,6 +439,12 @@ function chip_endpoint_data_version_count() {
 async function asNativeType(type) {
   function fn(pkgId) {
     const options = { hash: {} };
+    // Add clusterId if available in context
+    if (this.clusterId) {
+      options.hash.clusterId = this.clusterId;
+    } else if (this.clusterRef) {
+      options.hash.clusterId = this.clusterRef;
+    }
     return zclHelper.asUnderlyingZclType
       .call(this, type, options)
       .then((zclType) => {
@@ -666,6 +672,12 @@ async function getClusterCountForType(db, pkgId, type, dataType, options) {
  *
  */
 async function zapTypeToClusterObjectType(type, isDecodable, options) {
+  // Add clusterId if available in context
+  if (this.clusterId) {
+    options.hash.clusterId = this.clusterId;
+  } else if (this.clusterRef) {
+    options.hash.clusterId = this.clusterRef;
+  }
   // Use the entryType as a type
   if (type == 'array' && this.entryType) {
     type = this.entryType;
@@ -887,7 +899,12 @@ async function _zapTypeToPythonClusterObjectType(type, options) {
     if (type.toLowerCase().match(/^int\d+u$/)) {
       return 'uint';
     }
-
+    // Add clusterId if available in context
+    if (this.clusterId) {
+      options.hash.clusterId = this.clusterId;
+    } else if (this.clusterRef) {
+      options.hash.clusterId = this.clusterRef;
+    }
     let resolvedType = await zclHelper.asUnderlyingZclType.call(
       { global: this.global },
       type,
@@ -981,7 +998,12 @@ async function _getPythonFieldDefault(type, options) {
     if (type.toLowerCase().match(/^int\d+u$/)) {
       return '0';
     }
-
+    // Add clusterId if available in context
+    if (this.clusterId) {
+      options.hash.clusterId = this.clusterId;
+    } else if (this.clusterRef) {
+      options.hash.clusterId = this.clusterRef;
+    }
     let resolvedType = await zclHelper.asUnderlyingZclType.call(
       { global: this.global },
       type,

--- a/src-electron/generator/matter/chip-tool/templates/helper.js
+++ b/src-electron/generator/matter/chip-tool/templates/helper.js
@@ -31,6 +31,12 @@ function asDelimitedCommand(name) {
 function asTypeMinValue(type) {
   function fn(pkgId) {
     const options = { hash: {} };
+    // Add clusterId if available in context
+    if (this.clusterId) {
+      options.hash.clusterId = this.clusterId;
+    } else if (this.clusterRef) {
+      options.hash.clusterId = this.clusterRef;
+    }
     this.isArray = false;
     return zclHelper.asUnderlyingZclType
       .call(this, type, options)
@@ -76,6 +82,12 @@ function asTypeMinValue(type) {
 function asTypeMaxValue(type) {
   function fn(pkgId) {
     const options = { hash: {} };
+    // Add clusterId if available in context
+    if (this.clusterId) {
+      options.hash.clusterId = this.clusterId;
+    } else if (this.clusterRef) {
+      options.hash.clusterId = this.clusterRef;
+    }
     return zclHelper.asUnderlyingZclType
       .call(this, type, options)
       .then((zclType) => {

--- a/src-electron/generator/matter/controller/java/templates/helper.js
+++ b/src-electron/generator/matter/controller/java/templates/helper.js
@@ -118,6 +118,12 @@ function asJniBasicType(type, useBoxedTypes) {
   }
   function fn(pkgId) {
     const options = { hash: {} };
+    // Add clusterId if available in context
+    if (this.clusterId) {
+      options.hash.clusterId = this.clusterId;
+    } else if (this.clusterRef) {
+      options.hash.clusterId = this.clusterRef;
+    }
     return zclHelper.asUnderlyingZclType
       .call(this, type, options)
       .then((zclType) => {
@@ -138,6 +144,12 @@ function asJniBasicType(type, useBoxedTypes) {
 function asJniSignatureBasic(type, useBoxedTypes) {
   function fn(pkgId) {
     const options = { hash: {} };
+    // Add clusterId if available in context
+    if (this.clusterId) {
+      options.hash.clusterId = this.clusterId;
+    } else if (this.clusterRef) {
+      options.hash.clusterId = this.clusterRef;
+    }
     return zclHelper.asUnderlyingZclType
       .call(this, type, options)
       .then((zclType) => {
@@ -304,6 +316,12 @@ async function as_underlying_java_zcl_type(type, clusterId, options) {
 
 async function asUnderlyingBasicType(type) {
   const options = { hash: {} };
+  // Add clusterId if available in context
+  if (this.clusterId) {
+    options.hash.clusterId = this.clusterId;
+  } else if (this.clusterRef) {
+    options.hash.clusterId = this.clusterRef;
+  }
   let zclType = await zclHelper.asUnderlyingZclType.call(this, type, options);
   return ChipTypesHelper.asBasicType(zclType);
 }
@@ -312,6 +330,12 @@ async function asJavaType(type, zclType, cluster, options) {
   let pkgIds = await templateUtil.ensureZclPackageIds(this);
   if (zclType == null) {
     const options = { hash: {} };
+    // Add clusterId if available in context
+    if (this.clusterId) {
+      options.hash.clusterId = this.clusterId;
+    } else if (this.clusterRef) {
+      options.hash.clusterId = this.clusterRef;
+    }
     zclType = await zclHelper.asUnderlyingZclType.call(this, type, options);
   }
   let isStruct = await zclHelper

--- a/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
+++ b/src-electron/generator/matter/darwin/Framework/CHIP/templates/helper.js
@@ -83,6 +83,12 @@ async function asTypedExpressionFromObjectiveC(value, type) {
 function asObjectiveCNumberType(label, type, asLowerCased) {
   function fn(pkgId) {
     const options = { hash: {} };
+    // Add clusterId if available in context
+    if (this.clusterId) {
+      options.hash.clusterId = this.clusterId;
+    } else if (this.clusterRef) {
+      options.hash.clusterId = this.clusterRef;
+    }
     return zclHelper.asUnderlyingZclType
       .call(this, type, options)
       .then((zclType) => {

--- a/src-electron/validation/validation.js
+++ b/src-electron/validation/validation.js
@@ -388,13 +388,20 @@ async function getIntegerFromAttribute(attribute, typeSize, isSigned) {
  * @param {*} db
  * @param {*} zapSessionId
  * @param {*} attribType
+ * @param {*} clusterRef
  * @returns {*} { size: bit representation , isSigned: is signed type }
  */
-async function getIntegerAttributeSize(db, zapSessionId, attribType) {
+async function getIntegerAttributeSize(
+  db,
+  zapSessionId,
+  attribType,
+  clusterRef
+) {
   let packageIds = await queryPackage.getSessionZclPackageIds(db, zapSessionId)
-  const attribData = await types.getSignAndSizeOfZclType(
+  const attribData = await types.getSignAndSizeOfZclTypeAndClusterId(
     db,
     attribType,
+    clusterRef,
     packageIds
   )
   if (attribData) {
@@ -424,7 +431,8 @@ async function checkAttributeBoundsInteger(
   const { size, isSigned } = await getIntegerAttributeSize(
     db,
     zapSessionId,
-    attribute.type
+    attribute.type,
+    attribute.clusterRef
   )
   if (size === undefined || isSigned === undefined) {
     return false

--- a/test/endpoint-config.test.js
+++ b/test/endpoint-config.test.js
@@ -26,9 +26,9 @@ const importJs = require('../src-electron/importexport/import')
 const testUtil = require('./test-util')
 const queryEndpoint = require('../src-electron/db/query-endpoint')
 const queryEndpointType = require('../src-electron/db/query-endpoint-type')
+const queryZcl = require('../src-electron/db/query-zcl')
 const queryPackage = require('../src-electron/db/query-package')
 const querySession = require('../src-electron/db/query-session')
-const types = require('../src-electron/util/types')
 const bin = require('../src-electron/util/bin')
 
 let db
@@ -171,7 +171,11 @@ test(
 test(
   'Some intermediate queries',
   async () => {
-    let size = await types.typeSize(db, zclContext.packageId, 'bitmap8')
+    let size = await queryZcl.selectSizeFromType(
+      db,
+      [zclContext.packageId],
+      'bitmap8'
+    )
     expect(size).toBe(1)
   },
   testUtil.timeout.medium()

--- a/test/gen-meta.test.js
+++ b/test/gen-meta.test.js
@@ -246,6 +246,18 @@ test(
     expect(epc).toContain('Bitmap: ClusterBitmap')
     expect(epc).toContain('* First unused enum value for SparseEnum: 2')
     expect(epc).toContain('* First next larger enum value for SparseEnum: 4')
+    // Underlying types by cluster
+    expect(epc).toContain('* asUnderlyingType of struct: ProvisionalStruct')
+    expect(epc).toContain('* asUnderlyingType of struct: StableStruct')
+    expect(epc).toContain('* asUnderlyingType of enum StableEnum: uint8_t')
+    expect(epc).toContain('* asUnderlyingType of enum StableEnum2: uint8_t')
+    expect(epc).toContain('* asUnderlyingType of bitmap StableBitmap: uint8_t')
+    expect(epc).toContain('* asUnderlyingType of struct: SimpleStruct')
+    expect(epc).toContain('* asUnderlyingType of struct item a: uint8_t')
+    expect(epc).toContain('* asUnderlyingType of struct item b: uint8_t')
+    expect(epc).toContain(
+      '* asUnderlyingType of struct item c: /* TYPE WARNING: array array defaults to */ uint8_t *'
+    )
 
     epc = genResult.content['struct.h']
     expect(epc).toContain('Nest complex;// <- has nested array')

--- a/test/resource/meta/type-by-cluster.zapt
+++ b/test/resource/meta/type-by-cluster.zapt
@@ -5,9 +5,11 @@ Cluster: {{name}}
 
 Structs for cluster {{name}}:
 {{#zcl_structs}}
+   * asUnderlyingType of struct: {{as_underlying_zcl_type name clusterId=../id}}
 {{#if struct_contains_array}}
    * Struct with array: {{name}}
 {{#zcl_struct_items}}
+   * asUnderlyingType of struct item {{name}}: {{as_underlying_zcl_type type clusterId=../../id}}
 {{#if isEnum}}
       - enum item: {{name}}
 {{else}}
@@ -31,6 +33,7 @@ Enums for cluster {{name}}:
    * Enum: {{name}}
    * First unused enum value for {{name}}: {{first_unused_enum_value mode="first_unused"}} (0x{{first_unused_enum_value mode="first_unused" format="hex"}})
    * First next larger enum value for {{name}}: {{first_unused_enum_value mode="next_larger"}} (0x{{first_unused_enum_value mode="next_larger" format="hex"}})
+   * asUnderlyingType of enum {{name}}: {{as_underlying_zcl_type name clusterId=../id}}
 {{#zcl_enum_items}}
       - item: {{name}} = {{value}}
 {{/zcl_enum_items}}
@@ -39,6 +42,7 @@ Enums for cluster {{name}}:
 Bitmaps for cluster {{name}}:
 {{#zcl_bitmaps}}
    * Bitmap: {{name}}
+   * asUnderlyingType of bitmap {{name}}: {{as_underlying_zcl_type name clusterId=../id}}
 {{#zcl_bitmap_items}}
       - item: {{name}}
 {{/zcl_bitmap_items}}

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -239,7 +239,8 @@ test(
     const { size, isSigned } = await validation.getIntegerAttributeSize(
       db,
       sid,
-      attribute.type
+      attribute.type,
+      attribute.clusterRef
     )
     //Test Constraints
     let minMax = await validation.getBoundsInteger(attribute, size, isSigned)


### PR DESCRIPTION
- Updating types.getSignAndSizeOfZclType to types.getSignAndSizeOfZclTypeAndClusterId for better accuracy and avoiding duplicate data types across clusters.
- updating the code associated with the above as required in the code.
- deprecating as_bytes and data_types_for_enum as they are no longer used.
- Github: ZAP #1592