### PR TITLE
Add aarch64 paths to `apack.json` for Linux and Windows

### DIFF
--- a/apack.json
+++ b/apack.json
@@ -12,6 +12,10 @@
       "exe": "zap.exe",
       "optional": true
     },
+    "zap:win32.aarch64": {
+      "exe": "zap.exe",
+      "optional": true
+    },
     "zap:linux.x86_64": {
       "exe": "zap",
       "optional": true
@@ -34,6 +38,10 @@
       "exe": "src-script/zap-start.js"
     },
     "zap-cli:win32.x86_64": {
+      "exe": "zap-cli.exe",
+      "optional": true
+    },
+    "zap-cli:win32.aarch64": {
       "exe": "zap-cli.exe",
       "optional": true
     },


### PR DESCRIPTION
`zap-linux-arm64.zip` and `zap-windows-arm64.zip` are created as release artifacts but they aren't usable by tooling reading `apack.json` (e.g. `slc-cli`) on ARM64 platforms. This modification allows them to be picked up automatically.