### PR TITLE
Use fieldId for event fields; keep loader backwards compatible

### DIFF
--- a/src-electron/zcl/zcl-loader-silabs.js
+++ b/src-electron/zcl/zcl-loader-silabs.js
@@ -587,7 +587,8 @@ function prepareCluster(cluster, context, isExtension = false) {
         let lastFieldId = -1
         event.field.forEach((field) => {
           let defaultFieldId = lastFieldId + 1
-          lastFieldId = field.$.id ? parseInt(field.$.id) : defaultFieldId
+          const rawFieldId = field.$.fieldId ?? field.$.id
+          lastFieldId = rawFieldId ? defaultFieldId : parseInt(rawFieldId)
           if (field.$.removedIn == null) {
             ev.fields.push({
               name: field.$.name,

--- a/test/resource/meta/api_maturity.xml
+++ b/test/resource/meta/api_maturity.xml
@@ -82,15 +82,15 @@ limitations under the License.
 
     <event code="0x0001" name="StableEvent" priority="info" side="server">
       <description>A Test event</description>
-      <field id="1" name="arg1" type="INT8U" isNullable="true"/>
-      <field id="2" name="arg2" type="INT32U" array="true"/>
+      <field fieldId="1" name="arg1" type="INT8U" isNullable="true"/>
+      <field fieldId="2" name="arg2" type="INT32U" array="true"/>
     </event>
 
     <event code="0x0002" name="ProvisionalEvent" priority="info" side="server" apiMaturity="provisional">
       <description>A Provisional Test event</description>
-      <field id="1" name="arg1" type="INT8U" isNullable="true"/>
-      <field id="2" name="arg2" type="INT32U" array="true"/>
-      <field id="3" name="arg3" type="INT32U" array="true" apiMaturity="provisional"/>
+      <field fieldId="1" name="arg1" type="INT8U" isNullable="true"/>
+      <field fieldId="2" name="arg2" type="INT32U" array="true"/>
+      <field fieldId="3" name="arg3" type="INT32U" array="true" apiMaturity="provisional"/>
     </event>
 
   </cluster>

--- a/test/resource/meta/test1.xml
+++ b/test/resource/meta/test1.xml
@@ -43,9 +43,9 @@ limitations under the License.
     </command>
     <event code="0x0001" name="HelloEvent" priority="info" side="server">
       <description>Example test event</description>
-      <field id="1" name="arg1" type="INT8U" isNullable="true"/>
-      <field id="2" name="arg2" type="INT32U" array="true"/>
-      <field id="3" name="arg3" type="CHAR_STRING"/>
+      <field fieldId="1" name="arg1" type="INT8U" isNullable="true"/>
+      <field fieldId="2" name="arg2" type="INT32U" array="true"/>
+      <field fieldId="3" name="arg3" type="CHAR_STRING"/>
     </event>
   </cluster>
   <cluster>
@@ -72,9 +72,9 @@ limitations under the License.
     </command>
     <event code="0x0001" name="HelloEvent" priority="info" side="server" isFabricSensitive="true">
       <description>Example test event</description>
-      <field id="1" name="arg1" type="INT8U" isNullable="true"/>
-      <field id="2" name="arg2" type="INT32U" array="true"/>
-      <field id="3" name="arg3" type="CHAR_STRING"/>
+      <field fieldId="1" name="arg1" type="INT8U" isNullable="true"/>
+      <field fieldId="2" name="arg2" type="INT32U" array="true"/>
+      <field fieldId="3" name="arg3" type="CHAR_STRING"/>
     </event>
   </cluster>
 </configurator>

--- a/test/resource/old-matter/access-control-cluster.xml
+++ b/test/resource/old-matter/access-control-cluster.xml
@@ -105,20 +105,20 @@ limitations under the License.
 
     <event side="server" code="0x0000" name="AccessControlEntryChanged" priority="info" optional="false">
       <description>The cluster SHALL send AccessControlEntryChanged events whenever its ACL attribute data is changed by an Administrator.</description>
-      <field id="1" name="AdminNodeID" type="node_id" isNullable="true"/>
-      <field id="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
-      <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
-      <field id="4" name="LatestValue" type="AccessControlEntry" isNullable="true"/>
-      <field id="0xFE" name="AdminFabricIndex" type="fabric_idx"/>
+      <field fieldId="1" name="AdminNodeID" type="node_id" isNullable="true"/>
+      <field fieldId="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
+      <field fieldId="3" name="ChangeType" type="ChangeTypeEnum"/>
+      <field fieldId="4" name="LatestValue" type="AccessControlEntry" isNullable="true"/>
+      <field fieldId="0xFE" name="AdminFabricIndex" type="fabric_idx"/>
       <access op="read" privilege="administer"/>
     </event>
     <event side="server" code="0x0001" name="AccessControlExtensionChanged" priority="info" optional="false">
       <description>The cluster SHALL send AccessControlExtensionChanged events whenever its extension attribute data is changed by an Administrator.</description>
-      <field id="1" name="AdminNodeID" type="node_id" isNullable="true"/>
-      <field id="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
-      <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
-      <field id="4" name="LatestValue" type="ExtensionEntry" isNullable="true"/>
-      <field id="0xFE" name="AdminFabricIndex" type="fabric_idx"/>
+      <field fieldId="1" name="AdminNodeID" type="node_id" isNullable="true"/>
+      <field fieldId="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
+      <field fieldId="3" name="ChangeType" type="ChangeTypeEnum"/>
+      <field fieldId="4" name="LatestValue" type="ExtensionEntry" isNullable="true"/>
+      <field fieldId="0xFE" name="AdminFabricIndex" type="fabric_idx"/>
       <access op="read" privilege="administer"/>
     </event>
   </cluster>

--- a/test/resource/old-matter/basic-information-cluster.xml
+++ b/test/resource/old-matter/basic-information-cluster.xml
@@ -68,7 +68,7 @@ limitations under the License.
 
     <event side="server" code="0x00" name="StartUp" priority="critical" optional="false">
       <description>The StartUp event SHALL be emitted by a Node as soon as reasonable after completing a boot or reboot process.</description>
-      <field id="0" name="SoftwareVersion" type="INT32U"/>
+      <field fieldId="0" name="SoftwareVersion" type="INT32U"/>
     </event>
     <event side="server" code="0x01" name="ShutDown" priority="critical" optional="false">
       <description>The ShutDown event SHOULD be emitted by a Node prior to any orderly shutdown sequence on a best-effort basis.</description>
@@ -78,7 +78,7 @@ limitations under the License.
     </event>
     <event side="server" code="0x03" name="ReachableChanged" priority="info" optional="true">
       <description>This event (when supported) SHALL be generated when there is a change in the Reachable attribute.</description>
-      <field id="0" name="ReachableNewValue" type="boolean"/>
+      <field fieldId="0" name="ReachableNewValue" type="boolean"/>
     </event>
 
   </cluster>

--- a/test/resource/old-matter/boolean-state-cluster.xml
+++ b/test/resource/old-matter/boolean-state-cluster.xml
@@ -30,7 +30,7 @@ limitations under the License.
 
     <event code="0x0000" name="StateChange" priority="info" side="server">
       <description>This event SHALL be generated when the StateValue attribute changes.</description>
-      <field id="0" name="StateValue" type="boolean"/>
+      <field fieldId="0" name="StateValue" type="boolean"/>
     </event>
   </cluster>
 </configurator>

--- a/test/resource/old-matter/bridged-actions-cluster.xml
+++ b/test/resource/old-matter/bridged-actions-cluster.xml
@@ -173,17 +173,17 @@ limitations under the License.
 
     <event side="server" code="0x00" priority="info" name="StateChanged" optional="false">
       <description>This event SHALL be generated when there is a change in the Status of an ActionID.</description>
-      <field id="0" name="ActionID" type="INT16U" />
-      <field id="1" name="InvokeID" type="INT32U" />
-      <field id="2" name="NewState" type="ActionStateEnum" />
+      <field fieldId="0" name="ActionID" type="INT16U" />
+      <field fieldId="1" name="InvokeID" type="INT32U" />
+      <field fieldId="2" name="NewState" type="ActionStateEnum" />
     </event>
 
     <event side="server" code="0x01" priority="info" name="ActionFailed" optional="false">
       <description>This event SHALL be generated when there is some error which prevents the action from its normal planned execution.</description>
-      <field id="0" name="ActionID" type="INT16U" />
-      <field id="1" name="InvokeID" type="INT32U" />
-      <field id="2" name="NewState" type="ActionStateEnum" />
-      <field id="3" name="Error"    type="ActionErrorEnum" />
+      <field fieldId="0" name="ActionID" type="INT16U" />
+      <field fieldId="1" name="InvokeID" type="INT32U" />
+      <field fieldId="2" name="NewState" type="ActionStateEnum" />
+      <field fieldId="3" name="Error"    type="ActionErrorEnum" />
     </event>
 
   </cluster>

--- a/test/resource/old-matter/bridged-device-basic.xml
+++ b/test/resource/old-matter/bridged-device-basic.xml
@@ -47,7 +47,7 @@ limitations under the License.
 
         <event side="server" code="0x00" name="StartUp" priority="critical" optional="true">
             <description>The StartUp event SHALL be emitted by a Node as soon as reasonable after completing a boot or reboot process.</description>
-            <field id="0" name="SoftwareVersion" type="INT32U"/>
+            <field fieldId="0" name="SoftwareVersion" type="INT32U"/>
         </event>
         <event side="server" code="0x01" name="ShutDown" priority="critical" optional="true">
             <description>The ShutDown event SHOULD be emitted by a Node prior to any orderly shutdown sequence on a best-effort basis.</description>
@@ -57,7 +57,7 @@ limitations under the License.
         </event>
         <event side="server" code="0x03" name="ReachableChanged" priority="info" optional="false">
             <description>This event SHALL be generated when there is a change in the Reachable attribute.</description>
-            <field id="0" name="ReachableNewValue" type="boolean"/>
+            <field fieldId="0" name="ReachableNewValue" type="boolean"/>
         </event>
 
     </cluster>

--- a/test/resource/old-matter/chip-ota.xml
+++ b/test/resource/old-matter/chip-ota.xml
@@ -95,10 +95,10 @@ limitations under the License.
         <item name="Querying" value="0x2"/>
         <item name="DelayedOnQuery" value="0x3"/>
         <item name="Downloading" value="0x4"/>
-        <item name="Applying" value="0x5"/>       
+        <item name="Applying" value="0x5"/>
         <item name="DelayedOnApply" value="0x6"/>
         <item name="RollingBack" value="0x7"/>
-        <item name="DelayedOnUserConsent" value="0x8"/>            
+        <item name="DelayedOnUserConsent" value="0x8"/>
     </enum>
     <enum name="OTAChangeReasonEnum" type="ENUM8">
         <cluster code="0x002a"/>
@@ -136,22 +136,22 @@ limitations under the License.
         </command>
         <event side="server" code="0x00" name="StateTransition" priority="info" optional="false">
           <description>This event SHALL be generated when a change of the UpdateState attribute occurs due to an OTA Requestor moving through the states necessary to query for updates.</description>
-          <field id="0" name="PreviousState" type="OTAUpdateStateEnum"/>
-          <field id="1" name="NewState" type="OTAUpdateStateEnum"/>
-          <field id="2" name="Reason" type="OTAChangeReasonEnum"/>
-          <field id="3" name="TargetSoftwareVersion" type="INT32U" isNullable="true"/>
-        </event> 
+          <field fieldId="0" name="PreviousState" type="OTAUpdateStateEnum"/>
+          <field fieldId="1" name="NewState" type="OTAUpdateStateEnum"/>
+          <field fieldId="2" name="Reason" type="OTAChangeReasonEnum"/>
+          <field fieldId="3" name="TargetSoftwareVersion" type="INT32U" isNullable="true"/>
+        </event>
         <event side="server" code="0x01" name="VersionApplied" priority="critical" optional="false">
           <description>This event SHALL be generated whenever a new version starts executing after being applied due to a software update.</description>
-          <field id="0" name="SoftwareVersion" type="INT32U"/> 
-          <field id="1" name="ProductID" type="INT16U"/>
+          <field fieldId="0" name="SoftwareVersion" type="INT32U"/>
+          <field fieldId="1" name="ProductID" type="INT16U"/>
         </event>
         <event side="server" code="0x02" name="DownloadError" priority="info" optional="false">
           <description>This event SHALL be generated whenever an error occurs during OTA Requestor download operation.</description>
-          <field id="0" name="SoftwareVersion" type="INT32U"/> 
-          <field id="1" name="BytesDownloaded" type="INT64U"/>
-          <field id="2" name="ProgressPercent" type="INT8U" min="0" max="100" isNullable="true"/>
-          <field id="3" name="PlatformCode" type="INT64S" isNullable="true"/>
-        </event>                     
+          <field fieldId="0" name="SoftwareVersion" type="INT32U"/>
+          <field fieldId="1" name="BytesDownloaded" type="INT64U"/>
+          <field fieldId="2" name="ProgressPercent" type="INT8U" min="0" max="100" isNullable="true"/>
+          <field fieldId="3" name="PlatformCode" type="INT64S" isNullable="true"/>
+        </event>
     </cluster>
 </configurator>

--- a/test/resource/old-matter/door-lock-cluster.xml
+++ b/test/resource/old-matter/door-lock-cluster.xml
@@ -605,43 +605,43 @@ limitations under the License.
         <!-- Events -->
         <event side="server" code="0" name="DoorLockAlarm" priority="critical">
             <description>The door lock cluster provides several alarms which can be sent when there is a critical state on the door lock.</description>
-            <field id="0" name="AlarmCode" type="DlAlarmCode" />
+            <field fieldId="0" name="AlarmCode" type="DlAlarmCode" />
         </event>
         <!-- Conformance feature DPS - for now optional -->
         <event side="server" code="1" name="DoorStateChange" priority="critical" optional="true">
             <description>The door lock server sends out a DoorStateChange event when the door lock door state changes.</description>
-            <field id="0" name="DoorState" type="DlDoorState" />
+            <field fieldId="0" name="DoorState" type="DlDoorState" />
         </event>
         <event side="server" code="2" name="LockOperation" priority="critical">
             <description>The door lock server sends out a LockOperation event when the event is triggered by the various lock operation sources.</description>
-            <field id="0" name="LockOperationType" type="DlLockOperationType" />
-            <field id="1" name="OperationSource" type="DlOperationSource" />
-            <field id="2" name="UserIndex" type="INT16U" isNullable="true" />
-            <field id="3" name="FabricIndex" type="fabric_idx" isNullable="true" />
-            <field id="4" name="SourceNode" type="NODE_ID" isNullable="true" />
+            <field fieldId="0" name="LockOperationType" type="DlLockOperationType" />
+            <field fieldId="1" name="OperationSource" type="DlOperationSource" />
+            <field fieldId="2" name="UserIndex" type="INT16U" isNullable="true" />
+            <field fieldId="3" name="FabricIndex" type="fabric_idx" isNullable="true" />
+            <field fieldId="4" name="SourceNode" type="NODE_ID" isNullable="true" />
             <!-- Conformance feature [USR] - for now optional -->
-            <field id="5" name="Credentials" type="DlCredential" array="true" isNullable="true" optional="true" />
+            <field fieldId="5" name="Credentials" type="DlCredential" array="true" isNullable="true" optional="true" />
         </event>
         <event side="server" code="3" name="LockOperationError" priority="critical">
             <description>The door lock server sends out a LockOperationError event when a lock operation fails for various reasons.</description>
-            <field id="0" name="LockOperationType" type="DlLockOperationType" />
-            <field id="1" name="OperationSource" type="DlOperationSource" />
-            <field id="2" name="OperationError" type="DlOperationError" />
-            <field id="3" name="UserIndex" type="INT16U" isNullable="true" />
-            <field id="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
-            <field id="5" name="SourceNode" type="NODE_ID" isNullable="true" />
+            <field fieldId="0" name="LockOperationType" type="DlLockOperationType" />
+            <field fieldId="1" name="OperationSource" type="DlOperationSource" />
+            <field fieldId="2" name="OperationError" type="DlOperationError" />
+            <field fieldId="3" name="UserIndex" type="INT16U" isNullable="true" />
+            <field fieldId="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
+            <field fieldId="5" name="SourceNode" type="NODE_ID" isNullable="true" />
             <!-- Conformance feature [USR] - for now optional -->
-            <field id="6" name="Credentials" type="DlCredential" array="true" isNullable="true" optional="true" />
+            <field fieldId="6" name="Credentials" type="DlCredential" array="true" isNullable="true" optional="true" />
         </event>
         <event side="server" code="4" name="LockUserChange" priority="info">
             <description>The door lock server sends out a LockUserChange event when a lock user, schedule, or credential change has occurred.</description>
-            <field id="0" name="LockDataType" type="DlLockDataType" />
-            <field id="1" name="DataOperationType" type="DlDataOperationType" />
-            <field id="2" name="OperationSource" type="DlOperationSource" />
-            <field id="3" name="UserIndex" type="INT16U" isNullable="true" />
-            <field id="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
-            <field id="5" name="SourceNode" type="NODE_ID" isNullable="true" />
-            <field id="6" name="DataIndex" type="INT16U" isNullable="true" />
+            <field fieldId="0" name="LockDataType" type="DlLockDataType" />
+            <field fieldId="1" name="DataOperationType" type="DlDataOperationType" />
+            <field fieldId="2" name="OperationSource" type="DlOperationSource" />
+            <field fieldId="3" name="UserIndex" type="INT16U" isNullable="true" />
+            <field fieldId="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
+            <field fieldId="5" name="SourceNode" type="NODE_ID" isNullable="true" />
+            <field fieldId="6" name="DataIndex" type="INT16U" isNullable="true" />
         </event>
     </cluster>
 
@@ -671,7 +671,7 @@ limitations under the License.
         <field mask="0x01" name="Single" />
         <field mask="0x02" name="Dual" />
         <field mask="0x04" name="Tri" />
-    </bitmap> 
+    </bitmap>
 
     <struct name="DlCredential">
         <cluster code="0x0101" />

--- a/test/resource/old-matter/general-diagnostics-cluster.xml
+++ b/test/resource/old-matter/general-diagnostics-cluster.xml
@@ -38,7 +38,7 @@ limitations under the License.
     <item name="ThreadFault" value="0x03"/>
     <item name="NFCFault" value="0x04"/>
     <item name="BLEFault" value="0x05"/>
-    <item name="EthernetFault" value="0x06"/>    
+    <item name="EthernetFault" value="0x06"/>
   </enum>
   <enum name="NetworkFaultType" type="ENUM8">
     <cluster code="0x0033"/>
@@ -56,7 +56,7 @@ limitations under the License.
     <item name="HardwareWatchdogReset" value="0x04"/>
     <item name="SoftwareUpdateCompleted" value="0x05"/>
     <item name="SoftwareReset" value="0x06"/>
-  </enum>  
+  </enum>
   <enum name="InterfaceType" type="ENUM8">
     <cluster code="0x0033"/>
     <item name="Unspecified" value="0x00"/>
@@ -93,22 +93,22 @@ limitations under the License.
     <attribute side="server" code="0x07" define="ACTIVE_NETWORK_FAULTS" type="ARRAY" entryType="ENUM8" writable="false" optional="true">ActiveNetworkFaults</attribute>
     <event side="server" code="0x00" name="HardwareFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of hardware faults currently detected by the Node.</description>
-      <field id="0" name="Current" type="HardwareFaultType" array="true"/>
-      <field id="1" name="Previous" type="HardwareFaultType" array="true"/>
+      <field fieldId="0" name="Current" type="HardwareFaultType" array="true"/>
+      <field fieldId="1" name="Previous" type="HardwareFaultType" array="true"/>
     </event>
     <event side="server" code="0x01" name="RadioFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of radio faults currently detected by the Node.</description>
-      <field id="0" name="Current" type="RadioFaultType" array="true"/>
-      <field id="1" name="Previous" type="RadioFaultType" array="true"/>
+      <field fieldId="0" name="Current" type="RadioFaultType" array="true"/>
+      <field fieldId="1" name="Previous" type="RadioFaultType" array="true"/>
     </event>
     <event side="server" code="0x02" name="NetworkFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of network faults currently detected by the Node.</description>
-      <field id="0" name="Current" type="NetworkFaultType" array="true"/>
-      <field id="1" name="Previous" type="NetworkFaultType" array="true"/>
+      <field fieldId="0" name="Current" type="NetworkFaultType" array="true"/>
+      <field fieldId="1" name="Previous" type="NetworkFaultType" array="true"/>
     </event>
     <event side="server" code="0x03" name="BootReason" priority="critical" optional="false">
       <description>Indicate the reason that caused the device to start-up.</description>
-      <field id="0" name="BootReason" type="BootReasonType"/>
-    </event>               
+      <field fieldId="0" name="BootReason" type="BootReasonType"/>
+    </event>
   </cluster>
 </configurator>

--- a/test/resource/old-matter/power-source-cluster.xml
+++ b/test/resource/old-matter/power-source-cluster.xml
@@ -24,13 +24,13 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the Node.</description>
-    <!-- TODO: Add feature map once it is supported 
+    <!-- TODO: Add feature map once it is supported
     <tag name="WIRED" description="A wired power source"/>
     <tag name="BAT" description="A battery powered source"/>
     <tag name="RECHG" description="A rechargeable battery power source"/>
     <tag name="REPLC" description="A replaceable battery power source"/>
     -->
-    
+
     <attribute side="server" code="0x0000" define="POWER_SOURCE_STATUS" type="ENUM8"  min="0x00" max="0x03" writable="false">Status</attribute>
     <attribute side="server" code="0x0001" define="POWER_SOURCE_ORDER" type="INT8U" min="0x00" max="0xFF" writable="false">Order</attribute>
     <attribute side="server" code="0x0002" define="POWER_SOURCE_DESCRIPTION" type="CHAR_STRING" length="60" writable="false">Description</attribute>
@@ -66,17 +66,17 @@ limitations under the License.
     <!-- TODO: Do events work?
     <event code="0x0000" name="WiredFaultChange" priority="info" side="server">
       <description>The WiredFaultChange Event SHALL indicate a change in the set of wired faults currently detected by the Node on this wired power source.</description>
-      <field id="1" name="WiredFaultChangeType" type="WiredFaultChangeType"/>
+      <field fieldId="1" name="WiredFaultChangeType" type="WiredFaultChangeType"/>
     </event>
 
     <event code="0x0001" name="BatFaultChange" priority="info" side="server">
       <description>The BatFaultChange Event SHALL indicate a change in the set of battery faults currently detected by the Node on this battery power source.</description>
-      <field id="1" name="BatFaultChangeType" type="BatFaultChangeType"/>
+      <field fieldId="1" name="BatFaultChangeType" type="BatFaultChangeType"/>
     </event>
 
     <event code="0x0002" name="BatChargeFaultChange" priority="info" side="server">
       <description>The BatChargeFaultChange Event SHALL indicate a change in the set of charge faults currently detected by the Node on this battery power source.</description>
-      <field id="1" name="BatChargeFaultChangeType" type="BatChargeFaultChangeType"/>
+      <field fieldId="1" name="BatChargeFaultChangeType" type="BatChargeFaultChangeType"/>
     </event>
     -->
 

--- a/test/resource/old-matter/software-diagnostics-cluster.xml
+++ b/test/resource/old-matter/software-diagnostics-cluster.xml
@@ -29,7 +29,7 @@ limitations under the License.
     <item name="Id" type="INT64U"/>
     <item name="Name" type="CHAR_STRING" length="8"/>
     <item name="FaultRecording" type="OCTET_STRING" length="1024"/>
-  </struct>  
+  </struct>
   <cluster>
     <domain>General</domain>
     <name>Software Diagnostics</name>
@@ -45,10 +45,10 @@ limitations under the License.
     </command>
     <event side="server" code="0x00" name="SoftwareFault" priority="info" optional="true">
       <description>Indicate the last software fault that has taken place on the Node.</description>
-      <field id="0" name="SoftwareFault" type="SoftwareFaultStruct"/>
-    </event>    
+      <field fieldId="0" name="SoftwareFault" type="SoftwareFaultStruct"/>
+    </event>
   </cluster>
   <bitmap name="SoftwareDiagnosticsFeature" type="BITMAP32">
     <field name="WaterMarks" mask="0x1"/>
-  </bitmap>   
+  </bitmap>
 </configurator>

--- a/test/resource/old-matter/switch-cluster.xml
+++ b/test/resource/old-matter/switch-cluster.xml
@@ -35,33 +35,33 @@ Interactions with the switch device are exposed as attributes (for the latching 
     <attribute side="server" code="0x0002" define="MULTI_PRESS_MAX" type="INT8U" writable="false" optional="false" default="2" min="2">multi press max</attribute>
     <event side="server" code="0x00" priority="info" name="SwitchLatched" optional="true">
       <description>Switch Latched</description>
-      <field id="0" name="NewPosition" type="INT8U" />
+      <field fieldId="0" name="NewPosition" type="INT8U" />
     </event>
     <event side="server" code="0x01" priority="info" name="InitialPress" optional="true">
       <description>Initial Press</description>
-      <field id="0" name="NewPosition" type="INT8U" />
+      <field fieldId="0" name="NewPosition" type="INT8U" />
     </event>
     <event side="server" code="0x02" priority="info" name="LongPress" optional="true">
       <description>Long Press</description>
-      <field id="0" name="NewPosition" type="INT8U" />
+      <field fieldId="0" name="NewPosition" type="INT8U" />
     </event>
     <event side="server" code="0x03" priority="info" name="ShortRelease" optional="true">
       <description>Short Release</description>
-      <field id="0" name="PreviousPosition" type="INT8U" />
+      <field fieldId="0" name="PreviousPosition" type="INT8U" />
     </event>
     <event side="server" code="0x04" priority="info" name="LongRelease" optional="true">
       <description>Long Release</description>
-      <field id="0" name="PreviousPosition" type="INT8U" />
+      <field fieldId="0" name="PreviousPosition" type="INT8U" />
     </event>
     <event side="server" code="0x05" priority="info" name="MultiPressOngoing" optional="true">
       <description>MultiPress Ongoing</description>
-      <field id="0" name="NewPosition" type="INT8U" />
-      <field id="1" name="CurrentNumberOfPressesCounted" type="INT8U" />
+      <field fieldId="0" name="NewPosition" type="INT8U" />
+      <field fieldId="1" name="CurrentNumberOfPressesCounted" type="INT8U" />
     </event>
     <event side="server" code="0x06" priority="info" name="MultiPressComplete" optional="true">
       <description>MultiPress Complete</description>
-      <field id="0" name="NewPosition" type="INT8U" />
-      <field id="1" name="TotalNumberOfPressesCounted" type="INT8U" />
+      <field fieldId="0" name="NewPosition" type="INT8U" />
+      <field fieldId="1" name="TotalNumberOfPressesCounted" type="INT8U" />
     </event>
 
   </cluster>

--- a/test/resource/old-matter/test-cluster.xml
+++ b/test/resource/old-matter/test-cluster.xml
@@ -128,7 +128,7 @@ limitations under the License.
         <field mask="0x04" name="MaskVal3" />
         <field mask="0x40000000" name="MaskVal4" />
     </bitmap>
-    
+
     <bitmap name="Bitmap64MaskMap" type="BITMAP64">
         <cluster code="0x050F" />
         <field mask="0x01" name="MaskVal1" />
@@ -136,7 +136,7 @@ limitations under the License.
         <field mask="0x04" name="MaskVal3" />
         <field mask="0x4000000000000000" name="MaskVal4" />
     </bitmap>
-    
+
   <cluster>
     <domain>CHIP</domain>
     <name>Test Cluster</name>
@@ -567,17 +567,17 @@ limitations under the License.
 
     <event code="0x0001" name="TestEvent" priority="info" side="server">
       <description>Example test event</description>
-      <field id="1" name="arg1" type="INT8U"/>
-      <field id="2" name="arg2" type="SimpleEnum"/>
-      <field id="3" name="arg3" type="BOOLEAN"/>
-      <field id="4" name="arg4" type="SimpleBitmap"/>
-      <field id="5" name="arg5" type="SimpleStruct" array="true"/>
-      <field id="6" name="arg6" type="SimpleEnum" array="true"/>
+      <field fieldId="1" name="arg1" type="INT8U"/>
+      <field fieldId="2" name="arg2" type="SimpleEnum"/>
+      <field fieldId="3" name="arg3" type="BOOLEAN"/>
+      <field fieldId="4" name="arg4" type="SimpleBitmap"/>
+      <field fieldId="5" name="arg5" type="SimpleStruct" array="true"/>
+      <field fieldId="6" name="arg6" type="SimpleEnum" array="true"/>
     </event>
 
     <event code="0x0002" name="TestFabricScopedEvent" priority="info" side="server">
       <description>Example test event</description>
-      <field id="0xFE" name="arg1" type="fabric_idx"/>
+      <field fieldId="0xFE" name="arg1" type="fabric_idx"/>
     </event>
 
   </cluster>

--- a/test/resource/old-matter/thread-network-diagnostics-cluster.xml
+++ b/test/resource/old-matter/thread-network-diagnostics-cluster.xml
@@ -34,7 +34,7 @@ limitations under the License.
     <cluster code="0x0035"/>
     <item name="Connected" value="0x00"/>
     <item name="NotConnected" value="0x01"/>
-  </enum>  
+  </enum>
   <struct name="NeighborTable">
     <cluster code="0x0035"/>
     <item name="ExtAddress" type="INT64U"/>
@@ -164,7 +164,7 @@ limitations under the License.
     </command>
     <event side="server" code="0x00" name="ConnectionStatus" priority="info" optional="true">
       <description>Indicate that a Node’s connection status to a Thread network has changed</description>
-      <field id="0" name="ConnectionStatus" type="ThreadConnectionStatus"/>
+      <field fieldId="0" name="ConnectionStatus" type="ThreadConnectionStatus"/>
     </event>
   </cluster>
   <bitmap name="ThreadNetworkDiagnosticsFeature" type="BITMAP32">
@@ -173,5 +173,5 @@ limitations under the License.
     <field name="ErrorCounts" mask="0x2"/>
     <field name="MLECounts" mask="0x4"/>
     <field name="MACCounts" mask="0x8"/>
-  </bitmap>  
+  </bitmap>
 </configurator>

--- a/test/resource/old-matter/wifi-network-diagnostics-cluster.xml
+++ b/test/resource/old-matter/wifi-network-diagnostics-cluster.xml
@@ -23,7 +23,7 @@ limitations under the License.
     <item name="WEP" value="0x02"/>
     <item name="WPA" value="0x03"/>
     <item name="WPA2" value="0x04"/>
-    <item name="WPA3" value="0x05"/>    
+    <item name="WPA3" value="0x05"/>
   </enum>
   <enum name="WiFiVersionType" type="ENUM8">
     <cluster code="0x0036"/>
@@ -32,7 +32,7 @@ limitations under the License.
     <item name="802.11g" value="0x02"/>
     <item name="802.11n" value="0x03"/>
     <item name="802.11ac" value="0x04"/>
-    <item name="802.11ax" value="0x05"/>    
+    <item name="802.11ax" value="0x05"/>
   </enum>
   <enum name="AssociationFailureCause" type="ENUM8">
     <cluster code="0x0036"/>
@@ -45,7 +45,7 @@ limitations under the License.
     <cluster code="0x0036"/>
     <item name="Connected" value="0x00"/>
     <item name="NotConnected" value="0x01"/>
-  </enum>  
+  </enum>
   <cluster>
     <domain>General</domain>
     <name>WiFi Network Diagnostics</name>
@@ -70,20 +70,20 @@ limitations under the License.
     </command>
     <event side="server" code="0x00" name="Disconnection" priority="info" optional="true">
       <description>Indicate that a Node’s Wi-Fi connection has been disconnected as a result of de-authenticated or dis-association and indicates the reason.</description>
-      <field id="0" name="ReasonCode" type="INT16U"/>
+      <field fieldId="0" name="ReasonCode" type="INT16U"/>
     </event>
     <event side="server" code="0x01" name="AssociationFailure" priority="info" optional="true">
       <description>Indicate that a Node has failed to connect, or reconnect, to a Wi-Fi access point.</description>
-      <field id="0" name="AssociationFailure" type="AssociationFailureCause"/>
-      <field id="1" name="Status" type="INT16U"/>      
+      <field fieldId="0" name="AssociationFailure" type="AssociationFailureCause"/>
+      <field fieldId="1" name="Status" type="INT16U"/>
     </event>
     <event side="server" code="0x02" name="ConnectionStatus" priority="info" optional="true">
       <description>Indicate that a Node’s connection status to a Wi-Fi network has changed.</description>
-      <field id="0" name="ConnectionStatus" type="WiFiConnectionStatus"/>
-    </event>                  
+      <field fieldId="0" name="ConnectionStatus" type="WiFiConnectionStatus"/>
+    </event>
   </cluster>
   <bitmap name="WiFiNetworkDiagnosticsFeature" type="BITMAP32">
     <field name="PacketCounts" mask="0x1"/>
     <field name="ErrorCounts" mask="0x2"/>
-  </bitmap>  
+  </bitmap>
 </configurator>

--- a/zcl-builtin/matter/data-model/chip/access-control-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/access-control-cluster.xml
@@ -72,7 +72,7 @@ limitations under the License.
       and enforce Access Control for the Node's endpoints and their associated
       cluster instances.</description>
 
-    <!-- Modified attribute definition from `type="array" entryType="X"` to `array="true" type="X"`  
+    <!-- Modified attribute definition from `type="array" entryType="X"` to `array="true" type="X"`
      to support testing loading list-typed attributes -->
     <attribute side="server" code="0x0000" define="ACL" array="true" type="AccessControlEntryStruct" writable="true">
       <description>ACL</description>
@@ -114,18 +114,18 @@ limitations under the License.
 
     <event side="server" code="0x0000" name="AccessControlEntryChanged" priority="info" isFabricSensitive="true" optional="false">
       <description>The cluster SHALL send AccessControlEntryChanged events whenever its ACL attribute data is changed by an Administrator.</description>
-      <field id="1" name="AdminNodeID" type="node_id" isNullable="true"/>
-      <field id="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
-      <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
-      <field id="4" name="LatestValue" type="AccessControlEntryStruct" isNullable="true"/>
+      <field fieldId="1" name="AdminNodeID" type="node_id" isNullable="true"/>
+      <field fieldId="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
+      <field fieldId="3" name="ChangeType" type="ChangeTypeEnum"/>
+      <field fieldId="4" name="LatestValue" type="AccessControlEntryStruct" isNullable="true"/>
       <access op="read" privilege="administer"/>
     </event>
     <event side="server" code="0x0001" name="AccessControlExtensionChanged" priority="info" isFabricSensitive="true" optional="false">
       <description>The cluster SHALL send AccessControlExtensionChanged events whenever its extension attribute data is changed by an Administrator.</description>
-      <field id="1" name="AdminNodeID" type="node_id" isNullable="true"/>
-      <field id="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
-      <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
-      <field id="4" name="LatestValue" type="AccessControlExtensionStruct" isNullable="true"/>
+      <field fieldId="1" name="AdminNodeID" type="node_id" isNullable="true"/>
+      <field fieldId="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
+      <field fieldId="3" name="ChangeType" type="ChangeTypeEnum"/>
+      <field fieldId="4" name="LatestValue" type="AccessControlExtensionStruct" isNullable="true"/>
       <access op="read" privilege="administer"/>
     </event>
   </cluster>

--- a/zcl-builtin/matter/data-model/chip/actions-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/actions-cluster.xml
@@ -176,17 +176,17 @@ limitations under the License.
 
     <event side="server" code="0x00" priority="info" name="StateChanged" optional="false">
       <description>This event SHALL be generated when there is a change in the Status of an ActionID.</description>
-      <field id="0" name="ActionID" type="INT16U" />
-      <field id="1" name="InvokeID" type="INT32U" />
-      <field id="2" name="NewState" type="ActionStateEnum" />
+      <field fieldId="0" name="ActionID" type="INT16U" />
+      <field fieldId="1" name="InvokeID" type="INT32U" />
+      <field fieldId="2" name="NewState" type="ActionStateEnum" />
     </event>
 
     <event side="server" code="0x01" priority="info" name="ActionFailed" optional="false">
       <description>This event SHALL be generated when there is some error which prevents the action from its normal planned execution.</description>
-      <field id="0" name="ActionID" type="INT16U" />
-      <field id="1" name="InvokeID" type="INT32U" />
-      <field id="2" name="NewState" type="ActionStateEnum" />
-      <field id="3" name="Error"    type="ActionErrorEnum" />
+      <field fieldId="0" name="ActionID" type="INT16U" />
+      <field fieldId="1" name="InvokeID" type="INT32U" />
+      <field fieldId="2" name="NewState" type="ActionStateEnum" />
+      <field fieldId="3" name="Error"    type="ActionErrorEnum" />
     </event>
 
   </cluster>

--- a/zcl-builtin/matter/data-model/chip/basic-information-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/basic-information-cluster.xml
@@ -68,18 +68,18 @@ limitations under the License.
 
     <event side="server" code="0x00" name="StartUp" priority="critical" optional="false">
       <description>The StartUp event SHALL be emitted by a Node as soon as reasonable after completing a boot or reboot process.</description>
-      <field id="0" name="SoftwareVersion" type="INT32U"/>
+      <field fieldId="0" name="SoftwareVersion" type="INT32U"/>
     </event>
     <event side="server" code="0x01" name="ShutDown" priority="critical" optional="true">
       <description>The ShutDown event SHOULD be emitted by a Node prior to any orderly shutdown sequence on a best-effort basis.</description>
     </event>
     <event side="server" code="0x02" name="Leave" priority="info" optional="true">
       <description>The Leave event SHOULD be emitted by a Node prior to permanently leaving the Fabric.</description>
-      <field id="0" name="FabricIndex" type="fabric_idx"/>
+      <field fieldId="0" name="FabricIndex" type="fabric_idx"/>
     </event>
     <event side="server" code="0x03" name="ReachableChanged" priority="info" optional="true">
       <description>This event (when supported) SHALL be generated when there is a change in the Reachable attribute.</description>
-      <field id="0" name="ReachableNewValue" type="boolean"/>
+      <field fieldId="0" name="ReachableNewValue" type="boolean"/>
     </event>
 
   </cluster>

--- a/zcl-builtin/matter/data-model/chip/boolean-state-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/boolean-state-cluster.xml
@@ -30,7 +30,7 @@ limitations under the License.
 
     <event code="0x0000" name="StateChange" priority="info" side="server">
       <description>This event SHALL be generated when the StateValue attribute changes.</description>
-      <field id="0" name="StateValue" type="boolean"/>
+      <field fieldId="0" name="StateValue" type="boolean"/>
     </event>
   </cluster>
 </configurator>

--- a/zcl-builtin/matter/data-model/chip/bridged-device-basic-information.xml
+++ b/zcl-builtin/matter/data-model/chip/bridged-device-basic-information.xml
@@ -47,7 +47,7 @@ limitations under the License.
 
         <event side="server" code="0x00" name="StartUp" priority="critical" optional="true">
             <description>The StartUp event SHALL be emitted by a Node as soon as reasonable after completing a boot or reboot process.</description>
-            <field id="0" name="SoftwareVersion" type="INT32U"/>
+            <field fieldId="0" name="SoftwareVersion" type="INT32U"/>
         </event>
         <event side="server" code="0x01" name="ShutDown" priority="critical" optional="true">
             <description>The ShutDown event SHOULD be emitted by a Node prior to any orderly shutdown sequence on a best-effort basis.</description>
@@ -57,7 +57,7 @@ limitations under the License.
         </event>
         <event side="server" code="0x03" name="ReachableChanged" priority="info" optional="false">
             <description>This event SHALL be generated when there is a change in the Reachable attribute.</description>
-            <field id="0" name="ReachableNewValue" type="boolean"/>
+            <field fieldId="0" name="ReachableNewValue" type="boolean"/>
         </event>
 
     </cluster>

--- a/zcl-builtin/matter/data-model/chip/chip-ota.xml
+++ b/zcl-builtin/matter/data-model/chip/chip-ota.xml
@@ -135,22 +135,22 @@ limitations under the License.
         </command>
         <event side="server" code="0x00" name="StateTransition" priority="info" optional="false">
           <description>This event SHALL be generated when a change of the UpdateState attribute occurs due to an OTA Requestor moving through the states necessary to query for updates.</description>
-          <field id="0" name="PreviousState" type="OTAUpdateStateEnum"/>
-          <field id="1" name="NewState" type="OTAUpdateStateEnum"/>
-          <field id="2" name="Reason" type="OTAChangeReasonEnum"/>
-          <field id="3" name="TargetSoftwareVersion" type="INT32U" isNullable="true"/>
+          <field fieldId="0" name="PreviousState" type="OTAUpdateStateEnum"/>
+          <field fieldId="1" name="NewState" type="OTAUpdateStateEnum"/>
+          <field fieldId="2" name="Reason" type="OTAChangeReasonEnum"/>
+          <field fieldId="3" name="TargetSoftwareVersion" type="INT32U" isNullable="true"/>
         </event>
         <event side="server" code="0x01" name="VersionApplied" priority="critical" optional="false">
           <description>This event SHALL be generated whenever a new version starts executing after being applied due to a software update.</description>
-          <field id="0" name="SoftwareVersion" type="INT32U" default="0x00000000"/>
-          <field id="1" name="ProductID" type="INT16U"/>
+          <field fieldId="0" name="SoftwareVersion" type="INT32U" default="0x00000000"/>
+          <field fieldId="1" name="ProductID" type="INT16U"/>
         </event>
         <event side="server" code="0x02" name="DownloadError" priority="info" optional="false">
           <description>This event SHALL be generated whenever an error occurs during OTA Requestor download operation.</description>
-          <field id="0" name="SoftwareVersion" type="INT32U"/>
-          <field id="1" name="BytesDownloaded" type="INT64U"/>
-          <field id="2" name="ProgressPercent" type="INT8U" min="0" max="100" isNullable="true"/>
-          <field id="3" name="PlatformCode" type="INT64S" isNullable="true"/>
+          <field fieldId="0" name="SoftwareVersion" type="INT32U"/>
+          <field fieldId="1" name="BytesDownloaded" type="INT64U"/>
+          <field fieldId="2" name="ProgressPercent" type="INT8U" min="0" max="100" isNullable="true"/>
+          <field fieldId="3" name="PlatformCode" type="INT64S" isNullable="true"/>
         </event>
     </cluster>
 </configurator>

--- a/zcl-builtin/matter/data-model/chip/door-lock-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/door-lock-cluster.xml
@@ -415,48 +415,48 @@ limitations under the License.
         <!-- Events -->
         <event side="server" code="0" name="DoorLockAlarm" priority="critical" optional="true">
             <description>The door lock cluster provides several alarms which can be sent when there is a critical state on the door lock.</description>
-            <field id="0" name="AlarmCode" type="AlarmCodeEnum" />
+            <field fieldId="0" name="AlarmCode" type="AlarmCodeEnum" />
             <mandatoryConform/>
         </event>
         <!-- Conformance feature DPS - for now optional -->
         <event side="server" code="1" name="DoorStateChange" priority="critical" optional="true">
             <description>The door lock server sends out a DoorStateChange event when the door lock door state changes.</description>
-            <field id="0" name="DoorState" type="DoorStateEnum" />
+            <field fieldId="0" name="DoorState" type="DoorStateEnum" />
             <mandatoryConform>
                 <feature name="DPS"/>
             </mandatoryConform>
         </event>
         <event side="server" code="2" name="LockOperation" priority="critical" optional="true">
             <description>The door lock server sends out a LockOperation event when the event is triggered by the various lock operation sources.</description>
-            <field id="0" name="LockOperationType" type="LockOperationTypeEnum" />
-            <field id="1" name="OperationSource" type="OperationSourceEnum" />
-            <field id="2" name="UserIndex" type="INT16U" isNullable="true" />
-            <field id="3" name="FabricIndex" type="fabric_idx" isNullable="true" />
-            <field id="4" name="SourceNode" type="NODE_ID" isNullable="true" />
+            <field fieldId="0" name="LockOperationType" type="LockOperationTypeEnum" />
+            <field fieldId="1" name="OperationSource" type="OperationSourceEnum" />
+            <field fieldId="2" name="UserIndex" type="INT16U" isNullable="true" />
+            <field fieldId="3" name="FabricIndex" type="fabric_idx" isNullable="true" />
+            <field fieldId="4" name="SourceNode" type="NODE_ID" isNullable="true" />
             <!-- Conformance feature [USR] - for now optional -->
-            <field id="5" name="Credentials" type="CredentialStruct" array="true" isNullable="true" optional="true" />
+            <field fieldId="5" name="Credentials" type="CredentialStruct" array="true" isNullable="true" optional="true" />
         </event>
         <event side="server" code="3" name="LockOperationError" priority="critical">
             <description>The door lock server sends out a LockOperationError event when a lock operation fails for various reasons.</description>
-            <field id="0" name="LockOperationType" type="LockOperationTypeEnum" />
-            <field id="1" name="OperationSource" type="OperationSourceEnum" />
-            <field id="2" name="OperationError" type="OperationErrorEnum" />
-            <field id="3" name="UserIndex" type="INT16U" isNullable="true" />
-            <field id="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
-            <field id="5" name="SourceNode" type="NODE_ID" isNullable="true" />
+            <field fieldId="0" name="LockOperationType" type="LockOperationTypeEnum" />
+            <field fieldId="1" name="OperationSource" type="OperationSourceEnum" />
+            <field fieldId="2" name="OperationError" type="OperationErrorEnum" />
+            <field fieldId="3" name="UserIndex" type="INT16U" isNullable="true" />
+            <field fieldId="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
+            <field fieldId="5" name="SourceNode" type="NODE_ID" isNullable="true" />
             <!-- Conformance feature [USR] - for now optional -->
-            <field id="6" name="Credentials" type="CredentialStruct" array="true" isNullable="true" optional="true" />
+            <field fieldId="6" name="Credentials" type="CredentialStruct" array="true" isNullable="true" optional="true" />
             <mandatoryConform/>
         </event>
         <event side="server" code="4" name="LockUserChange" priority="info">
             <description>The door lock server sends out a LockUserChange event when a lock user, schedule, or credential change has occurred.</description>
-            <field id="0" name="LockDataType" type="LockDataTypeEnum" />
-            <field id="1" name="DataOperationType" type="DataOperationTypeEnum" />
-            <field id="2" name="OperationSource" type="OperationSourceEnum" />
-            <field id="3" name="UserIndex" type="INT16U" isNullable="true" />
-            <field id="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
-            <field id="5" name="SourceNode" type="NODE_ID" isNullable="true" />
-            <field id="6" name="DataIndex" type="INT16U" isNullable="true" />
+            <field fieldId="0" name="LockDataType" type="LockDataTypeEnum" />
+            <field fieldId="1" name="DataOperationType" type="DataOperationTypeEnum" />
+            <field fieldId="2" name="OperationSource" type="OperationSourceEnum" />
+            <field fieldId="3" name="UserIndex" type="INT16U" isNullable="true" />
+            <field fieldId="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
+            <field fieldId="5" name="SourceNode" type="NODE_ID" isNullable="true" />
+            <field fieldId="6" name="DataIndex" type="INT16U" isNullable="true" />
         </event>
     </cluster>
 
@@ -486,7 +486,7 @@ limitations under the License.
         <field mask="0x01" name="Single" />
         <field mask="0x02" name="Dual" />
         <field mask="0x04" name="Tri" />
-    </bitmap> 
+    </bitmap>
 
     <struct name="CredentialStruct">
         <cluster code="0x0101" />

--- a/zcl-builtin/matter/data-model/chip/general-diagnostics-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/general-diagnostics-cluster.xml
@@ -38,7 +38,7 @@ limitations under the License.
     <item name="ThreadFault" value="0x03"/>
     <item name="NFCFault" value="0x04"/>
     <item name="BLEFault" value="0x05"/>
-    <item name="EthernetFault" value="0x06"/>    
+    <item name="EthernetFault" value="0x06"/>
   </enum>
   <enum name="NetworkFaultEnum" type="ENUM8">
     <cluster code="0x0033"/>
@@ -56,7 +56,7 @@ limitations under the License.
     <item name="HardwareWatchdogReset" value="0x04"/>
     <item name="SoftwareUpdateCompleted" value="0x05"/>
     <item name="SoftwareReset" value="0x06"/>
-  </enum>  
+  </enum>
   <enum name="InterfaceTypeEnum" type="ENUM8">
     <cluster code="0x0033"/>
     <item name="Unspecified" value="0x00"/>
@@ -102,22 +102,22 @@ limitations under the License.
 
     <event side="server" code="0x00" name="HardwareFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of hardware faults currently detected by the Node.</description>
-      <field id="0" name="Current" type="HardwareFaultEnum" array="true"/>
-      <field id="1" name="Previous" type="HardwareFaultEnum" array="true"/>
+      <field fieldId="0" name="Current" type="HardwareFaultEnum" array="true"/>
+      <field fieldId="1" name="Previous" type="HardwareFaultEnum" array="true"/>
     </event>
     <event side="server" code="0x01" name="RadioFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of radio faults currently detected by the Node.</description>
-      <field id="0" name="Current" type="RadioFaultEnum" array="true"/>
-      <field id="1" name="Previous" type="RadioFaultEnum" array="true"/>
+      <field fieldId="0" name="Current" type="RadioFaultEnum" array="true"/>
+      <field fieldId="1" name="Previous" type="RadioFaultEnum" array="true"/>
     </event>
     <event side="server" code="0x02" name="NetworkFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of network faults currently detected by the Node.</description>
-      <field id="0" name="Current" type="NetworkFaultEnum" array="true"/>
-      <field id="1" name="Previous" type="NetworkFaultEnum" array="true"/>
+      <field fieldId="0" name="Current" type="NetworkFaultEnum" array="true"/>
+      <field fieldId="1" name="Previous" type="NetworkFaultEnum" array="true"/>
     </event>
     <event side="server" code="0x03" name="BootReason" priority="critical" optional="false">
       <description>Indicate the reason that caused the device to start-up.</description>
-      <field id="0" name="BootReason" type="BootReasonEnum"/>
+      <field fieldId="0" name="BootReason" type="BootReasonEnum"/>
     </event>
   </cluster>
 </configurator>

--- a/zcl-builtin/matter/data-model/chip/power-source-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/power-source-cluster.xml
@@ -24,7 +24,7 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the Node.</description>
-    
+
     <attribute side="server" code="0x0000" define="POWER_SOURCE_STATUS" type="PowerSourceStatusEnum" writable="false">Status</attribute>
     <attribute side="server" code="0x0001" define="POWER_SOURCE_ORDER" type="INT8U" min="0x00" max="0xFF" writable="false">Order</attribute>
     <attribute side="server" code="0x0002" define="POWER_SOURCE_DESCRIPTION" type="CHAR_STRING" length="60" writable="false">Description</attribute>
@@ -61,20 +61,20 @@ limitations under the License.
 
     <event code="0x0000" name="WiredFaultChange" priority="info" side="server" optional="true">
       <description>The WiredFaultChange Event SHALL indicate a change in the set of wired faults currently detected by the Node on this wired power source.</description>
-      <field id="0" name="Current" type="WiredFaultEnum" array="true" length="8"/>
-      <field id="1" name="Previous" type="WiredFaultEnum" array="true" length="8"/>
+      <field fieldId="0" name="Current" type="WiredFaultEnum" array="true" length="8"/>
+      <field fieldId="1" name="Previous" type="WiredFaultEnum" array="true" length="8"/>
     </event>
 
     <event code="0x0001" name="BatFaultChange" priority="info" side="server" optional="true">
       <description>The BatFaultChange Event SHALL indicate a change in the set of battery faults currently detected by the Node on this battery power source.</description>
-      <field id="0" name="Current" type="BatFaultEnum" array="true" length="8"/>
-      <field id="1" name="Previous" type="BatFaultEnum" array="true" length="8"/>
+      <field fieldId="0" name="Current" type="BatFaultEnum" array="true" length="8"/>
+      <field fieldId="1" name="Previous" type="BatFaultEnum" array="true" length="8"/>
     </event>
 
     <event code="0x0002" name="BatChargeFaultChange" priority="info" side="server" optional="true">
       <description>The BatChargeFaultChange Event SHALL indicate a change in the set of charge faults currently detected by the Node on this battery power source.</description>
-      <field id="0" name="Current" type="BatChargeFaultEnum" array="true" length="16"/>
-      <field id="1" name="Previous" type="BatChargeFaultEnum" array="true" length="16"/>
+      <field fieldId="0" name="Current" type="BatChargeFaultEnum" array="true" length="16"/>
+      <field fieldId="1" name="Previous" type="BatChargeFaultEnum" array="true" length="16"/>
     </event>
 
   </cluster>

--- a/zcl-builtin/matter/data-model/chip/software-diagnostics-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/software-diagnostics-cluster.xml
@@ -39,13 +39,13 @@ limitations under the License.
     </command>
     <event side="server" code="0x00" name="SoftwareFault" priority="info" optional="true">
       <description>Indicate the last software fault that has taken place on the Node.</description>
-      <field id="0" name="ID" type="INT64U"/>
-      <field id="1" name="Name" type="CHAR_STRING" length="8" optional="true"/>
-      <field id="2" name="FaultRecording" type="OCTET_STRING" length="1024" optional="true"/>
-    </event>    
+      <field fieldId="0" name="ID" type="INT64U"/>
+      <field fieldId="1" name="Name" type="CHAR_STRING" length="8" optional="true"/>
+      <field fieldId="2" name="FaultRecording" type="OCTET_STRING" length="1024" optional="true"/>
+    </event>
   </cluster>
   <bitmap name="SoftwareDiagnosticsFeature" type="BITMAP32">
     <cluster code="0x0034"/>
     <field name="WaterMarks" mask="0x1"/>
-  </bitmap>   
+  </bitmap>
 </configurator>

--- a/zcl-builtin/matter/data-model/chip/switch-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/switch-cluster.xml
@@ -35,33 +35,33 @@ Interactions with the switch device are exposed as attributes (for the latching 
     <attribute side="server" code="0x0002" define="MULTI_PRESS_MAX" type="INT8U" writable="false" optional="true" default="2" min="2">MultiPressMax</attribute>
     <event side="server" code="0x00" priority="info" name="SwitchLatched" optional="true">
       <description>SwitchLatched</description>
-      <field id="0" name="NewPosition" type="INT8U" />
+      <field fieldId="0" name="NewPosition" type="INT8U" />
     </event>
     <event side="server" code="0x01" priority="info" name="InitialPress" optional="true">
       <description>InitialPress</description>
-      <field id="0" name="NewPosition" type="INT8U" />
+      <field fieldId="0" name="NewPosition" type="INT8U" />
     </event>
     <event side="server" code="0x02" priority="info" name="LongPress" optional="true">
       <description>LongPress</description>
-      <field id="0" name="NewPosition" type="INT8U" />
+      <field fieldId="0" name="NewPosition" type="INT8U" />
     </event>
     <event side="server" code="0x03" priority="info" name="ShortRelease" optional="true">
       <description>ShortRelease</description>
-      <field id="0" name="PreviousPosition" type="INT8U" />
+      <field fieldId="0" name="PreviousPosition" type="INT8U" />
     </event>
     <event side="server" code="0x04" priority="info" name="LongRelease" optional="true">
       <description>LongRelease</description>
-      <field id="0" name="PreviousPosition" type="INT8U" />
+      <field fieldId="0" name="PreviousPosition" type="INT8U" />
     </event>
     <event side="server" code="0x05" priority="info" name="MultiPressOngoing" optional="true">
       <description>MultiPressOngoing</description>
-      <field id="0" name="NewPosition" type="INT8U" />
-      <field id="1" name="CurrentNumberOfPressesCounted" type="INT8U" />
+      <field fieldId="0" name="NewPosition" type="INT8U" />
+      <field fieldId="1" name="CurrentNumberOfPressesCounted" type="INT8U" />
     </event>
     <event side="server" code="0x06" priority="info" name="MultiPressComplete" optional="true">
       <description>MultiPressComplete</description>
-      <field id="0" name="PreviousPosition" type="INT8U" />
-      <field id="1" name="TotalNumberOfPressesCounted" type="INT8U" />
+      <field fieldId="0" name="PreviousPosition" type="INT8U" />
+      <field fieldId="1" name="TotalNumberOfPressesCounted" type="INT8U" />
     </event>
 
   </cluster>

--- a/zcl-builtin/matter/data-model/chip/test-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/test-cluster.xml
@@ -574,12 +574,12 @@ limitations under the License.
 
     <event code="0x0001" name="TestEvent" priority="info" side="server">
       <description>Example test event</description>
-      <field id="1" name="arg1" type="INT8U"/>
-      <field id="2" name="arg2" type="SimpleEnum"/>
-      <field id="3" name="arg3" type="BOOLEAN"/>
-      <field id="4" name="arg4" type="SimpleStruct"/>
-      <field id="5" name="arg5" type="SimpleStruct" array="true"/>
-      <field id="6" name="arg6" type="SimpleEnum" array="true"/>
+      <field fieldId="1" name="arg1" type="INT8U"/>
+      <field fieldId="2" name="arg2" type="SimpleEnum"/>
+      <field fieldId="3" name="arg3" type="BOOLEAN"/>
+      <field fieldId="4" name="arg4" type="SimpleStruct"/>
+      <field fieldId="5" name="arg5" type="SimpleStruct" array="true"/>
+      <field fieldId="6" name="arg6" type="SimpleEnum" array="true"/>
     </event>
 
     <event code="0x0002" name="TestFabricScopedEvent" priority="info" side="server" isFabricSensitive="true">

--- a/zcl-builtin/matter/data-model/chip/thread-network-diagnostics-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/thread-network-diagnostics-cluster.xml
@@ -34,7 +34,7 @@ limitations under the License.
     <cluster code="0x0035"/>
     <item name="Connected" value="0x00"/>
     <item name="NotConnected" value="0x01"/>
-  </enum>  
+  </enum>
   <struct name="NeighborTable">
     <cluster code="0x0035"/>
     <item name="ExtAddress" type="INT64U"/>
@@ -159,13 +159,13 @@ limitations under the License.
     </command>
     <event side="server" code="0x00" name="ConnectionStatus" priority="info" optional="true">
       <description>Indicate that a Node’s connection status to a Thread network has changed</description>
-      <field id="0" name="ConnectionStatus" type="ConnectionStatusEnum"/>
+      <field fieldId="0" name="ConnectionStatus" type="ConnectionStatusEnum"/>
     </event>
     <event side="server" code="0x01" name="NetworkFaultChange" priority="info" optional="true">
       <description>Indicate a change in the set of network faults currently detected by the Node</description>
-      <field id="0" name="Current" type="NetworkFault" array="true"/>
-      <field id="1" name="Previous" type="NetworkFault" array="true"/>
-    </event>    
+      <field fieldId="0" name="Current" type="NetworkFault" array="true"/>
+      <field fieldId="1" name="Previous" type="NetworkFault" array="true"/>
+    </event>
   </cluster>
   <bitmap name="ThreadNetworkDiagnosticsFeature" type="BITMAP32">
     <cluster code="0x0035"/>
@@ -173,5 +173,5 @@ limitations under the License.
     <field name="ErrorCounts" mask="0x2"/>
     <field name="MLECounts" mask="0x4"/>
     <field name="MACCounts" mask="0x8"/>
-  </bitmap>  
+  </bitmap>
 </configurator>

--- a/zcl-builtin/matter/data-model/chip/wifi-network-diagnostics-cluster.xml
+++ b/zcl-builtin/matter/data-model/chip/wifi-network-diagnostics-cluster.xml
@@ -23,7 +23,7 @@ limitations under the License.
     <item name="WEP" value="0x02"/>
     <item name="WPA" value="0x03"/>
     <item name="WPA2" value="0x04"/>
-    <item name="WPA3" value="0x05"/>    
+    <item name="WPA3" value="0x05"/>
   </enum>
   <enum name="WiFiVersionEnum" type="ENUM8">
     <cluster code="0x0036"/>
@@ -32,7 +32,7 @@ limitations under the License.
     <item name="g" value="0x02"/>
     <item name="n" value="0x03"/>
     <item name="ac" value="0x04"/>
-    <item name="ax" value="0x05"/>    
+    <item name="ax" value="0x05"/>
   </enum>
   <enum name="AssociationFailureCauseEnum" type="ENUM8">
     <cluster code="0x0036"/>
@@ -45,12 +45,12 @@ limitations under the License.
     <cluster code="0x0036"/>
     <item name="Connected" value="0x00"/>
     <item name="NotConnected" value="0x01"/>
-  </enum>  
+  </enum>
   <bitmap name="WiFiNetworkDiagnosticsFeature" type="BITMAP32">
     <cluster code="0x0036"/>
     <field name="PacketCounts" mask="0x1"/>
     <field name="ErrorCounts" mask="0x2"/>
-  </bitmap>  
+  </bitmap>
   <cluster>
     <domain>General</domain>
     <name>WiFi Network Diagnostics</name>
@@ -75,16 +75,16 @@ limitations under the License.
     </command>
     <event side="server" code="0x00" name="Disconnection" priority="info" optional="true">
       <description>Indicate that a Node’s Wi-Fi connection has been disconnected as a result of de-authenticated or dis-association and indicates the reason.</description>
-      <field id="0" name="ReasonCode" type="INT16U"/>
+      <field fieldId="0" name="ReasonCode" type="INT16U"/>
     </event>
     <event side="server" code="0x01" name="AssociationFailure" priority="info" optional="true">
       <description>Indicate that a Node has failed to connect, or reconnect, to a Wi-Fi access point.</description>
-      <field id="0" name="AssociationFailure" type="AssociationFailureCauseEnum"/>
-      <field id="1" name="Status" type="INT16U"/>      
+      <field fieldId="0" name="AssociationFailure" type="AssociationFailureCauseEnum"/>
+      <field fieldId="1" name="Status" type="INT16U"/>
     </event>
     <event side="server" code="0x02" name="ConnectionStatus" priority="info" optional="true">
       <description>Indicate that a Node’s connection status to a Wi-Fi network has changed.</description>
-      <field id="0" name="ConnectionStatus" type="ConnectionStatusEnum"/>
-    </event>                  
+      <field fieldId="0" name="ConnectionStatus" type="ConnectionStatusEnum"/>
+    </event>
   </cluster>
 </configurator>

--- a/zcl-builtin/matter/new-data-model/ACL-Cluster.xml
+++ b/zcl-builtin/matter/new-data-model/ACL-Cluster.xml
@@ -107,22 +107,22 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="AccessControlEntryStruct">
-      <field id="1" name="Privilege" type="AccessControlEntryPrivilegeEnum">
+      <field fieldId="1" name="Privilege" type="AccessControlEntryPrivilegeEnum">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="AuthMode" type="AccessControlEntryAuthModeEnum">
+      <field fieldId="2" name="AuthMode" type="AccessControlEntryAuthModeEnum">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="Subjects" type="list">
+      <field fieldId="3" name="Subjects" type="list">
         <entry type="SubjectID"/>
         <access fabricSensitive="true"/>
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="SubjectsPerAccessControlEntry"/>
       </field>
-      <field id="4" name="Targets" type="list">
+      <field fieldId="4" name="Targets" type="list">
         <entry type="AccessControlTargetStruct"/>
         <access fabricSensitive="true"/>
         <quality nullable="true"/>
@@ -132,7 +132,7 @@ Davis, CA 95616, USA
       <access fabricScoped="true"/>
     </struct>
     <struct name="AccessControlExtensionStruct">
-      <field id="1" name="Data" type="octstr">
+      <field fieldId="1" name="Data" type="octstr">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="128"/>
@@ -140,15 +140,15 @@ Davis, CA 95616, USA
       <access fabricScoped="true"/>
     </struct>
     <struct name="AccessControlTargetStruct">
-      <field id="0" name="Cluster" type="cluster-id">
+      <field fieldId="0" name="Cluster" type="cluster-id">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="Endpoint" type="endpoint-no">
+      <field fieldId="1" name="Endpoint" type="endpoint-no">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="DeviceType" type="devtype-id">
+      <field fieldId="2" name="DeviceType" type="devtype-id">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -190,20 +190,20 @@ Davis, CA 95616, USA
     <event id="0x00" name="AccessControlEntryChanged" priority="info">
       <access readPrivilege="admin" fabricSensitive="true"/>
       <mandatoryConform/>
-      <field id="1" name="AdminNodeID" type="node-id">
+      <field fieldId="1" name="AdminNodeID" type="node-id">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="AdminPasscodeID" type="uint16">
+      <field fieldId="2" name="AdminPasscodeID" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="ChangeType" type="ChangeTypeEnum">
+      <field fieldId="3" name="ChangeType" type="ChangeTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="4" name="LatestValue" type="AccessControlEntryStruct">
+      <field fieldId="4" name="LatestValue" type="AccessControlEntryStruct">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -211,20 +211,20 @@ Davis, CA 95616, USA
     <event id="0x01" name="AccessControlExtensionChanged" priority="info">
       <access readPrivilege="admin" fabricSensitive="true"/>
       <mandatoryConform/>
-      <field id="1" name="AdminNodeID" type="node-id">
+      <field fieldId="1" name="AdminNodeID" type="node-id">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="AdminPasscodeID" type="uint16">
+      <field fieldId="2" name="AdminPasscodeID" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="ChangeType" type="ChangeTypeEnum">
+      <field fieldId="3" name="ChangeType" type="ChangeTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="4" name="LatestValue" type="AccessControlExtensionStruct">
+      <field fieldId="4" name="LatestValue" type="AccessControlExtensionStruct">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/AccountLogin.xml
+++ b/zcl-builtin/matter/new-data-model/AccountLogin.xml
@@ -70,7 +70,7 @@ Davis, CA 95616, USA
     <command id="0x00" name="GetSetupPIN" direction="commandToServer" response="GetSetupPINResponse">
       <access invokePrivilege="admin" fabricScoped="true" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="TempAccountIdentifier" type="string">
+      <field fieldId="0" name="TempAccountIdentifier" type="string">
         <mandatoryConform/>
         <constraint type="lengthBetween" from="16" to="100"/>
       </field>
@@ -78,7 +78,7 @@ Davis, CA 95616, USA
     <command id="0x01" name="GetSetupPINResponse" direction="responseFromServer">
       <access fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="SetupPIN" type="string">
+      <field fieldId="0" name="SetupPIN" type="string">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -86,22 +86,22 @@ Davis, CA 95616, USA
     <command id="0x02" name="Login" direction="commandToServer" response="Y">
       <access invokePrivilege="admin" fabricScoped="true" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="TempAccountIdentifier" type="string">
+      <field fieldId="0" name="TempAccountIdentifier" type="string">
         <mandatoryConform/>
         <constraint type="lengthBetween" from="16" to="100"/>
       </field>
-      <field id="1" name="SetupPIN" type="string">
+      <field fieldId="1" name="SetupPIN" type="string">
         <mandatoryConform/>
         <constraint type="minLength" value="8"/>
       </field>
-      <field id="2" name="Node" type="node-id">
+      <field fieldId="2" name="Node" type="node-id">
         <optionalConform/>
       </field>
     </command>
     <command id="0x03" name="Logout" direction="commandToServer" response="Y">
       <access invokePrivilege="operate" fabricScoped="true" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="Node" type="node-id">
+      <field fieldId="0" name="Node" type="node-id">
         <optionalConform/>
       </field>
     </command>
@@ -110,7 +110,7 @@ Davis, CA 95616, USA
     <event id="0x00" name="LoggedOut" priority="critical">
       <access readPrivilege="admin" fabricSensitive="true"/>
       <optionalConform/>
-      <field id="0" name="Node" type="node-id">
+      <field fieldId="0" name="Node" type="node-id">
         <optionalConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/AdminCommissioningCluster.xml
+++ b/zcl-builtin/matter/new-data-model/AdminCommissioningCluster.xml
@@ -104,22 +104,22 @@ Davis, CA 95616, USA
     <command id="0x00" name="OpenCommissioningWindow" direction="commandToServer" response="Y">
       <access invokePrivilege="admin" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="CommissioningTimeout" type="uint16">
+      <field fieldId="0" name="CommissioningTimeout" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="PAKEPasscodeVerifier" type="octstr">
+      <field fieldId="1" name="PAKEPasscodeVerifier" type="octstr">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Discriminator" type="uint16">
+      <field fieldId="2" name="Discriminator" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="4095"/>
       </field>
-      <field id="3" name="Iterations" type="uint32">
+      <field fieldId="3" name="Iterations" type="uint32">
         <mandatoryConform/>
         <constraint type="between" from="1000" to="100000"/>
       </field>
-      <field id="4" name="Salt" type="octstr">
+      <field fieldId="4" name="Salt" type="octstr">
         <mandatoryConform/>
         <constraint type="lengthBetween" from="16" to="32"/>
       </field>
@@ -129,7 +129,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="BC"/>
       </mandatoryConform>
-      <field id="0" name="CommissioningTimeout" type="uint16">
+      <field fieldId="0" name="CommissioningTimeout" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/AlarmBase.xml
+++ b/zcl-builtin/matter/new-data-model/AlarmBase.xml
@@ -101,14 +101,14 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="RESET"/>
       </mandatoryConform>
-      <field id="0" name="Alarms" type="AlarmBitmap" default="0">
+      <field fieldId="0" name="Alarms" type="AlarmBitmap" default="0">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x01" name="ModifyEnabledAlarms" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <optionalConform/>
-      <field id="0" name="Mask" type="AlarmBitmap" default="0">
+      <field fieldId="0" name="Mask" type="AlarmBitmap" default="0">
         <mandatoryConform/>
       </field>
     </command>
@@ -117,16 +117,16 @@ Davis, CA 95616, USA
     <event id="0x00" name="Notify" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="1" name="Active" type="AlarmBitmap" default="0">
+      <field fieldId="1" name="Active" type="AlarmBitmap" default="0">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Inactive" type="AlarmBitmap" default="0">
+      <field fieldId="2" name="Inactive" type="AlarmBitmap" default="0">
         <mandatoryConform/>
       </field>
-      <field id="3" name="State" type="AlarmBitmap" default="0">
+      <field fieldId="3" name="State" type="AlarmBitmap" default="0">
         <mandatoryConform/>
       </field>
-      <field id="4" name="Mask" type="AlarmBitmap" default="0">
+      <field fieldId="4" name="Mask" type="AlarmBitmap" default="0">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/ApplicationBasic.xml
+++ b/zcl-builtin/matter/new-data-model/ApplicationBasic.xml
@@ -81,10 +81,10 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="ApplicationStruct">
-      <field id="0" name="CatalogVendorID" type="uint16">
+      <field fieldId="0" name="CatalogVendorID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ApplicationID" type="string">
+      <field fieldId="1" name="ApplicationID" type="string">
         <mandatoryConform/>
       </field>
     </struct>

--- a/zcl-builtin/matter/new-data-model/ApplicationLauncher.xml
+++ b/zcl-builtin/matter/new-data-model/ApplicationLauncher.xml
@@ -83,18 +83,18 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="ApplicationEPStruct">
-      <field id="0" name="Application" type="ApplicationStruct">
+      <field fieldId="0" name="Application" type="ApplicationStruct">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Endpoint" type="endpoint-no" default="MS">
+      <field fieldId="1" name="Endpoint" type="endpoint-no" default="MS">
         <optionalConform/>
       </field>
     </struct>
     <struct name="ApplicationStruct">
-      <field id="0" name="CatalogVendorID" type="uint16">
+      <field fieldId="0" name="CatalogVendorID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ApplicationID" type="string">
+      <field fieldId="1" name="ApplicationID" type="string">
         <mandatoryConform/>
       </field>
     </struct>
@@ -119,20 +119,20 @@ Davis, CA 95616, USA
     <command id="0x00" name="LaunchApp" direction="commandToServer" response="LauncherResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Application" type="ApplicationStruct">
+      <field fieldId="0" name="Application" type="ApplicationStruct">
         <mandatoryConform>
           <feature name="AP"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Data" type="octstr" default="MS">
+      <field fieldId="1" name="Data" type="octstr" default="MS">
         <optionalConform/>
       </field>
     </command>
     <command id="0x01" name="StopApp" direction="commandToServer" response="LauncherResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Application" type="ApplicationStruct" default="MS">
+      <field fieldId="0" name="Application" type="ApplicationStruct" default="MS">
         <mandatoryConform>
           <feature name="AP"/>
         </mandatoryConform>
@@ -142,7 +142,7 @@ Davis, CA 95616, USA
     <command id="0x02" name="HideApp" direction="commandToServer" response="LauncherResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Application" type="ApplicationStruct" default="MS">
+      <field fieldId="0" name="Application" type="ApplicationStruct" default="MS">
         <mandatoryConform>
           <feature name="AP"/>
         </mandatoryConform>
@@ -151,10 +151,10 @@ Davis, CA 95616, USA
     </command>
     <command id="0x03" name="LauncherResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="StatusEnum">
+      <field fieldId="0" name="Status" type="StatusEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Data" type="octstr" default="MS">
+      <field fieldId="1" name="Data" type="octstr" default="MS">
         <optionalConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/AudioOutput.xml
+++ b/zcl-builtin/matter/new-data-model/AudioOutput.xml
@@ -92,14 +92,14 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="OutputInfoStruct">
-      <field id="0" name="Index" type="uint8">
+      <field fieldId="0" name="Index" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="1" name="OutputType" type="OutputTypeEnum">
+      <field fieldId="1" name="OutputType" type="OutputTypeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Name" type="string">
+      <field fieldId="2" name="Name" type="string">
         <mandatoryConform/>
       </field>
     </struct>
@@ -119,7 +119,7 @@ Davis, CA 95616, USA
     <command id="0x00" name="SelectOutput" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Index" type="uint8">
+      <field fieldId="0" name="Index" type="uint8">
         <mandatoryConform/>
       </field>
     </command>
@@ -128,10 +128,10 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="NU"/>
       </mandatoryConform>
-      <field id="0" name="Index" type="uint8">
+      <field fieldId="0" name="Index" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Name" type="string">
+      <field fieldId="1" name="Name" type="string">
         <mandatoryConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/BasicInformationCluster.xml
+++ b/zcl-builtin/matter/new-data-model/BasicInformationCluster.xml
@@ -152,20 +152,20 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="CapabilityMinimaStruct">
-      <field id="0" name="CaseSessionsPerFabric" type="uint16" default="3">
+      <field fieldId="0" name="CaseSessionsPerFabric" type="uint16" default="3">
         <mandatoryConform/>
         <constraint type="min" value="3"/>
       </field>
-      <field id="1" name="SubscriptionsPerFabric" type="uint16" default="3">
+      <field fieldId="1" name="SubscriptionsPerFabric" type="uint16" default="3">
         <mandatoryConform/>
         <constraint type="min" value="3"/>
       </field>
     </struct>
     <struct name="ProductAppearanceStruct">
-      <field id="0" name="Finish" type="ProductFinishEnum">
+      <field fieldId="0" name="Finish" type="ProductFinishEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="PrimaryColor" type="ColorEnum">
+      <field fieldId="1" name="PrimaryColor" type="ColorEnum">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -307,7 +307,7 @@ Davis, CA 95616, USA
     <event id="0x00" name="StartUp" priority="critical">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="SoftwareVersion" type="uint32">
+      <field fieldId="0" name="SoftwareVersion" type="uint32">
         <mandatoryConform/>
       </field>
     </event>
@@ -318,14 +318,14 @@ Davis, CA 95616, USA
     <event id="0x02" name="Leave" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="FabricIndex" type="fabric-idx">
+      <field fieldId="0" name="FabricIndex" type="fabric-idx">
         <mandatoryConform/>
         <constraint type="between" from="1" to="254"/>
       </field>
     </event>
     <event id="0x03" name="ReachableChanged" priority="info">
       <access readPrivilege="view"/>
-      <field id="0" name="ReachableNewValue" type="bool">
+      <field fieldId="0" name="ReachableNewValue" type="bool">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/Binding-Cluster.xml
+++ b/zcl-builtin/matter/new-data-model/Binding-Cluster.xml
@@ -67,26 +67,26 @@ Davis, CA 95616, USA
   <classification hierarchy="base" role="utility" picsCode="BIND" scope="Endpoint"/>
   <dataTypes>
     <struct name="TargetStruct">
-      <field id="1" name="Node" type="node-id">
+      <field fieldId="1" name="Node" type="node-id">
         <mandatoryConform>
           <attribute name="Endpoint"/>
         </mandatoryConform>
       </field>
-      <field id="2" name="Group" type="group-id">
+      <field fieldId="2" name="Group" type="group-id">
         <mandatoryConform>
           <notTerm>
             <attribute name="Endpoint"/>
           </notTerm>
         </mandatoryConform>
       </field>
-      <field id="3" name="Endpoint" type="endpoint-no">
+      <field fieldId="3" name="Endpoint" type="endpoint-no">
         <mandatoryConform>
           <notTerm>
             <attribute name="Group"/>
           </notTerm>
         </mandatoryConform>
       </field>
-      <field id="4" name="Cluster" type="cluster-id">
+      <field fieldId="4" name="Cluster" type="cluster-id">
         <optionalConform/>
       </field>
       <access fabricScoped="true"/>

--- a/zcl-builtin/matter/new-data-model/BooleanState.xml
+++ b/zcl-builtin/matter/new-data-model/BooleanState.xml
@@ -76,7 +76,7 @@ Davis, CA 95616, USA
     <event id="0x00" name="StateChange" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="StateValue" type="bool">
+      <field fieldId="0" name="StateValue" type="bool">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/BooleanStateConfiguration.xml
+++ b/zcl-builtin/matter/new-data-model/BooleanStateConfiguration.xml
@@ -174,7 +174,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="SPRS"/>
       </mandatoryConform>
-      <field id="0" name="AlarmsToSuppress" type="AlarmModeBitmap">
+      <field fieldId="0" name="AlarmsToSuppress" type="AlarmModeBitmap">
         <mandatoryConform/>
       </field>
     </command>
@@ -186,7 +186,7 @@ Davis, CA 95616, USA
           <feature name="AUD"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="AlarmsToEnableDisable" type="AlarmModeBitmap">
+      <field fieldId="0" name="AlarmsToEnableDisable" type="AlarmModeBitmap">
         <mandatoryConform/>
       </field>
     </command>
@@ -200,10 +200,10 @@ Davis, CA 95616, USA
           <feature name="AUD"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="AlarmsActive" type="AlarmModeBitmap">
+      <field fieldId="0" name="AlarmsActive" type="AlarmModeBitmap">
         <mandatoryConform/>
       </field>
-      <field id="1" name="AlarmsSuppressed" type="AlarmModeBitmap">
+      <field fieldId="1" name="AlarmsSuppressed" type="AlarmModeBitmap">
         <mandatoryConform>
           <feature name="SPRS"/>
         </mandatoryConform>
@@ -212,7 +212,7 @@ Davis, CA 95616, USA
     <event id="0x01" name="SensorFault" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="SensorFault" type="SensorFaultBitmap">
+      <field fieldId="0" name="SensorFault" type="SensorFaultBitmap">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/Channel.xml
+++ b/zcl-builtin/matter/new-data-model/Channel.xml
@@ -123,175 +123,175 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="ChannelInfoStruct">
-      <field id="0" name="MajorNumber" type="uint16">
+      <field fieldId="0" name="MajorNumber" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="MinorNumber" type="uint16">
+      <field fieldId="1" name="MinorNumber" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Name" type="string" default="empty">
+      <field fieldId="2" name="Name" type="string" default="empty">
         <optionalConform/>
       </field>
-      <field id="3" name="CallSign" type="string" default="empty">
+      <field fieldId="3" name="CallSign" type="string" default="empty">
         <optionalConform/>
       </field>
-      <field id="4" name="AffiliateCallSign" type="string" default="empty">
+      <field fieldId="4" name="AffiliateCallSign" type="string" default="empty">
         <optionalConform/>
       </field>
-      <field id="5" name="Identifier" type="string" default="empty">
+      <field fieldId="5" name="Identifier" type="string" default="empty">
         <optionalConform/>
       </field>
-      <field id="6" name="Type" type="ChannelTypeEnum" default="empty">
+      <field fieldId="6" name="Type" type="ChannelTypeEnum" default="empty">
         <optionalConform/>
       </field>
     </struct>
     <struct name="ChannelPagingStruct">
-      <field id="0" name="PreviousToken" type="PageTokenStruct" default="null">
+      <field fieldId="0" name="PreviousToken" type="PageTokenStruct" default="null">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
-      <field id="1" name="NextToken" type="PageTokenStruct" default="null">
+      <field fieldId="1" name="NextToken" type="PageTokenStruct" default="null">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
     </struct>
     <struct name="LineupInfoStruct">
-      <field id="0" name="OperatorName" type="string">
+      <field fieldId="0" name="OperatorName" type="string">
         <mandatoryConform/>
       </field>
-      <field id="1" name="LineupName" type="string" default="empty">
+      <field fieldId="1" name="LineupName" type="string" default="empty">
         <optionalConform/>
       </field>
-      <field id="2" name="PostalCode" type="string" default="empty">
+      <field fieldId="2" name="PostalCode" type="string" default="empty">
         <optionalConform/>
       </field>
-      <field id="3" name="LineupInfoType" type="LineupInfoTypeEnum">
+      <field fieldId="3" name="LineupInfoType" type="LineupInfoTypeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
     </struct>
     <struct name="PageTokenStruct">
-      <field id="0" name="Limit" type="uint16" default="0">
+      <field fieldId="0" name="Limit" type="uint16" default="0">
         <optionalConform/>
       </field>
-      <field id="1" name="After" type="string" default="empty">
+      <field fieldId="1" name="After" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="8192"/>
       </field>
-      <field id="2" name="Before" type="string" default="empty">
+      <field fieldId="2" name="Before" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="8192"/>
       </field>
     </struct>
     <struct name="ProgramCastStruct">
-      <field id="0" name="Name" type="string">
+      <field fieldId="0" name="Name" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="256"/>
       </field>
-      <field id="1" name="Role" type="string">
+      <field fieldId="1" name="Role" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="256"/>
       </field>
     </struct>
     <struct name="ProgramCategoryStruct">
-      <field id="0" name="Category" type="string">
+      <field fieldId="0" name="Category" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="256"/>
       </field>
-      <field id="1" name="SubCategory" type="string" default="empty">
+      <field fieldId="1" name="SubCategory" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="256"/>
       </field>
     </struct>
     <struct name="ProgramStruct">
-      <field id="0" name="Identifier" type="string">
+      <field fieldId="0" name="Identifier" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="255"/>
       </field>
-      <field id="1" name="Channel" type="ChannelInfoStruct">
+      <field fieldId="1" name="Channel" type="ChannelInfoStruct">
         <mandatoryConform/>
       </field>
-      <field id="2" name="StartTime" type="epoch-s">
+      <field fieldId="2" name="StartTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="3" name="EndTime" type="epoch-s">
+      <field fieldId="3" name="EndTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="4" name="Title" type="string">
+      <field fieldId="4" name="Title" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="255"/>
       </field>
-      <field id="5" name="Subtitle" type="string" default="empty">
+      <field fieldId="5" name="Subtitle" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="255"/>
       </field>
-      <field id="6" name="Description" type="string" default="empty">
+      <field fieldId="6" name="Description" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="8192"/>
       </field>
-      <field id="7" name="AudioLanguages" type="list" default="empty">
+      <field fieldId="7" name="AudioLanguages" type="list" default="empty">
         <entry type="string">
           <constraint type="maxLength" value="50"/>
         </entry>
         <optionalConform/>
         <constraint type="maxCount" value="10"/>
       </field>
-      <field id="8" name="Ratings" type="list" default="empty">
+      <field fieldId="8" name="Ratings" type="list" default="empty">
         <entry type="string"/>
         <optionalConform/>
         <constraint type="maxCount" value="255"/>
       </field>
-      <field id="9" name="ThumbnailUrl" type="string" default="empty">
+      <field fieldId="9" name="ThumbnailUrl" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="8192"/>
       </field>
-      <field id="10" name="PosterArtUrl" type="string" default="empty">
+      <field fieldId="10" name="PosterArtUrl" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="8192"/>
       </field>
-      <field id="11" name="DvbiUrl" type="string" default="empty">
+      <field fieldId="11" name="DvbiUrl" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="8192"/>
       </field>
-      <field id="12" name="ReleaseDate" type="string" default="empty">
+      <field fieldId="12" name="ReleaseDate" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="30"/>
       </field>
-      <field id="13" name="ParentalGuidanceText" type="string" default="empty">
+      <field fieldId="13" name="ParentalGuidanceText" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="255"/>
       </field>
-      <field id="14" name="RecordingFlag" type="RecordingFlagBitmap">
+      <field fieldId="14" name="RecordingFlag" type="RecordingFlagBitmap">
         <mandatoryConform>
           <feature name="RP"/>
         </mandatoryConform>
       </field>
-      <field id="15" name="SeriesInfo" type="SeriesInfoStruct" default="null">
+      <field fieldId="15" name="SeriesInfo" type="SeriesInfoStruct" default="null">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
-      <field id="16" name="CategoryList" type="list" default="empty">
+      <field fieldId="16" name="CategoryList" type="list" default="empty">
         <entry type="ProgramCategoryStruct"/>
         <optionalConform/>
         <constraint type="maxCount" value="255"/>
       </field>
-      <field id="17" name="CastList" type="list" default="empty">
+      <field fieldId="17" name="CastList" type="list" default="empty">
         <entry type="ProgramCastStruct"/>
         <optionalConform/>
         <constraint type="maxCount" value="255"/>
       </field>
-      <field id="18" name="ExternalIDList" type="list" default="empty">
+      <field fieldId="18" name="ExternalIDList" type="list" default="empty">
         <entry type="ref_AdditionalInfoStruct"/>
         <optionalConform/>
         <constraint type="maxCount" value="255"/>
       </field>
     </struct>
     <struct name="SeriesInfoStruct">
-      <field id="0" name="Season" type="string">
+      <field fieldId="0" name="Season" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="256"/>
       </field>
-      <field id="1" name="Episode" type="string">
+      <field fieldId="1" name="Episode" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="256"/>
       </field>
@@ -329,7 +329,7 @@ Davis, CA 95616, USA
           <feature name="LI"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="Match" type="string">
+      <field fieldId="0" name="Match" type="string">
         <mandatoryConform/>
       </field>
     </command>
@@ -340,28 +340,28 @@ Davis, CA 95616, USA
           <feature name="LI"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="Status" type="StatusEnum">
+      <field fieldId="0" name="Status" type="StatusEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Data" type="string">
+      <field fieldId="1" name="Data" type="string">
         <optionalConform/>
       </field>
     </command>
     <command id="0x02" name="ChangeChannelByNumber" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="MajorNumber" type="uint16">
+      <field fieldId="0" name="MajorNumber" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="MinorNumber" type="uint16">
+      <field fieldId="1" name="MinorNumber" type="uint16">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x03" name="SkipChannel" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Count" type="int16">
+      <field fieldId="0" name="Count" type="int16">
         <mandatoryConform/>
       </field>
     </command>
@@ -370,31 +370,31 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="EG"/>
       </mandatoryConform>
-      <field id="0" name="StartTime" type="epoch-s">
+      <field fieldId="0" name="StartTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="1" name="EndTime" type="epoch-s">
+      <field fieldId="1" name="EndTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ChannelList" type="list" default="empty">
+      <field fieldId="2" name="ChannelList" type="list" default="empty">
         <entry type="ChannelInfoStruct"/>
         <optionalConform/>
         <constraint type="maxCount" value="255"/>
       </field>
-      <field id="3" name="PageToken" type="PageTokenStruct" default="null">
+      <field fieldId="3" name="PageToken" type="PageTokenStruct" default="null">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
-      <field id="5" name="RecordingFlag" type="RecordingFlagBitmap" default="null">
+      <field fieldId="5" name="RecordingFlag" type="RecordingFlagBitmap" default="null">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
-      <field id="6" name="ExternalIDList" type="list" default="empty">
+      <field fieldId="6" name="ExternalIDList" type="list" default="empty">
         <entry type="ref_AdditionalInfoStruct"/>
         <optionalConform/>
         <constraint type="maxCount" value="255"/>
       </field>
-      <field id="7" name="Data" type="octstr" default="MS">
+      <field fieldId="7" name="Data" type="octstr" default="MS">
         <optionalConform/>
         <constraint type="maxLength" value="8092"/>
       </field>
@@ -403,10 +403,10 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="EG"/>
       </mandatoryConform>
-      <field id="0" name="Paging" type="ChannelPagingStruct">
+      <field fieldId="0" name="Paging" type="ChannelPagingStruct">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ProgramList" type="list" default="empty">
+      <field fieldId="1" name="ProgramList" type="list" default="empty">
         <entry type="ProgramStruct"/>
         <mandatoryConform/>
       </field>
@@ -419,19 +419,19 @@ Davis, CA 95616, USA
           <feature name="EG"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="ProgramIdentifier" type="string">
+      <field fieldId="0" name="ProgramIdentifier" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="255"/>
       </field>
-      <field id="1" name="ShouldRecordSeries" type="bool">
+      <field fieldId="1" name="ShouldRecordSeries" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ExternalIDList" type="list" default="empty">
+      <field fieldId="2" name="ExternalIDList" type="list" default="empty">
         <entry type="ref_AdditionalInfoStruct"/>
         <optionalConform/>
         <constraint type="maxCount" value="255"/>
       </field>
-      <field id="3" name="Data" type="octstr" default="MS">
+      <field fieldId="3" name="Data" type="octstr" default="MS">
         <optionalConform/>
         <constraint type="maxLength" value="8092"/>
       </field>
@@ -444,19 +444,19 @@ Davis, CA 95616, USA
           <feature name="EG"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="ProgramIdentifier" type="string">
+      <field fieldId="0" name="ProgramIdentifier" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="255"/>
       </field>
-      <field id="1" name="ShouldRecordSeries" type="bool">
+      <field fieldId="1" name="ShouldRecordSeries" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ExternalIDList" type="list" default="empty">
+      <field fieldId="2" name="ExternalIDList" type="list" default="empty">
         <entry type="ref_AdditionalInfoStruct"/>
         <optionalConform/>
         <constraint type="maxCount" value="255"/>
       </field>
-      <field id="3" name="Data" type="octstr" default="MS">
+      <field fieldId="3" name="Data" type="octstr" default="MS">
         <optionalConform/>
         <constraint type="maxLength" value="8092"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ColorControl.xml
+++ b/zcl-builtin/matter/new-data-model/ColorControl.xml
@@ -459,11 +459,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HS"/>
       </mandatoryConform>
-      <field id="0" name="Hue" type="uint8">
+      <field fieldId="0" name="Hue" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="254"/>
       </field>
-      <field id="1" name="Direction" type="enum8">
+      <field fieldId="1" name="Direction" type="enum8">
         <enum>
           <item value="0" name="Item0" summary="Shortest distance">
             <mandatoryConform/>
@@ -481,15 +481,15 @@ Davis, CA 95616, USA
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16">
+      <field fieldId="2" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="3" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="4" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -499,7 +499,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HS"/>
       </mandatoryConform>
-      <field id="0" name="MoveMode" type="enum8">
+      <field fieldId="0" name="MoveMode" type="enum8">
         <enum>
           <item value="0" name="Item0" summary="Stop">
             <mandatoryConform/>
@@ -517,14 +517,14 @@ Davis, CA 95616, USA
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Rate" type="uint8">
+      <field fieldId="1" name="Rate" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="2" name="OptionsMask" type="map8" default="0">
+      <field fieldId="2" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="3" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -534,7 +534,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HS"/>
       </mandatoryConform>
-      <field id="0" name="StepMode" type="enum8">
+      <field fieldId="0" name="StepMode" type="enum8">
         <enum>
           <item value="0" name="Item0" summary="Reserved">
             <mandatoryConform/>
@@ -552,17 +552,17 @@ Davis, CA 95616, USA
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="StepSize" type="uint8">
+      <field fieldId="1" name="StepSize" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="2" name="TransitionTime" type="uint8">
+      <field fieldId="2" name="TransitionTime" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="3" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="4" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -572,19 +572,19 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HS"/>
       </mandatoryConform>
-      <field id="0" name="Saturation" type="uint8">
+      <field fieldId="0" name="Saturation" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="254"/>
       </field>
-      <field id="1" name="TransitionTime" type="uint16">
+      <field fieldId="1" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="2" name="OptionsMask" type="map8" default="0">
+      <field fieldId="2" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="3" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -594,7 +594,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HS"/>
       </mandatoryConform>
-      <field id="0" name="MoveMode" type="enum8">
+      <field fieldId="0" name="MoveMode" type="enum8">
         <enum>
           <item value="0" name="Item0" summary="Stop">
             <mandatoryConform/>
@@ -612,14 +612,14 @@ Davis, CA 95616, USA
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Rate" type="uint8">
+      <field fieldId="1" name="Rate" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="2" name="OptionsMask" type="map8" default="0">
+      <field fieldId="2" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="3" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -629,7 +629,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HS"/>
       </mandatoryConform>
-      <field id="0" name="StepMode" type="enum8">
+      <field fieldId="0" name="StepMode" type="enum8">
         <enum>
           <item value="0" name="Item0" summary="Reserved">
             <mandatoryConform/>
@@ -647,17 +647,17 @@ Davis, CA 95616, USA
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="StepSize" type="uint8">
+      <field fieldId="1" name="StepSize" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="2" name="TransitionTime" type="uint8">
+      <field fieldId="2" name="TransitionTime" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="3" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="4" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -667,23 +667,23 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HS"/>
       </mandatoryConform>
-      <field id="0" name="Hue" type="uint8">
+      <field fieldId="0" name="Hue" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="254"/>
       </field>
-      <field id="1" name="Saturation" type="uint8">
+      <field fieldId="1" name="Saturation" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="254"/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16">
+      <field fieldId="2" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="3" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="4" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -693,23 +693,23 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="XY"/>
       </mandatoryConform>
-      <field id="0" name="ColorX" type="uint16">
+      <field fieldId="0" name="ColorX" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="0xFEFF"/>
       </field>
-      <field id="1" name="ColorY" type="uint16">
+      <field fieldId="1" name="ColorY" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="0xFEFF"/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16">
+      <field fieldId="2" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="3" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="4" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -719,17 +719,17 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="XY"/>
       </mandatoryConform>
-      <field id="0" name="RateX" type="int16">
+      <field fieldId="0" name="RateX" type="int16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="RateY" type="int16">
+      <field fieldId="1" name="RateY" type="int16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="OptionsMask" type="map8" default="0">
+      <field fieldId="2" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="3" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -739,21 +739,21 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="XY"/>
       </mandatoryConform>
-      <field id="0" name="StepX" type="int16">
+      <field fieldId="0" name="StepX" type="int16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="StepY" type="int16">
+      <field fieldId="1" name="StepY" type="int16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16">
+      <field fieldId="2" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="3" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="4" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -763,19 +763,19 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CT"/>
       </mandatoryConform>
-      <field id="0" name="ColorTemperatureMireds" type="uint16">
+      <field fieldId="0" name="ColorTemperatureMireds" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="0xFEFF"/>
       </field>
-      <field id="1" name="TransitionTime" type="uint16">
+      <field fieldId="1" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="2" name="OptionsMask" type="map8" default="0">
+      <field fieldId="2" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="3" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -785,22 +785,22 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="EHUE"/>
       </mandatoryConform>
-      <field id="0" name="EnhancedHue" type="uint16">
+      <field fieldId="0" name="EnhancedHue" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Direction" type="enum8">
+      <field fieldId="1" name="Direction" type="enum8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16">
+      <field fieldId="2" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="3" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="4" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -810,18 +810,18 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="EHUE"/>
       </mandatoryConform>
-      <field id="0" name="MoveMode" type="enum8">
+      <field fieldId="0" name="MoveMode" type="enum8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Rate" type="uint16">
+      <field fieldId="1" name="Rate" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="OptionsMask" type="map8" default="0">
+      <field fieldId="2" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="3" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -831,22 +831,22 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="EHUE"/>
       </mandatoryConform>
-      <field id="0" name="StepMode" type="enum8">
+      <field fieldId="0" name="StepMode" type="enum8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="StepSize" type="uint16">
+      <field fieldId="1" name="StepSize" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16">
+      <field fieldId="2" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="3" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="4" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -856,22 +856,22 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="EHUE"/>
       </mandatoryConform>
-      <field id="0" name="EnhancedHue" type="uint16">
+      <field fieldId="0" name="EnhancedHue" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Saturation" type="uint8">
+      <field fieldId="1" name="Saturation" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="254"/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16">
+      <field fieldId="2" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="3" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="4" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -881,7 +881,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CL"/>
       </mandatoryConform>
-      <field id="0" name="UpdateFlags" type="map8">
+      <field fieldId="0" name="UpdateFlags" type="map8">
         <bitmap>
           <bitfield name="Reserved" bit="4-7">
             <mandatoryConform/>
@@ -902,7 +902,7 @@ Davis, CA 95616, USA
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Action" type="enum8">
+      <field fieldId="1" name="Action" type="enum8">
         <enum>
           <item value="0" name="Item0" summary="De-activate the color loop.">
             <mandatoryConform/>
@@ -917,7 +917,7 @@ Davis, CA 95616, USA
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Direction" type="enum8">
+      <field fieldId="2" name="Direction" type="enum8">
         <enum>
           <item value="0" name="Item0" summary="Decrement the hue in the color loop.">
             <mandatoryConform/>
@@ -929,17 +929,17 @@ Davis, CA 95616, USA
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="Time" type="uint16">
+      <field fieldId="3" name="Time" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="4" name="StartHue" type="uint16">
+      <field fieldId="4" name="StartHue" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="5" name="OptionsMask" type="map8" default="0">
+      <field fieldId="5" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="6" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="6" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -953,11 +953,11 @@ Davis, CA 95616, USA
           <feature name="CT"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="OptionsMask" type="map8" default="0">
+      <field fieldId="0" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="1" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -967,26 +967,26 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CT"/>
       </mandatoryConform>
-      <field id="0" name="MoveMode" type="map8">
+      <field fieldId="0" name="MoveMode" type="map8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Rate" type="uint16">
+      <field fieldId="1" name="Rate" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ColorTemperatureMinimumMireds" type="uint16">
-        <mandatoryConform/>
-        <constraint type="between" from="0" to="0xFEFF"/>
-      </field>
-      <field id="3" name="ColorTemperatureMaximumMireds" type="uint16">
+      <field fieldId="2" name="ColorTemperatureMinimumMireds" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="0xFEFF"/>
       </field>
-      <field id="4" name="OptionsMask" type="map8" default="0">
+      <field fieldId="3" name="ColorTemperatureMaximumMireds" type="uint16">
+        <mandatoryConform/>
+        <constraint type="between" from="0" to="0xFEFF"/>
+      </field>
+      <field fieldId="4" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="5" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="5" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -996,30 +996,30 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CT"/>
       </mandatoryConform>
-      <field id="0" name="StepMode" type="map8">
+      <field fieldId="0" name="StepMode" type="map8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="StepSize" type="uint16">
+      <field fieldId="1" name="StepSize" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16">
+      <field fieldId="2" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="3" name="ColorTemperatureMinimumMireds" type="uint16">
+      <field fieldId="3" name="ColorTemperatureMinimumMireds" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="0xFEFF"/>
       </field>
-      <field id="4" name="ColorTemperatureMaximumMireds" type="uint16">
+      <field fieldId="4" name="ColorTemperatureMaximumMireds" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="0xFEFF"/>
       </field>
-      <field id="5" name="OptionsMask" type="map8" default="0">
+      <field fieldId="5" name="OptionsMask" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="6" name="OptionsOverride" type="map8" default="0">
+      <field fieldId="6" name="OptionsOverride" type="map8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ContentAppObserver.xml
+++ b/zcl-builtin/matter/new-data-model/ContentAppObserver.xml
@@ -79,25 +79,25 @@ Davis, CA 95616, USA
     <command id="0x00" name="ContentAppMessage" direction="commandToServer" response="ContentAppMessageResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Data" type="string">
+      <field fieldId="0" name="Data" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="500"/>
       </field>
-      <field id="1" name="EncodingHint" type="string">
+      <field fieldId="1" name="EncodingHint" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="100"/>
       </field>
     </command>
     <command id="0x01" name="ContentAppMessageResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="StatusEnum">
+      <field fieldId="0" name="Status" type="StatusEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Data" type="string">
+      <field fieldId="1" name="Data" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="500"/>
       </field>
-      <field id="2" name="EncodingHint" type="string">
+      <field fieldId="2" name="EncodingHint" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="100"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ContentControl.xml
+++ b/zcl-builtin/matter/new-data-model/ContentControl.xml
@@ -115,66 +115,66 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="AppInfoStruct">
-      <field id="0" name="CatalogVendorID" type="uint16">
+      <field fieldId="0" name="CatalogVendorID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ApplicationID" type="string">
+      <field fieldId="1" name="ApplicationID" type="string">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="BlockChannelStruct">
-      <field id="0" name="BlockChannelIndex" type="uint16">
+      <field fieldId="0" name="BlockChannelIndex" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="MajorNumber" type="uint16">
+      <field fieldId="1" name="MajorNumber" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="MinorNumber" type="uint16">
+      <field fieldId="2" name="MinorNumber" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="3" name="Identifier" type="string">
+      <field fieldId="3" name="Identifier" type="string">
         <optionalConform/>
       </field>
     </struct>
     <struct name="RatingNameStruct">
-      <field id="0" name="RatingName" type="string">
+      <field fieldId="0" name="RatingName" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="8"/>
       </field>
-      <field id="1" name="RatingNameDesc" type="string">
+      <field fieldId="1" name="RatingNameDesc" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="64"/>
       </field>
     </struct>
     <struct name="TimePeriodStruct type">
-      <field id="0" name="StartHour" type="uint8">
+      <field fieldId="0" name="StartHour" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="23"/>
       </field>
-      <field id="1" name="StartMinute" type="uint8">
+      <field fieldId="1" name="StartMinute" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="59"/>
       </field>
-      <field id="2" name="EndHour" type="uint8">
+      <field fieldId="2" name="EndHour" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="23"/>
       </field>
-      <field id="3" name="EndMinute" type="uint8">
+      <field fieldId="3" name="EndMinute" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="59"/>
       </field>
     </struct>
     <struct name="TimeWindowStruct">
-      <field id="0" name="TimeWindowIndex" type="uint16">
+      <field fieldId="0" name="TimeWindowIndex" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="DayOfWeek" type="DayOfWeekBitmap type">
+      <field fieldId="1" name="DayOfWeek" type="DayOfWeekBitmap type">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="TimePeriod" type="list">
+      <field fieldId="2" name="TimePeriod" type="list">
         <entry type="TimePeriodStruct type"/>
         <mandatoryConform/>
         <constraint type="desc"/>
@@ -263,11 +263,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PM"/>
       </mandatoryConform>
-      <field id="0" name="OldPIN" type="string">
+      <field fieldId="0" name="OldPIN" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="6"/>
       </field>
-      <field id="1" name="NewPIN" type="string">
+      <field fieldId="1" name="NewPIN" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="6"/>
       </field>
@@ -282,7 +282,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PM"/>
       </mandatoryConform>
-      <field id="0" name="PINCode" type="string">
+      <field fieldId="0" name="PINCode" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="6"/>
       </field>
@@ -300,11 +300,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="ST"/>
       </mandatoryConform>
-      <field id="0" name="PINCode" type="string">
+      <field fieldId="0" name="PINCode" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="6"/>
       </field>
-      <field id="1" name="BonusTime" type="elapsed-s" default="300s">
+      <field fieldId="1" name="BonusTime" type="elapsed-s" default="300s">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -314,7 +314,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="ST"/>
       </mandatoryConform>
-      <field id="0" name="ScreenTime" type="elapsed-s">
+      <field fieldId="0" name="ScreenTime" type="elapsed-s">
         <mandatoryConform/>
         <constraint type="max" value="86400"/>
       </field>
@@ -336,7 +336,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="OCR"/>
       </mandatoryConform>
-      <field id="0" name="Rating" type="string">
+      <field fieldId="0" name="Rating" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="8"/>
       </field>
@@ -346,7 +346,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="SCR"/>
       </mandatoryConform>
-      <field id="0" name="Rating" type="string">
+      <field fieldId="0" name="Rating" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="8"/>
       </field>
@@ -356,7 +356,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="BC"/>
       </mandatoryConform>
-      <field id="0" name="Channels" type="list">
+      <field fieldId="0" name="Channels" type="list">
         <entry type="BlockChannelStruct"/>
         <mandatoryConform/>
       </field>
@@ -366,7 +366,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="BC"/>
       </mandatoryConform>
-      <field id="0" name="ChannelIndexes" type="list">
+      <field fieldId="0" name="ChannelIndexes" type="list">
         <entry type="uint16"/>
         <mandatoryConform/>
       </field>
@@ -376,7 +376,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="BA"/>
       </mandatoryConform>
-      <field id="0" name="Applications" type="list">
+      <field fieldId="0" name="Applications" type="list">
         <entry type="AppInfoStruct"/>
         <mandatoryConform/>
       </field>
@@ -386,7 +386,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="BA"/>
       </mandatoryConform>
-      <field id="0" name="Applications" type="list">
+      <field fieldId="0" name="Applications" type="list">
         <entry type="AppInfoStruct"/>
         <mandatoryConform/>
       </field>
@@ -396,7 +396,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="BTW"/>
       </mandatoryConform>
-      <field id="0" name="TimeWindow" type="TimeWindowStruct">
+      <field fieldId="0" name="TimeWindow" type="TimeWindowStruct">
         <mandatoryConform/>
       </field>
     </command>
@@ -405,7 +405,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="BTW"/>
       </mandatoryConform>
-      <field id="0" name="TimeWindowIndexes" type="list">
+      <field fieldId="0" name="TimeWindowIndexes" type="list">
         <entry type="uint16"/>
         <mandatoryConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ContentLauncher.xml
+++ b/zcl-builtin/matter/new-data-model/ContentLauncher.xml
@@ -180,80 +180,80 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="AdditionalInfoStruct">
-      <field id="0" name="Name" type="string">
+      <field fieldId="0" name="Name" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="256"/>
       </field>
-      <field id="1" name="Value" type="string">
+      <field fieldId="1" name="Value" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="8192"/>
       </field>
     </struct>
     <struct name="BrandingInformationStruct">
-      <field id="0" name="ProviderName" type="string">
+      <field fieldId="0" name="ProviderName" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="256"/>
       </field>
-      <field id="1" name="Background" type="StyleInformationStruct" default="MS">
+      <field fieldId="1" name="Background" type="StyleInformationStruct" default="MS">
         <optionalConform/>
       </field>
-      <field id="2" name="Logo" type="StyleInformationStruct" default="MS">
+      <field fieldId="2" name="Logo" type="StyleInformationStruct" default="MS">
         <optionalConform/>
       </field>
-      <field id="3" name="ProgressBar" type="StyleInformationStruct" default="MS">
+      <field fieldId="3" name="ProgressBar" type="StyleInformationStruct" default="MS">
         <optionalConform/>
       </field>
-      <field id="4" name="Splash" type="StyleInformationStruct" default="MS">
+      <field fieldId="4" name="Splash" type="StyleInformationStruct" default="MS">
         <optionalConform/>
       </field>
-      <field id="5" name="WaterMark" type="StyleInformationStruct" default="MS">
+      <field fieldId="5" name="WaterMark" type="StyleInformationStruct" default="MS">
         <optionalConform/>
       </field>
     </struct>
     <struct name="ContentSearchStruct">
-      <field id="0" name="ParameterList" type="list" default="0">
+      <field fieldId="0" name="ParameterList" type="list" default="0">
         <entry type="ParameterStruct"/>
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="DimensionStruct">
-      <field id="0" name="Width" type="double" default="MS">
+      <field fieldId="0" name="Width" type="double" default="MS">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Height" type="double" default="MS">
+      <field fieldId="1" name="Height" type="double" default="MS">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Metric" type="MetricTypeEnum">
+      <field fieldId="2" name="Metric" type="MetricTypeEnum">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="ParameterStruct">
-      <field id="0" name="Type" type="ParameterEnum">
+      <field fieldId="0" name="Type" type="ParameterEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Value" type="string">
+      <field fieldId="1" name="Value" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="1024"/>
       </field>
-      <field id="2" name="ExternalIDList" type="list" default="empty">
+      <field fieldId="2" name="ExternalIDList" type="list" default="empty">
         <entry type="AdditionalInfoStruct"/>
         <optionalConform/>
       </field>
     </struct>
     <struct name="PlaybackPreferencesStruct">
-      <field id="0" name="PlaybackPosition" type="uint64">
+      <field fieldId="0" name="PlaybackPosition" type="uint64">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="AS"/>
         </mandatoryConform>
       </field>
-      <field id="1" name="TextTrack" type="TrackPreferenceStruct">
+      <field fieldId="1" name="TextTrack" type="TrackPreferenceStruct">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="TT"/>
         </mandatoryConform>
       </field>
-      <field id="2" name="AudioTracks" type="list">
+      <field fieldId="2" name="AudioTracks" type="list">
         <entry type="TrackPreferenceStruct"/>
         <quality nullable="true"/>
         <mandatoryConform>
@@ -262,30 +262,30 @@ Davis, CA 95616, USA
       </field>
     </struct>
     <struct name="StyleInformationStruct">
-      <field id="0" name="ImageURL" type="string" default="MS">
+      <field fieldId="0" name="ImageURL" type="string" default="MS">
         <optionalConform/>
         <constraint type="maxLength" value="8192"/>
       </field>
-      <field id="1" name="Color" type="string" default="MS">
+      <field fieldId="1" name="Color" type="string" default="MS">
         <optionalConform/>
         <constraint type="maxLength" value="7"/>
         <constraint type="maxLength" value="9"/>
       </field>
-      <field id="2" name="Size" type="DimensionStruct" default="MS">
+      <field fieldId="2" name="Size" type="DimensionStruct" default="MS">
         <optionalConform/>
       </field>
     </struct>
     <struct name="TrackPreferenceStruct">
-      <field id="0" name="LanguageCode" type="string">
+      <field fieldId="0" name="LanguageCode" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="1" name="Characteristics" type="list" default="null">
+      <field fieldId="1" name="Characteristics" type="list" default="null">
         <entry type="ref_CharacteristicEnum"/>
         <quality nullable="true"/>
         <optionalConform/>
       </field>
-      <field id="2" name="AudioOutputIndex" type="uint8">
+      <field fieldId="2" name="AudioOutputIndex" type="uint8">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="AT"/>
@@ -319,21 +319,21 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CS"/>
       </mandatoryConform>
-      <field id="0" name="Search" type="ContentSearchStruct">
+      <field fieldId="0" name="Search" type="ContentSearchStruct">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="AutoPlay" type="bool">
+      <field fieldId="1" name="AutoPlay" type="bool">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Data" type="string" default="MS">
+      <field fieldId="2" name="Data" type="string" default="MS">
         <optionalConform/>
       </field>
-      <field id="3" name="PlaybackPreferences" type="PlaybackPreferencesStruct" default="MS">
+      <field fieldId="3" name="PlaybackPreferences" type="PlaybackPreferencesStruct" default="MS">
         <optionalConform/>
       </field>
-      <field id="4" name="UseCurrentContext" type="bool" default="TRUE">
+      <field fieldId="4" name="UseCurrentContext" type="bool" default="TRUE">
         <optionalConform/>
         <constraint type="desc"/>
       </field>
@@ -343,16 +343,16 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="UP"/>
       </mandatoryConform>
-      <field id="0" name="ContentURL" type="string">
+      <field fieldId="0" name="ContentURL" type="string">
         <mandatoryConform/>
       </field>
-      <field id="1" name="DisplayString" type="string" default="MS">
+      <field fieldId="1" name="DisplayString" type="string" default="MS">
         <optionalConform/>
       </field>
-      <field id="2" name="BrandingInformation" type="BrandingInformationStruct" default="MS">
+      <field fieldId="2" name="BrandingInformation" type="BrandingInformationStruct" default="MS">
         <optionalConform/>
       </field>
-      <field id="3" name="PlaybackPreferences" type="PlaybackPreferencesStruct" default="MS">
+      <field fieldId="3" name="PlaybackPreferences" type="PlaybackPreferencesStruct" default="MS">
         <optionalConform/>
       </field>
     </command>
@@ -363,10 +363,10 @@ Davis, CA 95616, USA
           <feature name="UP"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="Status" type="StatusEnum">
+      <field fieldId="0" name="Status" type="StatusEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Data" type="string" default="MS">
+      <field fieldId="1" name="Data" type="string" default="MS">
         <optionalConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/DemandResponseLoadControl.xml
+++ b/zcl-builtin/matter/new-data-model/DemandResponseLoadControl.xml
@@ -262,103 +262,103 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="AverageLoadControlStruct">
-      <field id="1" name="LoadAdjustment" type="int8">
+      <field fieldId="1" name="LoadAdjustment" type="int8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="100"/>
       </field>
     </struct>
     <struct name="DutyCycleControlStruct">
-      <field id="1" name="DutyCycle" type="uint8">
+      <field fieldId="1" name="DutyCycle" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="100"/>
       </field>
     </struct>
     <struct name="HeatingSourceControlStruct">
-      <field id="1" name="HeatingSource" type="HeatingSourceEnum">
+      <field fieldId="1" name="HeatingSource" type="HeatingSourceEnum">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="LoadControlEventStruct">
-      <field id="0" name="EventID" type="octstr" default="0">
+      <field fieldId="0" name="EventID" type="octstr" default="0">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="ProgramID" type="octstr" default="null">
+      <field fieldId="1" name="ProgramID" type="octstr" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="2" name="Control" type="EventControlBitmap" default="1">
+      <field fieldId="2" name="Control" type="EventControlBitmap" default="1">
         <mandatoryConform/>
       </field>
-      <field id="3" name="DeviceClass" type="DeviceClassBitmap">
+      <field fieldId="3" name="DeviceClass" type="DeviceClassBitmap">
         <mandatoryConform/>
       </field>
-      <field id="4" name="EnrollmentGroup" type="uint8" default="null">
+      <field fieldId="4" name="EnrollmentGroup" type="uint8" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="ENRLG"/>
         </mandatoryConform>
       </field>
-      <field id="5" name="Criticality" type="CriticalityLevelEnum" default="0">
+      <field fieldId="5" name="Criticality" type="CriticalityLevelEnum" default="0">
         <mandatoryConform/>
       </field>
-      <field id="6" name="StartTime" type="epoch-s" default="null">
+      <field fieldId="6" name="StartTime" type="epoch-s" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="7" name="Transitions" type="list" default="empty">
+      <field fieldId="7" name="Transitions" type="list" default="empty">
         <entry type="LoadControlEventTransitionStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="10"/>
       </field>
     </struct>
     <struct name="LoadControlEventTransitionStruct">
-      <field id="1" name="Duration" type="uint16" default="0">
+      <field fieldId="1" name="Duration" type="uint16" default="0">
         <mandatoryConform/>
         <constraint type="max" value="1440"/>
       </field>
-      <field id="2" name="Control" type="EventTransitionControlBitmap" default="0">
+      <field fieldId="2" name="Control" type="EventTransitionControlBitmap" default="0">
         <mandatoryConform/>
       </field>
-      <field id="3" name="TemperatureControl" type="TemperatureControlStruct" default="null">
+      <field fieldId="3" name="TemperatureControl" type="TemperatureControlStruct" default="null">
         <quality nullable="true"/>
       </field>
-      <field id="4" name="AverageLoadControl" type="AverageLoadControlStruct" default="null">
+      <field fieldId="4" name="AverageLoadControl" type="AverageLoadControlStruct" default="null">
         <quality nullable="true"/>
       </field>
-      <field id="5" name="DutyCycleControl" type="DutyCycleControlStruct" default="null">
+      <field fieldId="5" name="DutyCycleControl" type="DutyCycleControlStruct" default="null">
         <quality nullable="true"/>
       </field>
-      <field id="6" name="PowerSavingsControl" type="PowerSavingsControlStruct" default="null">
+      <field fieldId="6" name="PowerSavingsControl" type="PowerSavingsControlStruct" default="null">
         <quality nullable="true"/>
       </field>
-      <field id="7" name="HeatingSourceControl" type="HeatingSourceControlStruct" default="null">
+      <field fieldId="7" name="HeatingSourceControl" type="HeatingSourceControlStruct" default="null">
         <quality nullable="true"/>
       </field>
     </struct>
     <struct name="LoadControlProgramStruct">
-      <field id="0" name="ProgramID" type="octstr" default="0">
+      <field fieldId="0" name="ProgramID" type="octstr" default="0">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="Name" type="string">
+      <field fieldId="1" name="Name" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="2" name="EnrollmentGroup" type="uint8" default="null">
+      <field fieldId="2" name="EnrollmentGroup" type="uint8" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="ENRLG"/>
         </mandatoryConform>
         <constraint type="between" from="0x01" to="0xFF"/>
       </field>
-      <field id="3" name="RandomStartMinutes" type="uint8" default="null">
+      <field fieldId="3" name="RandomStartMinutes" type="uint8" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="0x00" to="0x3C"/>
       </field>
-      <field id="4" name="RandomDurationMinutes" type="uint8" default="null">
+      <field fieldId="4" name="RandomDurationMinutes" type="uint8" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="0x00" to="0x3C"/>
@@ -366,33 +366,33 @@ Davis, CA 95616, USA
       <access fabricScoped="true"/>
     </struct>
     <struct name="PowerSavingsControlStruct">
-      <field id="1" name="PowerSavings" type="PowerSavingsEnum">
+      <field fieldId="1" name="PowerSavings" type="PowerSavingsEnum">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="TemperatureControlStruct">
-      <field id="0" name="CoolingTempOffset" type="ref_TempDiff" default="null">
+      <field fieldId="0" name="CoolingTempOffset" type="ref_TempDiff" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="TEMPO"/>
         </mandatoryConform>
         <constraint type="between" from="0x00" to="0x0FE"/>
       </field>
-      <field id="1" name="HeatingTempOffset" type="ref_TempDiff" default="null">
+      <field fieldId="1" name="HeatingTempOffset" type="ref_TempDiff" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="TEMPO"/>
         </mandatoryConform>
         <constraint type="between" from="0x00" to="0x0FE"/>
       </field>
-      <field id="2" name="CoolingTempSetpoint" type="temperature" default="null">
+      <field fieldId="2" name="CoolingTempSetpoint" type="temperature" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="TEMPS"/>
         </mandatoryConform>
         <constraint type="between" from="0x954D" to="0x7FFF"/>
       </field>
-      <field id="3" name="HeatingTempSetpoint" type="temperature" default="null">
+      <field fieldId="3" name="HeatingTempSetpoint" type="temperature" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="TEMPS"/>
@@ -455,14 +455,14 @@ Davis, CA 95616, USA
     <command id="0x00" name="RegisterLoadControlProgramRequest" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="LoadControlProgram" type="LoadControlProgramStruct">
+      <field fieldId="0" name="LoadControlProgram" type="LoadControlProgramStruct">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x01" name="UnregisterLoadControlProgramRequest" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="LoadControlProgramID" type="octstr">
+      <field fieldId="0" name="LoadControlProgramID" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
@@ -470,18 +470,18 @@ Davis, CA 95616, USA
     <command id="0x02" name="AddLoadControlEventRequest" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Event" type="LoadControlEventStruct">
+      <field fieldId="0" name="Event" type="LoadControlEventStruct">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x03" name="RemoveLoadControlEventRequest" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="EventID" type="octstr">
+      <field fieldId="0" name="EventID" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="CancelControl" type="CancelControlBitmap" default="0">
+      <field fieldId="1" name="CancelControl" type="CancelControlBitmap" default="0">
         <mandatoryConform/>
       </field>
     </command>
@@ -494,24 +494,24 @@ Davis, CA 95616, USA
     <event id="0x00" name="LoadControlEventStatusChange" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="EventID" type="octstr">
+      <field fieldId="0" name="EventID" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="TransitionIndex" type="uint8" default="null">
+      <field fieldId="1" name="TransitionIndex" type="uint8" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="Status" type="LoadControlEventStatusEnum">
+      <field fieldId="2" name="Status" type="LoadControlEventStatusEnum">
         <mandatoryConform/>
       </field>
-      <field id="3" name="Criticality" type="CriticalityLevelEnum">
+      <field fieldId="3" name="Criticality" type="CriticalityLevelEnum">
         <mandatoryConform/>
       </field>
-      <field id="4" name="Control" type="EventControlBitmap" default="0">
+      <field fieldId="4" name="Control" type="EventControlBitmap" default="0">
         <mandatoryConform/>
       </field>
-      <field id="5" name="TemperatureControl" type="TemperatureControlStruct" default="null">
+      <field fieldId="5" name="TemperatureControl" type="TemperatureControlStruct" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <orTerm>
@@ -520,31 +520,31 @@ Davis, CA 95616, USA
           </orTerm>
         </mandatoryConform>
       </field>
-      <field id="6" name="AverageLoadControl" type="AverageLoadControlStruct" default="null">
+      <field fieldId="6" name="AverageLoadControl" type="AverageLoadControlStruct" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="LOADA"/>
         </mandatoryConform>
       </field>
-      <field id="7" name="DutyCycleControl" type="DutyCycleControlStruct" default="null">
+      <field fieldId="7" name="DutyCycleControl" type="DutyCycleControlStruct" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="DUTYC"/>
         </mandatoryConform>
       </field>
-      <field id="8" name="PowerSavingsControl" type="PowerSavingsControlStruct" default="null">
+      <field fieldId="8" name="PowerSavingsControl" type="PowerSavingsControlStruct" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="PWRSV"/>
         </mandatoryConform>
       </field>
-      <field id="9" name="HeatingSourceControl" type="HeatingSourceControlStruct" default="null">
+      <field fieldId="9" name="HeatingSourceControl" type="HeatingSourceControlStruct" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="HEATS"/>
         </mandatoryConform>
       </field>
-      <field id="255" name="Signature" type="octstr" default="null">
+      <field fieldId="255" name="Signature" type="octstr" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="48"/>

--- a/zcl-builtin/matter/new-data-model/Descriptor-Cluster.xml
+++ b/zcl-builtin/matter/new-data-model/Descriptor-Cluster.xml
@@ -71,10 +71,10 @@ Davis, CA 95616, USA
   </features>
   <dataTypes>
     <struct name="DeviceTypeStruct">
-      <field id="0" name="DeviceType" type="devtype-id">
+      <field fieldId="0" name="DeviceType" type="devtype-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Revision" type="uint16">
+      <field fieldId="1" name="Revision" type="uint16">
         <mandatoryConform/>
         <constraint type="min" value="1"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/DeviceEnergyManagement.xml
+++ b/zcl-builtin/matter/new-data-model/DeviceEnergyManagement.xml
@@ -267,173 +267,173 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="ConstraintsStruct">
-      <field id="0" name="StartTime" type="epoch-s">
+      <field fieldId="0" name="StartTime" type="epoch-s">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Duration" type="elapsed-s">
+      <field fieldId="1" name="Duration" type="elapsed-s">
         <mandatoryConform/>
         <constraint type="between" from="0" to="86400"/>
       </field>
-      <field id="2" name="NominalPower" type="power-mW">
+      <field fieldId="2" name="NominalPower" type="power-mW">
         <mandatoryConform>
           <feature name="PFR"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="MaximumEnergy" type="energy-mWh">
+      <field fieldId="3" name="MaximumEnergy" type="energy-mWh">
         <mandatoryConform>
           <feature name="PFR"/>
         </mandatoryConform>
       </field>
-      <field id="4" name="LoadControl" type="int8">
+      <field fieldId="4" name="LoadControl" type="int8">
         <mandatoryConform>
           <feature name="SFR"/>
         </mandatoryConform>
       </field>
     </struct>
     <struct name="CostStruct">
-      <field id="0" name="CostType" type="CostTypeEnum" default="0">
+      <field fieldId="0" name="CostType" type="CostTypeEnum" default="0">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Value" type="int32" default="0">
+      <field fieldId="1" name="Value" type="int32" default="0">
         <mandatoryConform/>
       </field>
-      <field id="2" name="DecimalPoints" type="uint8" default="0">
+      <field fieldId="2" name="DecimalPoints" type="uint8" default="0">
         <mandatoryConform/>
       </field>
-      <field id="3" name="Currency" type="uint16" default="0">
+      <field fieldId="3" name="Currency" type="uint16" default="0">
         <optionalConform/>
         <constraint type="max" value="999"/>
       </field>
     </struct>
     <struct name="ForecastStruct">
-      <field id="0" name="ForecastId" type="uint16" default="0">
+      <field fieldId="0" name="ForecastId" type="uint16" default="0">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ActiveSlotNumber" type="uint16" default="0">
+      <field fieldId="1" name="ActiveSlotNumber" type="uint16" default="0">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="StartTime" type="epoch-s">
+      <field fieldId="2" name="StartTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="3" name="EndTime" type="epoch-s">
+      <field fieldId="3" name="EndTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="4" name="EarliestStartTime" type="epoch-s">
+      <field fieldId="4" name="EarliestStartTime" type="epoch-s">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="STA"/>
         </mandatoryConform>
       </field>
-      <field id="5" name="LatestEndTime" type="epoch-s">
+      <field fieldId="5" name="LatestEndTime" type="epoch-s">
         <mandatoryConform>
           <feature name="STA"/>
         </mandatoryConform>
       </field>
-      <field id="6" name="IsPauseable" type="bool">
+      <field fieldId="6" name="IsPauseable" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="7" name="Slots" type="list">
+      <field fieldId="7" name="Slots" type="list">
         <entry type="SlotStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="10"/>
       </field>
-      <field id="8" name="ForecastUpdateReason" type="ForecastUpdateReasonEnum">
+      <field fieldId="8" name="ForecastUpdateReason" type="ForecastUpdateReasonEnum">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="PowerAdjustStruct">
-      <field id="0" name="MinPower" type="power-mW" default="0">
+      <field fieldId="0" name="MinPower" type="power-mW" default="0">
         <mandatoryConform/>
       </field>
-      <field id="1" name="MaxPower" type="power-mW" default="0">
+      <field fieldId="1" name="MaxPower" type="power-mW" default="0">
         <mandatoryConform/>
       </field>
-      <field id="2" name="MinDuration" type="elapsed-s" default="0">
+      <field fieldId="2" name="MinDuration" type="elapsed-s" default="0">
         <mandatoryConform/>
       </field>
-      <field id="3" name="MaxDuration" type="elapsed-s">
+      <field fieldId="3" name="MaxDuration" type="elapsed-s">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="SlotAdjustmentStruct">
-      <field id="0" name="SlotIndex" type="uint8">
+      <field fieldId="0" name="SlotIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="NominalPower" type="power-mW">
+      <field fieldId="1" name="NominalPower" type="power-mW">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Duration" type="elapsed-s">
+      <field fieldId="2" name="Duration" type="elapsed-s">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
     </struct>
     <struct name="SlotStruct">
-      <field id="0" name="MinDuration" type="elapsed-s">
+      <field fieldId="0" name="MinDuration" type="elapsed-s">
         <mandatoryConform/>
       </field>
-      <field id="1" name="MaxDuration" type="elapsed-s">
+      <field fieldId="1" name="MaxDuration" type="elapsed-s">
         <mandatoryConform/>
       </field>
-      <field id="2" name="DefaultDuration" type="elapsed-s">
+      <field fieldId="2" name="DefaultDuration" type="elapsed-s">
         <mandatoryConform/>
       </field>
-      <field id="3" name="ElapsedSlotTime" type="elapsed-s">
+      <field fieldId="3" name="ElapsedSlotTime" type="elapsed-s">
         <mandatoryConform/>
       </field>
-      <field id="4" name="RemainingSlotTime" type="elapsed-s">
+      <field fieldId="4" name="RemainingSlotTime" type="elapsed-s">
         <mandatoryConform/>
       </field>
-      <field id="5" name="SlotIsPauseable" type="bool">
+      <field fieldId="5" name="SlotIsPauseable" type="bool">
         <mandatoryConform>
           <feature name="PAU"/>
         </mandatoryConform>
       </field>
-      <field id="6" name="MinPauseDuration" type="elapsed-s">
+      <field fieldId="6" name="MinPauseDuration" type="elapsed-s">
         <mandatoryConform>
           <feature name="PAU"/>
         </mandatoryConform>
       </field>
-      <field id="7" name="MaxPauseDuration" type="elapsed-s">
+      <field fieldId="7" name="MaxPauseDuration" type="elapsed-s">
         <mandatoryConform>
           <feature name="PAU"/>
         </mandatoryConform>
       </field>
-      <field id="8" name="ManufacturerESAState" type="uint16">
+      <field fieldId="8" name="ManufacturerESAState" type="uint16">
         <mandatoryConform>
           <feature name="SFR"/>
         </mandatoryConform>
       </field>
-      <field id="9" name="NominalPower" type="power-mW">
+      <field fieldId="9" name="NominalPower" type="power-mW">
         <mandatoryConform>
           <feature name="PFR"/>
         </mandatoryConform>
       </field>
-      <field id="10" name="MinPower" type="power-mW">
+      <field fieldId="10" name="MinPower" type="power-mW">
         <mandatoryConform>
           <feature name="PFR"/>
         </mandatoryConform>
       </field>
-      <field id="11" name="MaxPower" type="power-mW">
+      <field fieldId="11" name="MaxPower" type="power-mW">
         <mandatoryConform>
           <feature name="PFR"/>
         </mandatoryConform>
       </field>
-      <field id="12" name="NominalEnergy" type="energy-mWh">
+      <field fieldId="12" name="NominalEnergy" type="energy-mWh">
         <mandatoryConform>
           <feature name="PFR"/>
         </mandatoryConform>
       </field>
-      <field id="13" name="Costs" type="list">
+      <field fieldId="13" name="Costs" type="list">
         <entry type="CostStruct"/>
         <optionalConform/>
         <constraint type="maxCount" value="5"/>
       </field>
-      <field id="14" name="MinPowerAdjustment" type="power-mW">
+      <field fieldId="14" name="MinPowerAdjustment" type="power-mW">
         <mandatoryConform>
           <andTerm>
             <feature name="FA"/>
@@ -441,7 +441,7 @@ Davis, CA 95616, USA
           </andTerm>
         </mandatoryConform>
       </field>
-      <field id="15" name="MaxPowerAdjustment" type="power-mW">
+      <field fieldId="15" name="MaxPowerAdjustment" type="power-mW">
         <mandatoryConform>
           <andTerm>
             <feature name="FA"/>
@@ -449,7 +449,7 @@ Davis, CA 95616, USA
           </andTerm>
         </mandatoryConform>
       </field>
-      <field id="16" name="MinDurationAdjustment" type="elapsed-s">
+      <field fieldId="16" name="MinDurationAdjustment" type="elapsed-s">
         <mandatoryConform>
           <andTerm>
             <feature name="FA"/>
@@ -460,7 +460,7 @@ Davis, CA 95616, USA
           </andTerm>
         </mandatoryConform>
       </field>
-      <field id="17" name="MaxDurationAdjustment" type="elapsed-s">
+      <field fieldId="17" name="MaxDurationAdjustment" type="elapsed-s">
         <mandatoryConform>
           <andTerm>
             <feature name="FA"/>
@@ -479,15 +479,15 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PA"/>
       </mandatoryConform>
-      <field id="0" name="Power" type="power-mW">
+      <field fieldId="0" name="Power" type="power-mW">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Duration" type="elapsed-s">
+      <field fieldId="1" name="Duration" type="elapsed-s">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Cause" type="AdjustmentCauseEnum">
+      <field fieldId="2" name="Cause" type="AdjustmentCauseEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -503,11 +503,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="STA"/>
       </mandatoryConform>
-      <field id="0" name="RequestedStartTime" type="epoch-s">
+      <field fieldId="0" name="RequestedStartTime" type="epoch-s">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Cause" type="AdjustmentCauseEnum">
+      <field fieldId="1" name="Cause" type="AdjustmentCauseEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -517,11 +517,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PAU"/>
       </mandatoryConform>
-      <field id="0" name="Duration" type="elapsed-s">
+      <field fieldId="0" name="Duration" type="elapsed-s">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Cause" type="AdjustmentCauseEnum">
+      <field fieldId="1" name="Cause" type="AdjustmentCauseEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -537,15 +537,15 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="FA"/>
       </mandatoryConform>
-      <field id="0" name="ForecastId" type="uint32">
+      <field fieldId="0" name="ForecastId" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="1" name="SlotAdjustments" type="list">
+      <field fieldId="1" name="SlotAdjustments" type="list">
         <entry type="SlotAdjustmentStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="10"/>
       </field>
-      <field id="2" name="Cause" type="AdjustmentCauseEnum">
+      <field fieldId="2" name="Cause" type="AdjustmentCauseEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -555,12 +555,12 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CON"/>
       </mandatoryConform>
-      <field id="0" name="Constraints" type="list">
+      <field fieldId="0" name="Constraints" type="list">
         <entry type="ConstraintsStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="10"/>
       </field>
-      <field id="1" name="Cause" type="AdjustmentCauseEnum">
+      <field fieldId="1" name="Cause" type="AdjustmentCauseEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -588,13 +588,13 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PA"/>
       </mandatoryConform>
-      <field id="0" name="Cause" type="CauseEnum" default="NormalCompletion">
+      <field fieldId="0" name="Cause" type="CauseEnum" default="NormalCompletion">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Duration" type="elapsed-s">
+      <field fieldId="1" name="Duration" type="elapsed-s">
         <mandatoryConform/>
       </field>
-      <field id="2" name="EnergyUse" type="energy-mWh">
+      <field fieldId="2" name="EnergyUse" type="energy-mWh">
         <mandatoryConform/>
       </field>
     </event>
@@ -609,7 +609,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PAU"/>
       </mandatoryConform>
-      <field id="0" name="Cause" type="CauseEnum" default="NormalCompletion">
+      <field fieldId="0" name="Cause" type="CauseEnum" default="NormalCompletion">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/DiagnosticLogsCluster.xml
+++ b/zcl-builtin/matter/new-data-model/DiagnosticLogsCluster.xml
@@ -105,30 +105,30 @@ Davis, CA 95616, USA
     <command id="0x00" name="RetrieveLogsRequest" direction="commandToServer" response="RetrieveLogsResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Intent" type="IntentEnum">
+      <field fieldId="0" name="Intent" type="IntentEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="RequestedProtocol" type="TransferProtocolEnum">
+      <field fieldId="1" name="RequestedProtocol" type="TransferProtocolEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="TransferFileDesignator" type="string">
+      <field fieldId="2" name="TransferFileDesignator" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="32"/>
       </field>
     </command>
     <command id="0x01" name="RetrieveLogsResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="StatusEnum">
+      <field fieldId="0" name="Status" type="StatusEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="LogContent" type="octstr">
+      <field fieldId="1" name="LogContent" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="1024"/>
       </field>
-      <field id="2" name="UTCTimeStamp" type="epoch-us">
+      <field fieldId="2" name="UTCTimeStamp" type="epoch-us">
         <optionalConform/>
       </field>
-      <field id="3" name="TimeSinceBoot" type="ref_DataTypeSystemTimeUs">
+      <field fieldId="3" name="TimeSinceBoot" type="ref_DataTypeSystemTimeUs">
         <optionalConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/DiagnosticsGeneral.xml
+++ b/zcl-builtin/matter/new-data-model/DiagnosticsGeneral.xml
@@ -183,35 +183,35 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="NetworkInterface">
-      <field id="0" name="Name" type="string">
+      <field fieldId="0" name="Name" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="1" name="IsOperational" type="bool">
+      <field fieldId="1" name="IsOperational" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="2" name="OffPremiseServicesReachableIPv4" type="bool" default="null">
+      <field fieldId="2" name="OffPremiseServicesReachableIPv4" type="bool" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="OffPremiseServicesReachableIPv6" type="bool" default="null">
+      <field fieldId="3" name="OffPremiseServicesReachableIPv6" type="bool" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="HardwareAddress" type="Hardware Address">
+      <field fieldId="4" name="HardwareAddress" type="Hardware Address">
         <mandatoryConform/>
       </field>
-      <field id="5" name="IPv4Addresses" type="list">
+      <field fieldId="5" name="IPv4Addresses" type="list">
         <entry type="ref_Ipv4Adr"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="4"/>
       </field>
-      <field id="6" name="IPv6Addresses" type="list">
+      <field fieldId="6" name="IPv6Addresses" type="list">
         <entry type="ref_Ipv6Adr"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="8"/>
       </field>
-      <field id="7" name="Type" type="InterfaceTypeEnum">
+      <field fieldId="7" name="Type" type="InterfaceTypeEnum">
         <mandatoryConform/>
       </field>
     </struct>
@@ -272,11 +272,11 @@ Davis, CA 95616, USA
     <command id="0x00" name="TestEventTrigger" direction="commandToServer" response="Y">
       <access invokePrivilege="manage"/>
       <mandatoryConform/>
-      <field id="0" name="EnableKey" type="octstr">
+      <field fieldId="0" name="EnableKey" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="EventTrigger" type="uint64">
+      <field fieldId="1" name="EventTrigger" type="uint64">
         <mandatoryConform/>
       </field>
     </command>
@@ -286,10 +286,10 @@ Davis, CA 95616, USA
     </command>
     <command id="0x02" name="TimeSnapshotResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="SystemTimeMs" type="ref_DataTypeSystemTimeMs" default="MS">
+      <field fieldId="0" name="SystemTimeMs" type="ref_DataTypeSystemTimeMs" default="MS">
         <mandatoryConform/>
       </field>
-      <field id="1" name="PosixTimeMs" type="ref_DataTypePosixMs" default="null">
+      <field fieldId="1" name="PosixTimeMs" type="ref_DataTypePosixMs" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -299,14 +299,14 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="DMTEST"/>
       </mandatoryConform>
-      <field id="0" name="EnableKey" type="octstr">
+      <field fieldId="0" name="EnableKey" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="Value" type="uint8">
+      <field fieldId="1" name="Value" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Count" type="uint16">
+      <field fieldId="2" name="Count" type="uint16">
         <mandatoryConform/>
         <constraint type="max" value="2048"/>
       </field>
@@ -316,7 +316,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="DMTEST"/>
       </mandatoryConform>
-      <field id="0" name="Payload" type="octstr">
+      <field fieldId="0" name="Payload" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="2048"/>
       </field>
@@ -326,12 +326,12 @@ Davis, CA 95616, USA
     <event id="0x00" name="HardwareFaultChange" priority="critical">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="Current" type="list">
+      <field fieldId="0" name="Current" type="list">
         <entry type="HardwareFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="11"/>
       </field>
-      <field id="1" name="Previous" type="list">
+      <field fieldId="1" name="Previous" type="list">
         <entry type="HardwareFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="11"/>
@@ -340,12 +340,12 @@ Davis, CA 95616, USA
     <event id="0x01" name="RadioFaultChange" priority="critical">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="Current" type="list">
+      <field fieldId="0" name="Current" type="list">
         <entry type="RadioFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="7"/>
       </field>
-      <field id="1" name="Previous" type="list">
+      <field fieldId="1" name="Previous" type="list">
         <entry type="RadioFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="7"/>
@@ -354,12 +354,12 @@ Davis, CA 95616, USA
     <event id="0x02" name="NetworkFaultChange" priority="critical">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="Current" type="list">
+      <field fieldId="0" name="Current" type="list">
         <entry type="NetworkFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="4"/>
       </field>
-      <field id="1" name="Previous" type="list">
+      <field fieldId="1" name="Previous" type="list">
         <entry type="NetworkFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="4"/>
@@ -368,7 +368,7 @@ Davis, CA 95616, USA
     <event id="0x03" name="BootReason" priority="critical">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="BootReason" type="BootReasonEnum">
+      <field fieldId="0" name="BootReason" type="BootReasonEnum">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/DiagnosticsSoftware.xml
+++ b/zcl-builtin/matter/new-data-model/DiagnosticsSoftware.xml
@@ -70,20 +70,20 @@ Davis, CA 95616, USA
   </features>
   <dataTypes>
     <struct name="ThreadMetricsStruct">
-      <field id="0" name="ID" type="uint64">
+      <field fieldId="0" name="ID" type="uint64">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Name" type="string" default="empty">
+      <field fieldId="1" name="Name" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="8"/>
       </field>
-      <field id="2" name="StackFreeCurrent" type="uint32" default="MS">
+      <field fieldId="2" name="StackFreeCurrent" type="uint32" default="MS">
         <optionalConform/>
       </field>
-      <field id="3" name="StackFreeMinimum" type="uint32" default="MS">
+      <field fieldId="3" name="StackFreeMinimum" type="uint32" default="MS">
         <optionalConform/>
       </field>
-      <field id="4" name="StackSize" type="uint32" default="MS">
+      <field fieldId="4" name="StackSize" type="uint32" default="MS">
         <optionalConform/>
       </field>
     </struct>
@@ -122,14 +122,14 @@ Davis, CA 95616, USA
     <event id="0x00" name="SoftwareFault" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="ID" type="uint64" default="0">
+      <field fieldId="0" name="ID" type="uint64" default="0">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Name" type="string" default="empty">
+      <field fieldId="1" name="Name" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="8"/>
       </field>
-      <field id="2" name="FaultRecording" type="octstr" default="empty">
+      <field fieldId="2" name="FaultRecording" type="octstr" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="1024"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/DiagnosticsThread.xml
+++ b/zcl-builtin/matter/new-data-model/DiagnosticsThread.xml
@@ -125,131 +125,131 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="NeighborTableStruct">
-      <field id="0" name="ExtAddress" type="uint64">
+      <field fieldId="0" name="ExtAddress" type="uint64">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Age" type="uint32">
+      <field fieldId="1" name="Age" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Rloc16" type="uint16">
+      <field fieldId="2" name="Rloc16" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="3" name="LinkFrameCounter" type="uint32">
+      <field fieldId="3" name="LinkFrameCounter" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="4" name="MleFrameCounter" type="uint32">
+      <field fieldId="4" name="MleFrameCounter" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="5" name="LQI" type="uint8">
+      <field fieldId="5" name="LQI" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="255"/>
       </field>
-      <field id="6" name="AverageRssi" type="int8" default="null">
+      <field fieldId="6" name="AverageRssi" type="int8" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="-128" to="0"/>
       </field>
-      <field id="7" name="LastRssi" type="int8" default="null">
+      <field fieldId="7" name="LastRssi" type="int8" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="-128" to="0"/>
       </field>
-      <field id="8" name="FrameErrorRate" type="uint8" default="0">
+      <field fieldId="8" name="FrameErrorRate" type="uint8" default="0">
         <mandatoryConform/>
         <constraint type="between" from="0" to="100"/>
       </field>
-      <field id="9" name="MessageErrorRate" type="uint8" default="0">
+      <field fieldId="9" name="MessageErrorRate" type="uint8" default="0">
         <mandatoryConform/>
         <constraint type="between" from="0" to="100"/>
       </field>
-      <field id="10" name="RxOnWhenIdle" type="bool">
+      <field fieldId="10" name="RxOnWhenIdle" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="11" name="FullThreadDevice" type="bool">
+      <field fieldId="11" name="FullThreadDevice" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="12" name="FullNetworkData" type="bool">
+      <field fieldId="12" name="FullNetworkData" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="13" name="IsChild" type="bool">
+      <field fieldId="13" name="IsChild" type="bool">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="OperationalDatasetComponents">
-      <field id="0" name="ActiveTimestampPresent" type="bool">
+      <field fieldId="0" name="ActiveTimestampPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="1" name="PendingTimestampPresent" type="bool">
+      <field fieldId="1" name="PendingTimestampPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="2" name="MasterKeyPresent" type="bool">
+      <field fieldId="2" name="MasterKeyPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="3" name="NetworkNamePresent" type="bool">
+      <field fieldId="3" name="NetworkNamePresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="4" name="ExtendedPanIdPresent" type="bool">
+      <field fieldId="4" name="ExtendedPanIdPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="5" name="MeshLocalPrefixPresent" type="bool">
+      <field fieldId="5" name="MeshLocalPrefixPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="6" name="DelayPresent" type="bool">
+      <field fieldId="6" name="DelayPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="7" name="PanIdPresent" type="bool">
+      <field fieldId="7" name="PanIdPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="8" name="ChannelPresent" type="bool">
+      <field fieldId="8" name="ChannelPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="9" name="PskcPresent" type="bool">
+      <field fieldId="9" name="PskcPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="10" name="SecurityPolicyPresent" type="bool">
+      <field fieldId="10" name="SecurityPolicyPresent" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="11" name="ChannelMaskPresent" type="bool">
+      <field fieldId="11" name="ChannelMaskPresent" type="bool">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="RouteTableStruct">
-      <field id="0" name="ExtAddress" type="uint64">
+      <field fieldId="0" name="ExtAddress" type="uint64">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Rloc16" type="uint16">
+      <field fieldId="1" name="Rloc16" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="RouterId" type="uint8">
+      <field fieldId="2" name="RouterId" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="3" name="NextHop" type="uint8">
+      <field fieldId="3" name="NextHop" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="4" name="PathCost" type="uint8">
+      <field fieldId="4" name="PathCost" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="5" name="LQIIn" type="uint8">
+      <field fieldId="5" name="LQIIn" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="6" name="LQIOut" type="uint8">
+      <field fieldId="6" name="LQIOut" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="7" name="Age" type="uint8">
+      <field fieldId="7" name="Age" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="8" name="Allocated" type="bool">
+      <field fieldId="8" name="Allocated" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="9" name="LinkEstablished" type="bool">
+      <field fieldId="9" name="LinkEstablished" type="bool">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="SecurityPolicy">
-      <field id="0" name="RotationTime" type="uint16">
+      <field fieldId="0" name="RotationTime" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Flags" type="uint16">
+      <field fieldId="1" name="Flags" type="uint16">
         <mandatoryConform/>
       </field>
     </struct>
@@ -676,19 +676,19 @@ Davis, CA 95616, USA
     <event id="0x00" name="ConnectionStatus" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="ConnectionStatus" type="ConnectionStatusEnum">
+      <field fieldId="0" name="ConnectionStatus" type="ConnectionStatusEnum">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x01" name="NetworkFaultChange" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="Current" type="list">
+      <field fieldId="0" name="Current" type="list">
         <entry type="NetworkFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="4"/>
       </field>
-      <field id="1" name="Previous" type="list">
+      <field fieldId="1" name="Previous" type="list">
         <entry type="NetworkFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="4"/>

--- a/zcl-builtin/matter/new-data-model/DiagnosticsWiFi.xml
+++ b/zcl-builtin/matter/new-data-model/DiagnosticsWiFi.xml
@@ -233,24 +233,24 @@ Davis, CA 95616, USA
     <event id="0x00" name="Disconnection" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="ReasonCode" type="uint16">
+      <field fieldId="0" name="ReasonCode" type="uint16">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x01" name="AssociationFailure" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="AssociationFailureCause" type="AssociationFailureCauseEnum">
+      <field fieldId="0" name="AssociationFailureCause" type="AssociationFailureCauseEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Status" type="uint16">
+      <field fieldId="1" name="Status" type="uint16">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x02" name="ConnectionStatus" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="ConnectionStatus" type="ConnectionStatusEnum">
+      <field fieldId="0" name="ConnectionStatus" type="ConnectionStatusEnum">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/DoorLock.xml
+++ b/zcl-builtin/matter/new-data-model/DoorLock.xml
@@ -778,10 +778,10 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="CredentialStruct">
-      <field id="0" name="CredentialType" type="CredentialTypeEnum">
+      <field fieldId="0" name="CredentialType" type="CredentialTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="CredentialIndex" type="uint16" default="0">
+      <field fieldId="1" name="CredentialIndex" type="uint16" default="0">
         <mandatoryConform/>
       </field>
     </struct>
@@ -1189,7 +1189,7 @@ Davis, CA 95616, USA
     <command id="0x00" name="LockDoor" direction="commandToServer" response="Y">
       <access invokePrivilege="operate" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="PINCode" type="octstr">
+      <field fieldId="0" name="PINCode" type="octstr">
         <optionalConform>
           <andTerm>
             <feature name="COTA"/>
@@ -1201,7 +1201,7 @@ Davis, CA 95616, USA
     <command id="0x01" name="UnlockDoor" direction="commandToServer" response="Y">
       <access invokePrivilege="operate" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="PINCode" type="octstr">
+      <field fieldId="0" name="PINCode" type="octstr">
         <optionalConform>
           <andTerm>
             <feature name="COTA"/>
@@ -1217,10 +1217,10 @@ Davis, CA 95616, USA
     <command id="0x03" name="UnlockWithTimeout" direction="commandToServer" response="Y">
       <access invokePrivilege="operate" timed="true"/>
       <optionalConform/>
-      <field id="0" name="Timeout" type="uint16">
+      <field fieldId="0" name="Timeout" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="PINCode" type="octstr">
+      <field fieldId="1" name="PINCode" type="octstr">
         <optionalConform>
           <andTerm>
             <feature name="COTA"/>
@@ -1234,7 +1234,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="LOG"/>
       </mandatoryConform>
-      <field id="0" name="LogIndex" type="uint16">
+      <field fieldId="0" name="LogIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -1243,28 +1243,28 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="LOG"/>
       </mandatoryConform>
-      <field id="0" name="LogEntryID" type="uint16">
+      <field fieldId="0" name="LogEntryID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Timestamp" type="epoch-s">
+      <field fieldId="1" name="Timestamp" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="2" name="EventType" type="EventTypeEnum">
+      <field fieldId="2" name="EventType" type="EventTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="3" name="Source" type="EventSourceEnum">
+      <field fieldId="3" name="Source" type="EventSourceEnum">
         <mandatoryConform/>
       </field>
-      <field id="4" name="EventID" type="uint8">
-        <mandatoryConform/>
-        <constraint type="desc"/>
-      </field>
-      <field id="5" name="UserID" type="uint16">
+      <field fieldId="4" name="EventID" type="uint8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="6" name="PIN" type="octstr">
+      <field fieldId="5" name="UserID" type="uint16">
+        <mandatoryConform/>
+        <constraint type="desc"/>
+      </field>
+      <field fieldId="6" name="PIN" type="octstr">
         <mandatoryConform/>
       </field>
     </command>
@@ -1278,20 +1278,20 @@ Davis, CA 95616, USA
           <feature name="PIN"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="UserStatus" type="UserStatusEnum" default="OccupiedEnabled">
+      <field fieldId="1" name="UserStatus" type="UserStatusEnum" default="OccupiedEnabled">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
+      <field fieldId="2" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="PIN" type="octstr">
+      <field fieldId="3" name="PIN" type="octstr">
         <mandatoryConform/>
       </field>
     </command>
@@ -1305,7 +1305,7 @@ Davis, CA 95616, USA
           <feature name="PIN"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -1319,21 +1319,21 @@ Davis, CA 95616, USA
           <feature name="PIN"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="UserStatus" type="UserStatusEnum" default="Available">
+      <field fieldId="1" name="UserStatus" type="UserStatusEnum" default="Available">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="UserType" type="UserTypeEnum">
+      <field fieldId="2" name="UserType" type="UserTypeEnum">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="PINCode" type="octstr" default="empty">
+      <field fieldId="3" name="PINCode" type="octstr" default="empty">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -1348,7 +1348,7 @@ Davis, CA 95616, USA
           <feature name="PIN"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="PINSlotIndex" type="uint16">
+      <field fieldId="0" name="PINSlotIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfPINUsersSupported"/>
         <constraint type="allowed" value="0xFFFE"/>
@@ -1379,11 +1379,11 @@ Davis, CA 95616, USA
           </orTerm>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="UserStatus" type="UserStatusEnum">
+      <field fieldId="1" name="UserStatus" type="UserStatusEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -1402,7 +1402,7 @@ Davis, CA 95616, USA
           </orTerm>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -1413,11 +1413,11 @@ Davis, CA 95616, USA
           <feature name="USR"/>
         </notTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="UserStatus" type="UserStatusEnum">
+      <field fieldId="1" name="UserStatus" type="UserStatusEnum">
         <mandatoryConform/>
       </field>
     </command>
@@ -1426,30 +1426,30 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="WDSCH"/>
       </mandatoryConform>
-      <field id="0" name="WeekDayIndex" type="uint8">
+      <field fieldId="0" name="WeekDayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfWeekDaySchedulesSupportedPerUser"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
-      <field id="2" name="DaysMask" type="DaysMaskBitmap">
+      <field fieldId="2" name="DaysMask" type="DaysMaskBitmap">
         <mandatoryConform/>
       </field>
-      <field id="3" name="StartHour" type="uint8">
+      <field fieldId="3" name="StartHour" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="23"/>
       </field>
-      <field id="4" name="StartMinute" type="uint8">
+      <field fieldId="4" name="StartMinute" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="59"/>
       </field>
-      <field id="5" name="EndHour" type="uint8">
+      <field fieldId="5" name="EndHour" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="23"/>
       </field>
-      <field id="6" name="EndMinute" type="uint8">
+      <field fieldId="6" name="EndMinute" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="59"/>
       </field>
@@ -1459,11 +1459,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="WDSCH"/>
       </mandatoryConform>
-      <field id="0" name="WeekDayIndex" type="uint8">
+      <field fieldId="0" name="WeekDayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfWeekDaySchedulesSupportedPerUser"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
@@ -1472,34 +1472,34 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="WDSCH"/>
       </mandatoryConform>
-      <field id="0" name="WeekDayIndex" type="uint8">
+      <field fieldId="0" name="WeekDayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfWeekDaySchedulesSupportedPerUser"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
-      <field id="2" name="Status" type="enum8" default="SUCCESS">
+      <field fieldId="2" name="Status" type="enum8" default="SUCCESS">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="DaysMask" type="DaysMaskBitmap">
+      <field fieldId="3" name="DaysMask" type="DaysMaskBitmap">
         <optionalConform/>
       </field>
-      <field id="4" name="StartHour" type="uint8">
+      <field fieldId="4" name="StartHour" type="uint8">
         <optionalConform/>
         <constraint type="between" from="0" to="23"/>
       </field>
-      <field id="5" name="StartMinute" type="uint8">
+      <field fieldId="5" name="StartMinute" type="uint8">
         <optionalConform/>
         <constraint type="between" from="0" to="59"/>
       </field>
-      <field id="6" name="EndHour" type="uint8">
+      <field fieldId="6" name="EndHour" type="uint8">
         <optionalConform/>
         <constraint type="between" from="0" to="23"/>
       </field>
-      <field id="7" name="EndMinute" type="uint8">
+      <field fieldId="7" name="EndMinute" type="uint8">
         <optionalConform/>
         <constraint type="between" from="0" to="59"/>
       </field>
@@ -1509,12 +1509,12 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="WDSCH"/>
       </mandatoryConform>
-      <field id="0" name="WeekDayIndex" type="uint8">
+      <field fieldId="0" name="WeekDayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfWeekDaySchedulesSupportedPerUser"/>
         <constraint type="allowed" value="0xFE"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
@@ -1524,18 +1524,18 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="YDSCH"/>
       </mandatoryConform>
-      <field id="0" name="YearDayIndex" type="uint8">
+      <field fieldId="0" name="YearDayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfYearDaySchedulesSupportedPerUser"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
-      <field id="2" name="LocalStartTime" type="epoch-s">
+      <field fieldId="2" name="LocalStartTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="3" name="LocalEndTime" type="epoch-s">
+      <field fieldId="3" name="LocalEndTime" type="epoch-s">
         <mandatoryConform/>
       </field>
     </command>
@@ -1544,11 +1544,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="YDSCH"/>
       </mandatoryConform>
-      <field id="0" name="YearDayIndex" type="uint8">
+      <field fieldId="0" name="YearDayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfYearDaySchedulesSupportedPerUser"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
@@ -1557,22 +1557,22 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="YDSCH"/>
       </mandatoryConform>
-      <field id="0" name="YearDayIndex" type="uint8">
+      <field fieldId="0" name="YearDayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfYearDaySchedulesSupportedPerUser"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
-      <field id="2" name="Status" type="enum8" default="SUCCESS">
+      <field fieldId="2" name="Status" type="enum8" default="SUCCESS">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="LocalStartTime" type="epoch-s">
+      <field fieldId="2" name="LocalStartTime" type="epoch-s">
         <optionalConform/>
       </field>
-      <field id="3" name="LocalEndTime" type="epoch-s">
+      <field fieldId="3" name="LocalEndTime" type="epoch-s">
         <optionalConform/>
       </field>
     </command>
@@ -1581,12 +1581,12 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="YDSCH"/>
       </mandatoryConform>
-      <field id="0" name="YearDayIndex" type="uint8">
+      <field fieldId="0" name="YearDayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfYearDaySchedulesSupportedPerUser"/>
         <constraint type="allowed" value="0xFE"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
@@ -1596,17 +1596,17 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HDSCH"/>
       </mandatoryConform>
-      <field id="0" name="HolidayIndex" type="uint8">
+      <field fieldId="0" name="HolidayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfHolidaySchedulesSupported"/>
       </field>
-      <field id="1" name="LocalStartTime" type="epoch-s">
+      <field fieldId="1" name="LocalStartTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="2" name="LocalEndTime" type="epoch-s">
+      <field fieldId="2" name="LocalEndTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="3" name="OperatingMode" type="OperatingModeEnum">
+      <field fieldId="3" name="OperatingMode" type="OperatingModeEnum">
         <mandatoryConform/>
       </field>
     </command>
@@ -1615,7 +1615,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HDSCH"/>
       </mandatoryConform>
-      <field id="0" name="HolidayIndex" type="uint8">
+      <field fieldId="0" name="HolidayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfHolidaySchedulesSupported"/>
       </field>
@@ -1624,23 +1624,23 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HDSCH"/>
       </mandatoryConform>
-      <field id="0" name="HolidayIndex" type="uint8">
+      <field fieldId="0" name="HolidayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfHolidaySchedulesSupported"/>
       </field>
-      <field id="1" name="Status" type="enum8" default="SUCCESS">
+      <field fieldId="1" name="Status" type="enum8" default="SUCCESS">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="LocalStartTime" type="epoch-s">
+      <field fieldId="2" name="LocalStartTime" type="epoch-s">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
-      <field id="3" name="Local End Time" type="epoch-s">
+      <field fieldId="3" name="Local End Time" type="epoch-s">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
-      <field id="4" name="OperatingMode" type="OperatingModeEnum">
+      <field fieldId="4" name="OperatingMode" type="OperatingModeEnum">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
@@ -1650,7 +1650,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="HDSCH"/>
       </mandatoryConform>
-      <field id="0" name="HolidayIndex" type="uint8">
+      <field fieldId="0" name="HolidayIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfHolidaySchedulesSupported"/>
         <constraint type="allowed" value="0xFE"/>
@@ -1670,11 +1670,11 @@ Davis, CA 95616, USA
           </orTerm>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="UserType" type="UserTypeEnum">
+      <field fieldId="1" name="UserType" type="UserTypeEnum">
         <mandatoryConform/>
       </field>
     </command>
@@ -1692,7 +1692,7 @@ Davis, CA 95616, USA
           </orTerm>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -1703,11 +1703,11 @@ Davis, CA 95616, USA
           <feature name="USR"/>
         </notTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="UserType" type="UserTypeEnum">
+      <field fieldId="1" name="UserType" type="UserTypeEnum">
         <mandatoryConform/>
       </field>
     </command>
@@ -1721,21 +1721,21 @@ Davis, CA 95616, USA
           <feature name="RID"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="UserStatus" type="UserStatusEnum" default="OccupiedEnabled">
+      <field fieldId="1" name="UserStatus" type="UserStatusEnum" default="OccupiedEnabled">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
+      <field fieldId="2" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="RFIDCode" type="octstr">
+      <field fieldId="3" name="RFIDCode" type="octstr">
         <mandatoryConform/>
       </field>
     </command>
@@ -1749,7 +1749,7 @@ Davis, CA 95616, USA
           <feature name="RID"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -1763,21 +1763,21 @@ Davis, CA 95616, USA
           <feature name="RID"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="UserID" type="uint16">
+      <field fieldId="0" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="UserStatus" type="UserStatusEnum" default="Available">
+      <field fieldId="1" name="UserStatus" type="UserStatusEnum" default="Available">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="UserType" type="UserTypeEnum">
+      <field fieldId="2" name="UserType" type="UserTypeEnum">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="RFIDCode" type="octstr" default="empty">
+      <field fieldId="3" name="RFIDCode" type="octstr" default="empty">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -1792,7 +1792,7 @@ Davis, CA 95616, USA
           <feature name="RID"/>
         </andTerm>
       </mandatoryConform>
-      <field id="0" name="RFIDSlotIndex" type="uint16">
+      <field fieldId="0" name="RFIDSlotIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfRFIDUsersSupported"/>
         <constraint type="allowed" value="0xFFFE"/>
@@ -1814,31 +1814,31 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="OperationType" type="DataOperationTypeEnum">
+      <field fieldId="0" name="OperationType" type="DataOperationTypeEnum">
         <mandatoryConform/>
         <constraint type="allowed" value="Add"/>
         <constraint type="allowed" value="Modify"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
-      <field id="2" name="UserName" type="string" default="empty">
+      <field fieldId="2" name="UserName" type="string" default="empty">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="10"/>
       </field>
-      <field id="3" name="UserUniqueID" type="uint32" default="0xFFFFFFFF">
+      <field fieldId="3" name="UserUniqueID" type="uint32" default="0xFFFFFFFF">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="UserStatus" type="UserStatusEnum" default="OccupiedEnabled">
+      <field fieldId="4" name="UserStatus" type="UserStatusEnum" default="OccupiedEnabled">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="allowed" value="OccupiedEnabled"/>
         <constraint type="allowed" value="OccupiedDisabled"/>
       </field>
-      <field id="5" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
+      <field fieldId="5" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="allowed" value="UnrestrictedUser"/>
@@ -1849,7 +1849,7 @@ Davis, CA 95616, USA
         <constraint type="allowed" value="ScheduleRestrictedUser"/>
         <constraint type="allowed" value="RemoteOnlyUser"/>
       </field>
-      <field id="6" name="CredentialRule" type="CredentialRuleEnum" default="Single">
+      <field fieldId="6" name="CredentialRule" type="CredentialRuleEnum" default="Single">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -1859,7 +1859,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="UserIndex" type="uint16">
+      <field fieldId="0" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
@@ -1868,47 +1868,47 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="UserIndex" type="uint16">
+      <field fieldId="0" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
-      <field id="1" name="UserName" type="string" default="empty">
+      <field fieldId="1" name="UserName" type="string" default="empty">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="10"/>
       </field>
-      <field id="2" name="UserUniqueID" type="uint32" default="0">
+      <field fieldId="2" name="UserUniqueID" type="uint32" default="0">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="UserStatus" type="UserStatusEnum" default="Available">
+      <field fieldId="3" name="UserStatus" type="UserStatusEnum" default="Available">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
+      <field fieldId="4" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="5" name="CredentialRule" type="CredentialRuleEnum" default="Single">
+      <field fieldId="5" name="CredentialRule" type="CredentialRuleEnum" default="Single">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="6" name="Credentials" type="list">
+      <field fieldId="6" name="Credentials" type="list">
         <entry type="CredentialStruct"/>
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="countBetween" from="0" to="NumberOfCredentialsSupportedPerUser"/>
       </field>
-      <field id="7" name="CreatorFabricIndex" type="fabric-idx">
+      <field fieldId="7" name="CreatorFabricIndex" type="fabric-idx">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="8" name="LastModifiedFabricIndex" type="fabric-idx">
+      <field fieldId="8" name="LastModifiedFabricIndex" type="fabric-idx">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="9" name="NextUserIndex" type="uint16">
+      <field fieldId="9" name="NextUserIndex" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
@@ -1919,7 +1919,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="UserIndex" type="uint16">
+      <field fieldId="0" name="UserIndex" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
         <constraint type="allowed" value="0xFFFE"/>
@@ -1936,33 +1936,33 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="NOT"/>
       </optionalConform>
-      <field id="0" name="ProgramEventSource" type="EventSourceEnum">
+      <field fieldId="0" name="ProgramEventSource" type="EventSourceEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="ProgramEventCode" type="ProgrammingEventCodeEnum">
+      <field fieldId="1" name="ProgramEventCode" type="ProgrammingEventCodeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="UserID" type="uint16">
+      <field fieldId="2" name="UserID" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="PIN" type="octstr">
+      <field fieldId="3" name="PIN" type="octstr">
         <mandatoryConform/>
       </field>
-      <field id="4" name="UserType" type="UserTypeEnum">
-        <mandatoryConform/>
-        <constraint type="desc"/>
-      </field>
-      <field id="5" name="UserStatus" type="UserStatusEnum">
+      <field fieldId="4" name="UserType" type="UserTypeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="6" name="LocalTime" type="epoch-s">
+      <field fieldId="5" name="UserStatus" type="UserStatusEnum">
+        <mandatoryConform/>
+        <constraint type="desc"/>
+      </field>
+      <field fieldId="6" name="LocalTime" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="7" name="Data" type="string">
+      <field fieldId="7" name="Data" type="string">
         <optionalConform/>
       </field>
     </command>
@@ -1971,30 +1971,30 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="OperationType" type="DataOperationTypeEnum">
+      <field fieldId="0" name="OperationType" type="DataOperationTypeEnum">
         <mandatoryConform/>
         <constraint type="allowed" value="Add"/>
         <constraint type="allowed" value="Modify"/>
       </field>
-      <field id="1" name="Credential" type="CredentialStruct">
+      <field fieldId="1" name="Credential" type="CredentialStruct">
         <mandatoryConform/>
       </field>
-      <field id="2" name="CredentialData" type="octstr">
+      <field fieldId="2" name="CredentialData" type="octstr">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="UserIndex" type="uint16">
+      <field fieldId="3" name="UserIndex" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
-      <field id="4" name="UserStatus" type="UserStatusEnum" default="OccupiedEnabled">
+      <field fieldId="4" name="UserStatus" type="UserStatusEnum" default="OccupiedEnabled">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="allowed" value="OccupiedEnabled"/>
         <constraint type="allowed" value="OccupiedDisabled"/>
       </field>
-      <field id="5" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
+      <field fieldId="5" name="UserType" type="UserTypeEnum" default="UnrestrictedUser">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="allowed" value="UnrestrictedUser"/>
@@ -2010,16 +2010,16 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="Status" type="status">
+      <field fieldId="0" name="Status" type="status">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="UserIndex" type="uint16" default="0">
+      <field fieldId="1" name="UserIndex" type="uint16" default="0">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
-      <field id="2" name="NextCredentialIndex" type="uint16">
+      <field fieldId="2" name="NextCredentialIndex" type="uint16">
         <quality nullable="true"/>
         <optionalConform/>
         <constraint type="desc"/>
@@ -2030,7 +2030,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="Credential" type="CredentialStruct">
+      <field fieldId="0" name="Credential" type="CredentialStruct">
         <mandatoryConform/>
       </field>
     </command>
@@ -2038,28 +2038,28 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="CredentialExists" type="bool">
+      <field fieldId="0" name="CredentialExists" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="1" name="UserIndex" type="uint16">
+      <field fieldId="1" name="UserIndex" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="1" to="NumberOfTotalUsersSupported"/>
       </field>
-      <field id="2" name="CreatorFabricIndex" type="fabric-idx">
+      <field fieldId="2" name="CreatorFabricIndex" type="fabric-idx">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="LastModifiedFabricIndex" type="fabric-idx">
+      <field fieldId="3" name="LastModifiedFabricIndex" type="fabric-idx">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="NextCredentialIndex" type="uint16">
+      <field fieldId="4" name="NextCredentialIndex" type="uint16">
         <quality nullable="true"/>
         <optionalConform/>
         <constraint type="desc"/>
       </field>
-      <field id="5" name="CredentialData" type="octstr">
+      <field fieldId="5" name="CredentialData" type="octstr">
         <quality nullable="true"/>
         <optionalConform>
           <feature name="ALIRO"/>
@@ -2072,7 +2072,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="Credential" type="CredentialStruct">
+      <field fieldId="0" name="Credential" type="CredentialStruct">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
@@ -2083,7 +2083,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="UBOLT"/>
       </mandatoryConform>
-      <field id="0" name="PINCode" type="octstr">
+      <field fieldId="0" name="PINCode" type="octstr">
         <optionalConform>
           <andTerm>
             <feature name="COTA"/>
@@ -2097,19 +2097,19 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="ALIRO"/>
       </mandatoryConform>
-      <field id="0" name="SigningKey" type="octstr">
+      <field fieldId="0" name="SigningKey" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="1" name="VerificationKey" type="octstr">
+      <field fieldId="1" name="VerificationKey" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="65"/>
       </field>
-      <field id="2" name="GroupIdentifier" type="octstr">
+      <field fieldId="2" name="GroupIdentifier" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="3" name="GroupResolvingKey" type="octstr">
+      <field fieldId="3" name="GroupResolvingKey" type="octstr">
         <mandatoryConform>
           <feature name="ALBU"/>
         </mandatoryConform>
@@ -2127,7 +2127,7 @@ Davis, CA 95616, USA
     <event id="0x00" name="DoorLockAlarm" priority="critical">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="AlarmCode" type="AlarmCodeEnum">
+      <field fieldId="0" name="AlarmCode" type="AlarmCodeEnum">
         <mandatoryConform/>
       </field>
     </event>
@@ -2136,32 +2136,32 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="DPS"/>
       </mandatoryConform>
-      <field id="0" name="DoorState" type="DoorStateEnum">
+      <field fieldId="0" name="DoorState" type="DoorStateEnum">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x02" name="LockOperation" priority="critical">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="LockOperationType" type="LockOperationTypeEnum">
+      <field fieldId="0" name="LockOperationType" type="LockOperationTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="OperationSource" type="OperationSourceEnum">
+      <field fieldId="1" name="OperationSource" type="OperationSourceEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="UserIndex" type="uint16">
+      <field fieldId="2" name="UserIndex" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="FabricIndex" type="fabric-idx">
+      <field fieldId="3" name="FabricIndex" type="fabric-idx">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="SourceNode" type="node-id">
+      <field fieldId="4" name="SourceNode" type="node-id">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="5" name="Credentials" type="list">
+      <field fieldId="5" name="Credentials" type="list">
         <entry type="CredentialStruct"/>
         <quality nullable="true"/>
         <optionalConform>
@@ -2173,28 +2173,28 @@ Davis, CA 95616, USA
     <event id="0x03" name="LockOperationError" priority="critical">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="LockOperationType" type="LockOperationTypeEnum">
+      <field fieldId="0" name="LockOperationType" type="LockOperationTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="OperationSource" type="OperationSourceEnum">
+      <field fieldId="1" name="OperationSource" type="OperationSourceEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="OperationError" type="OperationErrorEnum">
+      <field fieldId="2" name="OperationError" type="OperationErrorEnum">
         <mandatoryConform/>
       </field>
-      <field id="3" name="UserIndex" type="uint16">
+      <field fieldId="3" name="UserIndex" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="FabricIndex" type="fabric-idx">
+      <field fieldId="4" name="FabricIndex" type="fabric-idx">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="5" name="SourceNode" type="node-id">
+      <field fieldId="5" name="SourceNode" type="node-id">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="6" name="Credentials" type="list">
+      <field fieldId="6" name="Credentials" type="list">
         <entry type="CredentialStruct"/>
         <quality nullable="true"/>
         <optionalConform>
@@ -2208,31 +2208,31 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="USR"/>
       </mandatoryConform>
-      <field id="0" name="LockDataType" type="LockDataTypeEnum">
+      <field fieldId="0" name="LockDataType" type="LockDataTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="DataOperationType" type="DataOperationTypeEnum">
+      <field fieldId="1" name="DataOperationType" type="DataOperationTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="OperationSource" type="OperationSourceEnum">
+      <field fieldId="2" name="OperationSource" type="OperationSourceEnum">
         <mandatoryConform/>
         <constraint type="allowed" value="Unspecified"/>
         <constraint type="allowed" value="Keypad"/>
         <constraint type="allowed" value="Remote"/>
       </field>
-      <field id="3" name="UserIndex" type="uint16">
+      <field fieldId="3" name="UserIndex" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="FabricIndex" type="fabric-idx">
+      <field fieldId="4" name="FabricIndex" type="fabric-idx">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="5" name="SourceNode" type="node-id">
+      <field fieldId="5" name="SourceNode" type="node-id">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="6" name="DataIndex" type="uint16">
+      <field fieldId="6" name="DataIndex" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ElectricalEnergyMeasurement.xml
+++ b/zcl-builtin/matter/new-data-model/ElectricalEnergyMeasurement.xml
@@ -81,28 +81,28 @@ Davis, CA 95616, USA
   </features>
   <dataTypes>
     <struct name="CumulativeEnergyResetStruct">
-      <field id="0" name="ImportedResetTimestamp" type="epoch-s" default="null">
+      <field fieldId="0" name="ImportedResetTimestamp" type="epoch-s" default="null">
         <access read="true"/>
         <quality nullable="true"/>
         <optionalConform>
           <feature name="IMPE"/>
         </optionalConform>
       </field>
-      <field id="1" name="ExportedResetTimestamp" type="epoch-s" default="null">
+      <field fieldId="1" name="ExportedResetTimestamp" type="epoch-s" default="null">
         <access read="true"/>
         <quality nullable="true"/>
         <optionalConform>
           <feature name="EXPE"/>
         </optionalConform>
       </field>
-      <field id="2" name="ImportedResetSystime" type="systime-ms" default="null">
+      <field fieldId="2" name="ImportedResetSystime" type="systime-ms" default="null">
         <access read="true"/>
         <quality nullable="true"/>
         <optionalConform>
           <feature name="IMPE"/>
         </optionalConform>
       </field>
-      <field id="3" name="ExportedResetSystime" type="systime-ms" default="null">
+      <field fieldId="3" name="ExportedResetSystime" type="systime-ms" default="null">
         <access read="true"/>
         <quality nullable="true"/>
         <optionalConform>
@@ -111,22 +111,22 @@ Davis, CA 95616, USA
       </field>
     </struct>
     <struct name="EnergyMeasurementStruct">
-      <field id="0" name="Energy" type="energy-mWh">
+      <field fieldId="0" name="Energy" type="energy-mWh">
         <access read="true"/>
         <mandatoryConform/>
         <constraint type="between" from="0" to="2"/>
       </field>
-      <field id="1" name="StartTimestamp" type="epoch-s">
+      <field fieldId="1" name="StartTimestamp" type="epoch-s">
         <access read="true"/>
       </field>
-      <field id="2" name="EndTimestamp" type="epoch-s">
+      <field fieldId="2" name="EndTimestamp" type="epoch-s">
         <access read="true"/>
         <constraint type="min" value="StartTimestamp+1"/>
       </field>
-      <field id="3" name="StartSystime" type="systime-ms">
+      <field fieldId="3" name="StartSystime" type="systime-ms">
         <access read="true"/>
       </field>
-      <field id="4" name="EndSystime" type="systime-ms">
+      <field fieldId="4" name="EndSystime" type="systime-ms">
         <access read="true"/>
         <constraint type="min" value="StartSystime+1"/>
       </field>
@@ -192,7 +192,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CUME"/>
       </mandatoryConform>
-      <field id="0" name="EnergyImported" type="EnergyMeasurementStruct">
+      <field fieldId="0" name="EnergyImported" type="EnergyMeasurementStruct">
         <mandatoryConform>
           <andTerm>
             <feature name="CUME"/>
@@ -200,7 +200,7 @@ Davis, CA 95616, USA
           </andTerm>
         </mandatoryConform>
       </field>
-      <field id="1" name="EnergyExported" type="EnergyMeasurementStruct">
+      <field fieldId="1" name="EnergyExported" type="EnergyMeasurementStruct">
         <mandatoryConform>
           <andTerm>
             <feature name="CUME"/>
@@ -214,7 +214,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PERE"/>
       </mandatoryConform>
-      <field id="0" name="EnergyImported" type="EnergyMeasurementStruct">
+      <field fieldId="0" name="EnergyImported" type="EnergyMeasurementStruct">
         <mandatoryConform>
           <andTerm>
             <feature name="PERE"/>
@@ -222,7 +222,7 @@ Davis, CA 95616, USA
           </andTerm>
         </mandatoryConform>
       </field>
-      <field id="1" name="EnergyExported" type="EnergyMeasurementStruct">
+      <field fieldId="1" name="EnergyExported" type="EnergyMeasurementStruct">
         <mandatoryConform>
           <andTerm>
             <feature name="PERE"/>

--- a/zcl-builtin/matter/new-data-model/ElectricalPowerMeasurement.xml
+++ b/zcl-builtin/matter/new-data-model/ElectricalPowerMeasurement.xml
@@ -101,61 +101,61 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="HarmonicMeasurementStruct">
-      <field id="0" name="Order" type="uint8" default="1">
+      <field fieldId="0" name="Order" type="uint8" default="1">
         <mandatoryConform/>
         <constraint type="min" value="1"/>
       </field>
-      <field id="1" name="Measurement" type="int64" default="null">
+      <field fieldId="1" name="Measurement" type="int64" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="-2" to="2"/>
       </field>
     </struct>
     <struct name="MeasurementRangeStruct">
-      <field id="0" name="MeasurementType" type="ref_MeasurementTypeEnum">
+      <field fieldId="0" name="MeasurementType" type="ref_MeasurementTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Min" type="int64">
-        <mandatoryConform/>
-        <constraint type="between" from="-2" to="2"/>
-      </field>
-      <field id="2" name="Max" type="int64">
+      <field fieldId="1" name="Min" type="int64">
         <mandatoryConform/>
         <constraint type="between" from="-2" to="2"/>
       </field>
-      <field id="3" name="StartTimestamp" type="epoch-s">
+      <field fieldId="2" name="Max" type="int64">
+        <mandatoryConform/>
+        <constraint type="between" from="-2" to="2"/>
+      </field>
+      <field fieldId="3" name="StartTimestamp" type="epoch-s">
         <mandatoryConform>
           <attribute name="EndTimestamp"/>
         </mandatoryConform>
       </field>
-      <field id="4" name="EndTimestamp" type="epoch-s">
+      <field fieldId="4" name="EndTimestamp" type="epoch-s">
         <constraint type="min" value="StartTimestamp+1"/>
       </field>
-      <field id="5" name="MinTimestamp" type="epoch-s">
+      <field fieldId="5" name="MinTimestamp" type="epoch-s">
         <mandatoryConform>
           <attribute name="EndTimestamp"/>
         </mandatoryConform>
       </field>
-      <field id="6" name="MaxTimestamp" type="epoch-s">
+      <field fieldId="6" name="MaxTimestamp" type="epoch-s">
         <mandatoryConform>
           <attribute name="EndTimestamp"/>
         </mandatoryConform>
         <constraint type="min" value="MinTimestamp+1"/>
       </field>
-      <field id="7" name="StartSystime" type="systime-ms">
+      <field fieldId="7" name="StartSystime" type="systime-ms">
         <mandatoryConform>
           <attribute name="EndSystime"/>
         </mandatoryConform>
       </field>
-      <field id="8" name="EndSystime" type="systime-ms">
+      <field fieldId="8" name="EndSystime" type="systime-ms">
         <constraint type="min" value="StartSystime+1"/>
       </field>
-      <field id="9" name="MinSystime" type="systime-ms">
+      <field fieldId="9" name="MinSystime" type="systime-ms">
         <mandatoryConform>
           <attribute name="EndSystime"/>
         </mandatoryConform>
       </field>
-      <field id="10" name="MaxSystime" type="systime-ms">
+      <field fieldId="10" name="MaxSystime" type="systime-ms">
         <mandatoryConform>
           <attribute name="EndSystime"/>
         </mandatoryConform>
@@ -308,7 +308,7 @@ Davis, CA 95616, USA
   <events>
     <event id="0x00" name="MeasurementPeriodRanges" priority="info">
       <access readPrivilege="view"/>
-      <field id="0" name="Ranges" type="list" default="R V">
+      <field fieldId="0" name="Ranges" type="list" default="R V">
         <entry type="MeasurementRangeStruct"/>
         <mandatoryConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/EnergyCalendar.xml
+++ b/zcl-builtin/matter/new-data-model/EnergyCalendar.xml
@@ -157,60 +157,60 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="CalendarPeriod">
-      <field id="0" name="StartDate" type="epoch-s">
+      <field fieldId="0" name="StartDate" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Days" type="list">
+      <field fieldId="1" name="Days" type="list">
         <entry type="DayStruct"/>
         <mandatoryConform/>
         <constraint type="minCount" value="1"/>
       </field>
     </struct>
     <struct name="DayStruct">
-      <field id="0" name="Date" type="epoch-s">
+      <field fieldId="0" name="Date" type="epoch-s">
         <optionalConform choice="a"/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="DaysOfWeek" type="TransitionDayOfWeekBitmap">
+      <field fieldId="1" name="DaysOfWeek" type="TransitionDayOfWeekBitmap">
         <optionalConform choice="a"/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Transitions" type="list">
+      <field fieldId="2" name="Transitions" type="list">
         <entry type="TransitionStruct"/>
         <mandatoryConform/>
         <constraint type="minCount" value="1"/>
       </field>
     </struct>
     <struct name="PeakPeriodStatusStruct">
-      <field id="0" name="CurrentDaySeverity" type="PeakPeriodSeverityEnum">
+      <field fieldId="0" name="CurrentDaySeverity" type="PeakPeriodSeverityEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="NextDaySeverity" type="PeakPeriodSeverityEnum">
+      <field fieldId="1" name="NextDaySeverity" type="PeakPeriodSeverityEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="PeakPeriod" type="uint16">
+      <field fieldId="2" name="PeakPeriod" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="3" name="PeakPeriodPriorNotice" type="uint16">
+      <field fieldId="3" name="PeakPeriodPriorNotice" type="uint16">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="TransitionStruct">
-      <field id="0" name="TransitionTime" type="uint16">
+      <field fieldId="0" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="1439"/>
       </field>
-      <field id="1" name="PriceTier" type="uint32">
+      <field fieldId="1" name="PriceTier" type="uint32">
         <optionalConform choice="a" more="true">
           <feature name="PTIER"/>
         </optionalConform>
       </field>
-      <field id="2" name="FriendlyCredit" type="bool">
+      <field fieldId="2" name="FriendlyCredit" type="bool">
         <optionalConform choice="a" more="true">
           <feature name="FCRED"/>
         </optionalConform>
       </field>
-      <field id="3" name="AuxiliaryLoad" type="AuxiliaryLoadBitmap">
+      <field fieldId="3" name="AuxiliaryLoad" type="AuxiliaryLoadBitmap">
         <optionalConform choice="a" more="true">
           <feature name="AUXLD"/>
         </optionalConform>

--- a/zcl-builtin/matter/new-data-model/EnergyEVSE.xml
+++ b/zcl-builtin/matter/new-data-model/EnergyEVSE.xml
@@ -220,22 +220,22 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="ChargingTargetScheduleStruct">
-      <field id="0" name="DayOfWeekForSequence" type="TargetDayOfWeekBitmap">
+      <field fieldId="0" name="DayOfWeekForSequence" type="TargetDayOfWeekBitmap">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="ChargingTargets" type="list">
+      <field fieldId="1" name="ChargingTargets" type="list">
         <entry type="ChargingTargetStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="10"/>
       </field>
     </struct>
     <struct name="ChargingTargetStruct">
-      <field id="0" name="TargetTimeMinutesPastMidnight" type="uint16" default="0">
+      <field fieldId="0" name="TargetTimeMinutesPastMidnight" type="uint16" default="0">
         <mandatoryConform/>
         <constraint type="between" from="0" to="1439"/>
       </field>
-      <field id="1" name="TargetSoC" type="percent" default="0">
+      <field fieldId="1" name="TargetSoC" type="percent" default="0">
         <otherwiseConform>
           <mandatoryConform>
             <feature name="SOC"/>
@@ -243,7 +243,7 @@ Davis, CA 95616, USA
           <optionalConform choice="a" more="true"/>
         </otherwiseConform>
       </field>
-      <field id="2" name="AddedEnergy" type="energy-mWh" default="0">
+      <field fieldId="2" name="AddedEnergy" type="energy-mWh" default="0">
         <optionalConform choice="a" more="true"/>
         <constraint type="min" value="0"/>
       </field>
@@ -403,7 +403,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PREF"/>
       </mandatoryConform>
-      <field id="0" name="ChargingTargetSchedules" type="list">
+      <field fieldId="0" name="ChargingTargetSchedules" type="list">
         <entry type="ChargingTargetScheduleStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="7"/>
@@ -416,15 +416,15 @@ Davis, CA 95616, USA
     <command id="0x02" name="EnableCharging" direction="commandToServer" response="Y">
       <access invokePrivilege="operate" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="ChargingEnabledUntil" type="epoch-s" default="null">
+      <field fieldId="0" name="ChargingEnabledUntil" type="epoch-s" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="MinimumChargeCurrent" type="amperage-mA">
+      <field fieldId="1" name="MinimumChargeCurrent" type="amperage-mA">
         <mandatoryConform/>
         <constraint type="min" value="0"/>
       </field>
-      <field id="2" name="MaximumChargeCurrent" type="amperage-mA">
+      <field fieldId="2" name="MaximumChargeCurrent" type="amperage-mA">
         <mandatoryConform/>
         <constraint type="min" value="0"/>
       </field>
@@ -434,11 +434,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="V2X"/>
       </mandatoryConform>
-      <field id="0" name="DischargingEnabledUntil" type="epoch-s" default="null">
+      <field fieldId="0" name="DischargingEnabledUntil" type="epoch-s" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="MaximumDischargeCurrent" type="amperage-mA">
+      <field fieldId="1" name="MaximumDischargeCurrent" type="amperage-mA">
         <mandatoryConform/>
         <constraint type="min" value="0"/>
       </field>
@@ -452,7 +452,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PREF"/>
       </mandatoryConform>
-      <field id="0" name="ChargingTargetSchedules" type="list">
+      <field fieldId="0" name="ChargingTargetSchedules" type="list">
         <entry type="ChargingTargetScheduleStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="7"/>
@@ -475,27 +475,27 @@ Davis, CA 95616, USA
     <event id="0x00" name="EVConnected" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="SessionID" type="uint32">
+      <field fieldId="0" name="SessionID" type="uint32">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x01" name="EVNotDetected" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="SessionID" type="uint32">
+      <field fieldId="0" name="SessionID" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="1" name="State" type="StateEnum">
+      <field fieldId="1" name="State" type="StateEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SessionDuration" type="elapsed-s">
+      <field fieldId="2" name="SessionDuration" type="elapsed-s">
         <mandatoryConform/>
       </field>
-      <field id="3" name="SessionEnergyCharged" type="energy-mWh">
+      <field fieldId="3" name="SessionEnergyCharged" type="energy-mWh">
         <mandatoryConform/>
         <constraint type="min" value="0"/>
       </field>
-      <field id="4" name="SessionEnergyDischarged" type="energy-mWh">
+      <field fieldId="4" name="SessionEnergyDischarged" type="energy-mWh">
         <mandatoryConform>
           <feature name="V2X"/>
         </mandatoryConform>
@@ -505,13 +505,13 @@ Davis, CA 95616, USA
     <event id="0x02" name="EnergyTransferStarted" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="SessionID" type="uint32">
+      <field fieldId="0" name="SessionID" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="1" name="State" type="StateEnum">
+      <field fieldId="1" name="State" type="StateEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="MaximumCurrent" type="amperage-mA">
+      <field fieldId="2" name="MaximumCurrent" type="amperage-mA">
         <mandatoryConform/>
         <constraint type="min" value="0"/>
       </field>
@@ -519,16 +519,16 @@ Davis, CA 95616, USA
     <event id="0x03" name="EnergyTransferStopped" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="SessionID" type="uint32">
+      <field fieldId="0" name="SessionID" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="1" name="State" type="StateEnum">
+      <field fieldId="1" name="State" type="StateEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Reason" type="EnergyTransferStoppedReasonEnum">
+      <field fieldId="2" name="Reason" type="EnergyTransferStoppedReasonEnum">
         <mandatoryConform/>
       </field>
-      <field id="4" name="EnergyTransferred" type="energy-mWh">
+      <field fieldId="4" name="EnergyTransferred" type="energy-mWh">
         <mandatoryConform/>
         <constraint type="min" value="0"/>
       </field>
@@ -536,17 +536,17 @@ Davis, CA 95616, USA
     <event id="0x04" name="Fault" priority="critical">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="SessionID" type="uint32">
+      <field fieldId="0" name="SessionID" type="uint32">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="State" type="StateEnum">
+      <field fieldId="1" name="State" type="StateEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="FaultStatePreviousState" type="FaultStateEnum">
+      <field fieldId="2" name="FaultStatePreviousState" type="FaultStateEnum">
         <mandatoryConform/>
       </field>
-      <field id="4" name="FaultStateCurrentState" type="FaultStateEnum">
+      <field fieldId="4" name="FaultStateCurrentState" type="FaultStateEnum">
         <mandatoryConform/>
       </field>
     </event>
@@ -555,7 +555,7 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="RFID"/>
       </optionalConform>
-      <field id="0" name="UID" type="octstr">
+      <field fieldId="0" name="UID" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="10"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/EnergyPreference.xml
+++ b/zcl-builtin/matter/new-data-model/EnergyPreference.xml
@@ -89,10 +89,10 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="BalanceStruct">
-      <field id="0" name="Step" type="percent" default="MS">
+      <field fieldId="0" name="Step" type="percent" default="MS">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Label" type="string">
+      <field fieldId="1" name="Label" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="64"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/EnergyPrice.xml
+++ b/zcl-builtin/matter/new-data-model/EnergyPrice.xml
@@ -117,41 +117,41 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="PriceComponentStruct">
-      <field id="0" name="Price" type="int32">
+      <field fieldId="0" name="Price" type="int32">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Source" type="PriceComponentSourceEnum" default="Tariff">
+      <field fieldId="1" name="Source" type="PriceComponentSourceEnum" default="Tariff">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Description" type="string">
+      <field fieldId="2" name="Description" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="32 chars"/>
       </field>
       <access fabricScoped="true"/>
     </struct>
     <struct name="PriceStruct">
-      <field id="0" name="PeriodStart" type="epoch-s">
+      <field fieldId="0" name="PeriodStart" type="epoch-s">
         <mandatoryConform/>
       </field>
-      <field id="1" name="PeriodEnd" type="epoch-s" default="null">
+      <field fieldId="1" name="PeriodEnd" type="epoch-s" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="Price" type="int32">
+      <field fieldId="2" name="Price" type="int32">
         <mandatoryConform/>
       </field>
-      <field id="3" name="DecimalPoints" type="uint8" default="0">
+      <field fieldId="3" name="DecimalPoints" type="uint8" default="0">
         <mandatoryConform/>
       </field>
-      <field id="4" name="Currency" type="uint16">
+      <field fieldId="4" name="Currency" type="uint16">
         <mandatoryConform/>
         <constraint type="max" value="999"/>
       </field>
-      <field id="5" name="Description" type="string">
+      <field fieldId="5" name="Description" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="6" name="Components" type="list" default="empty">
+      <field fieldId="6" name="Components" type="list" default="empty">
         <entry type="PriceComponentStruct"/>
         <optionalConform/>
         <constraint type="maxCount" value="10"/>
@@ -181,14 +181,14 @@ Davis, CA 95616, USA
     <command id="0x00" name="GetDetailedPriceRequest" direction="commandToServer" response="GetDetailedPriceResponse">
       <access invokePrivilege="operate"/>
       <optionalConform/>
-      <field id="0" name="Details" type="PriceDetailBitmap" default="0">
+      <field fieldId="0" name="Details" type="PriceDetailBitmap" default="0">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x01" name="GetDetailedPriceResponse" direction="responseFromServer">
       <access invokePrivilege="operate"/>
       <optionalConform/>
-      <field id="0" name="Price" type="PriceStruct" default="null">
+      <field fieldId="0" name="Price" type="PriceStruct" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -198,7 +198,7 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="FORE"/>
       </optionalConform>
-      <field id="0" name="Details" type="PriceDetailBitmap" default="0">
+      <field fieldId="0" name="Details" type="PriceDetailBitmap" default="0">
         <mandatoryConform/>
       </field>
     </command>
@@ -207,7 +207,7 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="FORE"/>
       </optionalConform>
-      <field id="0" name="Price" type="list" default="empty">
+      <field fieldId="0" name="Price" type="list" default="empty">
         <entry type="PriceStruct"/>
         <mandatoryConform/>
       </field>
@@ -217,14 +217,14 @@ Davis, CA 95616, USA
     <event id="0x00" name="PriceChange" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="Price" type="PriceStruct">
+      <field fieldId="0" name="Price" type="PriceStruct">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x01" name="ForecastChange" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="Forecast" type="list">
+      <field fieldId="0" name="Forecast" type="list">
         <entry type="PriceStruct"/>
         <mandatoryConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/FanControl.xml
+++ b/zcl-builtin/matter/new-data-model/FanControl.xml
@@ -287,13 +287,13 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="STEP"/>
       </mandatoryConform>
-      <field id="0" name="Direction" type="StepDirectionEnum" default="Increase">
+      <field fieldId="0" name="Direction" type="StepDirectionEnum" default="Increase">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Wrap" type="bool" default="false">
+      <field fieldId="1" name="Wrap" type="bool" default="false">
         <optionalConform/>
       </field>
-      <field id="2" name="LowestOff" type="bool" default="true">
+      <field fieldId="2" name="LowestOff" type="bool" default="true">
         <optionalConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/GeneralCommissioningCluster.xml
+++ b/zcl-builtin/matter/new-data-model/GeneralCommissioningCluster.xml
@@ -93,10 +93,10 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="BasicCommissioningInfo">
-      <field id="0" name="FailSafeExpiryLengthSeconds" type="uint16">
+      <field fieldId="0" name="FailSafeExpiryLengthSeconds" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="MaxCumulativeFailsafeSeconds" type="uint16">
+      <field fieldId="1" name="MaxCumulativeFailsafeSeconds" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Group-Key-Management-Cluster.xml
+++ b/zcl-builtin/matter/new-data-model/Group-Key-Management-Cluster.xml
@@ -89,72 +89,72 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="GroupInfoMapStruct">
-      <field id="1" name="GroupId" type="group-id">
+      <field fieldId="1" name="GroupId" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Endpoints" type="list">
+      <field fieldId="2" name="Endpoints" type="list">
         <entry type="endpoint-no"/>
         <mandatoryConform/>
         <constraint type="minCount" value="1"/>
       </field>
-      <field id="3" name="GroupName" type="string">
+      <field fieldId="3" name="GroupName" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="16"/>
       </field>
       <access fabricScoped="true"/>
     </struct>
     <struct name="GroupKeyMapStruct">
-      <field id="1" name="GroupId" type="group-id">
+      <field fieldId="1" name="GroupId" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="GroupKeySetID" type="uint16">
+      <field fieldId="2" name="GroupKeySetID" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="65535"/>
       </field>
       <access fabricScoped="true"/>
     </struct>
     <struct name="GroupKeySetStruct">
-      <field id="0" name="GroupKeySetID" type="uint16">
+      <field fieldId="0" name="GroupKeySetID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="GroupKeySecurityPolicy" type="GroupKeySecurityPolicyEnum">
+      <field fieldId="1" name="GroupKeySecurityPolicy" type="GroupKeySecurityPolicyEnum">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="EpochKey0" type="octstr">
-        <access fabricSensitive="true"/>
-        <quality nullable="true"/>
-        <mandatoryConform/>
-        <constraint type="maxLength" value="16"/>
-      </field>
-      <field id="3" name="EpochStartTime0" type="epoch-us">
-        <access fabricSensitive="true"/>
-        <quality nullable="true"/>
-        <mandatoryConform/>
-      </field>
-      <field id="4" name="EpochKey1" type="octstr">
+      <field fieldId="2" name="EpochKey0" type="octstr">
         <access fabricSensitive="true"/>
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="5" name="EpochStartTime1" type="epoch-us">
+      <field fieldId="3" name="EpochStartTime0" type="epoch-us">
         <access fabricSensitive="true"/>
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="6" name="EpochKey2" type="octstr">
+      <field fieldId="4" name="EpochKey1" type="octstr">
         <access fabricSensitive="true"/>
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="7" name="EpochStartTime2" type="epoch-us">
+      <field fieldId="5" name="EpochStartTime1" type="epoch-us">
         <access fabricSensitive="true"/>
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="8" name="GroupKeyMulticastPolicy" type="GroupKeyMulticastPolicyEnum">
+      <field fieldId="6" name="EpochKey2" type="octstr">
+        <access fabricSensitive="true"/>
+        <quality nullable="true"/>
+        <mandatoryConform/>
+        <constraint type="maxLength" value="16"/>
+      </field>
+      <field fieldId="7" name="EpochStartTime2" type="epoch-us">
+        <access fabricSensitive="true"/>
+        <quality nullable="true"/>
+        <mandatoryConform/>
+      </field>
+      <field fieldId="8" name="GroupKeyMulticastPolicy" type="GroupKeyMulticastPolicyEnum">
         <access fabricSensitive="true"/>
         <otherwiseConform>
           <provisionalConform/>
@@ -193,40 +193,40 @@ Davis, CA 95616, USA
     <command id="0x00" name="KeySetWrite Command" direction="commandToServer" response="Y">
       <access invokePrivilege="admin" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupKeySet" type="GroupKeySetStruct">
+      <field fieldId="0" name="GroupKeySet" type="GroupKeySetStruct">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x01" name="KeySetRead Command" direction="commandToServer" response="KeySetReadResponse Command">
       <access invokePrivilege="admin" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupKeySetID" type="uint16">
+      <field fieldId="0" name="GroupKeySetID" type="uint16">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x02" name="KeySetReadResponse Command" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="GroupKeySet" type="GroupKeySetStruct">
+      <field fieldId="0" name="GroupKeySet" type="GroupKeySetStruct">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x03" name="KeySetRemove Command" direction="commandToServer" response="Y">
       <access invokePrivilege="admin" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupKeySetID" type="uint16">
+      <field fieldId="0" name="GroupKeySetID" type="uint16">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x04" name="KeySetReadAllIndices Command" direction="commandToServer" response="KeySetReadAllIndicesResponse Command">
       <access invokePrivilege="admin" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="reserved">
+      <field fieldId="0" name="reserved">
         <disallowConform/>
       </field>
     </command>
     <command id="0x05" name="KeySetReadAllIndicesResponse Command" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="GroupKeySetIDs" type="list">
+      <field fieldId="0" name="GroupKeySetIDs" type="list">
         <entry type="uint16"/>
         <mandatoryConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Groups.xml
+++ b/zcl-builtin/matter/new-data-model/Groups.xml
@@ -92,22 +92,22 @@ Davis, CA 95616, USA
     <command id="0x00" name="AddGroup" direction="commandToServer" response="AddGroupResponse">
       <access invokePrivilege="manage" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
         <constraint type="min" value="1"/>
       </field>
-      <field id="1" name="GroupName" type="string">
+      <field fieldId="1" name="GroupName" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
     </command>
     <command id="0x00" name="AddGroupResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="enum8">
+      <field fieldId="0" name="Status" type="enum8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupID" type="group-id">
+      <field fieldId="1" name="GroupID" type="group-id">
         <mandatoryConform/>
         <constraint type="min" value="1"/>
       </field>
@@ -115,22 +115,22 @@ Davis, CA 95616, USA
     <command id="0x01" name="ViewGroup" direction="commandToServer" response="ViewGroupResponse">
       <access invokePrivilege="operate" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
         <constraint type="min" value="1"/>
       </field>
     </command>
     <command id="0x01" name="ViewGroupResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="enum8">
+      <field fieldId="0" name="Status" type="enum8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupID" type="group-id">
+      <field fieldId="1" name="GroupID" type="group-id">
         <mandatoryConform/>
         <constraint type="min" value="1"/>
       </field>
-      <field id="2" name="GroupName" type="string">
+      <field fieldId="2" name="GroupName" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
@@ -138,7 +138,7 @@ Davis, CA 95616, USA
     <command id="0x02" name="GetGroupMembership" direction="commandToServer" response="GetGroupMembershipResponse">
       <access invokePrivilege="operate" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupList" type="list">
+      <field fieldId="0" name="GroupList" type="list">
         <entry type="group-id">
           <constraint type="min" value="1"/>
         </entry>
@@ -147,11 +147,11 @@ Davis, CA 95616, USA
     </command>
     <command id="0x02" name="GetGroupMembershipResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Capacity" type="uint8">
+      <field fieldId="0" name="Capacity" type="uint8">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="GroupList" type="list">
+      <field fieldId="1" name="GroupList" type="list">
         <entry type="group-id">
           <constraint type="min" value="1"/>
         </entry>
@@ -161,18 +161,18 @@ Davis, CA 95616, USA
     <command id="0x03" name="RemoveGroup" direction="commandToServer" response="RemoveGroupResponse">
       <access invokePrivilege="manage" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
         <constraint type="min" value="1"/>
       </field>
     </command>
     <command id="0x03" name="RemoveGroupResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="enum8">
+      <field fieldId="0" name="Status" type="enum8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupID" type="group-id">
+      <field fieldId="1" name="GroupID" type="group-id">
         <mandatoryConform/>
         <constraint type="min" value="1"/>
       </field>
@@ -184,11 +184,11 @@ Davis, CA 95616, USA
     <command id="0x05" name="AddGroupIfIdentifying" direction="commandToServer" response="Y">
       <access invokePrivilege="manage" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
         <constraint type="min" value="1"/>
       </field>
-      <field id="1" name="GroupName" type="string">
+      <field fieldId="1" name="GroupName" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ICDManagement.xml
+++ b/zcl-builtin/matter/new-data-model/ICDManagement.xml
@@ -98,15 +98,15 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="MonitoringRegistrationStruct">
-      <field id="1" name="CheckInNodeID" type="node-id">
+      <field fieldId="1" name="CheckInNodeID" type="node-id">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="MonitoredSubject" type="subject-id">
+      <field fieldId="2" name="MonitoredSubject" type="subject-id">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="Key">
+      <field fieldId="3" name="Key">
         <deprecateConform/>
       </field>
       <access fabricScoped="true"/>
@@ -179,17 +179,17 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CIP"/>
       </mandatoryConform>
-      <field id="0" name="CheckInNodeID" type="node-id">
+      <field fieldId="0" name="CheckInNodeID" type="node-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="MonitoredSubject" type="subject-id">
+      <field fieldId="1" name="MonitoredSubject" type="subject-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Key" type="octstr">
+      <field fieldId="2" name="Key" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="3" name="VerificationKey" type="octstr">
+      <field fieldId="3" name="VerificationKey" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="16"/>
       </field>
@@ -198,7 +198,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CIP"/>
       </mandatoryConform>
-      <field id="0" name="ICDCounter" type="uint32">
+      <field fieldId="0" name="ICDCounter" type="uint32">
         <mandatoryConform/>
       </field>
     </command>
@@ -207,10 +207,10 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CIP"/>
       </mandatoryConform>
-      <field id="0" name="CheckInNodeID" type="node-id">
+      <field fieldId="0" name="CheckInNodeID" type="node-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="VerificationKey" type="octstr">
+      <field fieldId="1" name="VerificationKey" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="16"/>
       </field>
@@ -223,7 +223,7 @@ Davis, CA 95616, USA
         </mandatoryConform>
         <optionalConform/>
       </otherwiseConform>
-      <field id="0" name="StayActiveDuration" type="uint32">
+      <field fieldId="0" name="StayActiveDuration" type="uint32">
         <mandatoryConform/>
       </field>
     </command>
@@ -234,7 +234,7 @@ Davis, CA 95616, USA
         </mandatoryConform>
         <optionalConform/>
       </otherwiseConform>
-      <field id="0" name="PromisedActiveDuration" type="uint32">
+      <field fieldId="0" name="PromisedActiveDuration" type="uint32">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Identify.xml
+++ b/zcl-builtin/matter/new-data-model/Identify.xml
@@ -135,18 +135,18 @@ Davis, CA 95616, USA
     <command id="0x00" name="Identify" direction="commandToServer" response="Y">
       <access invokePrivilege="manage"/>
       <mandatoryConform/>
-      <field id="0" name="IdentifyTime" type="uint16">
+      <field fieldId="0" name="IdentifyTime" type="uint16">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x40" name="TriggerEffect" direction="commandToServer" response="Y">
       <access invokePrivilege="manage"/>
       <optionalConform/>
-      <field id="0" name="EffectIdentifier" type="EffectIdentifierEnum">
+      <field fieldId="0" name="EffectIdentifier" type="EffectIdentifierEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="EffectVariant" type="EffectVariantEnum">
+      <field fieldId="1" name="EffectVariant" type="EffectVariantEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/KeypadInput.xml
+++ b/zcl-builtin/matter/new-data-model/KeypadInput.xml
@@ -353,13 +353,13 @@ Davis, CA 95616, USA
     <command id="0x00" name="SendKey" direction="commandToServer" response="SendKeyResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="KeyCode" type="CecKeyCodeEnum">
+      <field fieldId="0" name="KeyCode" type="CecKeyCodeEnum">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x01" name="SendKeyResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="StatusEnum">
+      <field fieldId="0" name="Status" type="StatusEnum">
         <mandatoryConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/Label-Cluster-LabelCluster.xml
+++ b/zcl-builtin/matter/new-data-model/Label-Cluster-LabelCluster.xml
@@ -67,11 +67,11 @@ Davis, CA 95616, USA
   <classification hierarchy="base" role="utility" picsCode="LABEL" scope="Endpoint"/>
   <dataTypes>
     <struct name="LabelStruct">
-      <field id="0" name="Label" type="string" default="empty">
+      <field fieldId="0" name="Label" type="string" default="empty">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="Value" type="string" default="empty">
+      <field fieldId="1" name="Value" type="string" default="empty">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/LevelControl.xml
+++ b/zcl-builtin/matter/new-data-model/LevelControl.xml
@@ -216,19 +216,19 @@ Davis, CA 95616, USA
     <command id="0x00" name="MoveToLevel" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Level" type="uint8">
+      <field fieldId="0" name="Level" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="254"/>
       </field>
-      <field id="1" name="TransitionTime" type="uint16">
+      <field fieldId="1" name="TransitionTime" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="OptionsMask" type="OptionsBitmap" default="0">
+      <field fieldId="2" name="OptionsMask" type="OptionsBitmap" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="OptionsOverride" type="OptionsBitmap" default="0">
+      <field fieldId="3" name="OptionsOverride" type="OptionsBitmap" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -236,19 +236,19 @@ Davis, CA 95616, USA
     <command id="0x01" name="Move" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="MoveMode" type="MoveModeEnum">
+      <field fieldId="0" name="MoveMode" type="MoveModeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Rate" type="uint8">
+      <field fieldId="1" name="Rate" type="uint8">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="OptionsMask" type="OptionsBitmap" default="0">
+      <field fieldId="2" name="OptionsMask" type="OptionsBitmap" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="OptionsOverride" type="OptionsBitmap" default="0">
+      <field fieldId="3" name="OptionsOverride" type="OptionsBitmap" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -256,22 +256,22 @@ Davis, CA 95616, USA
     <command id="0x02" name="Step" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="StepMode" type="StepModeEnum">
+      <field fieldId="0" name="StepMode" type="StepModeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="StepSize" type="uint8">
+      <field fieldId="1" name="StepSize" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16">
+      <field fieldId="2" name="TransitionTime" type="uint16">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="OptionsMask" type="OptionsBitmap" default="0">
+      <field fieldId="3" name="OptionsMask" type="OptionsBitmap" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="OptionsOverride" type="OptionsBitmap" default="0">
+      <field fieldId="4" name="OptionsOverride" type="OptionsBitmap" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -279,11 +279,11 @@ Davis, CA 95616, USA
     <command id="0x03" name="Stop" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="OptionsMask" type="OptionsBitmap" default="0">
+      <field fieldId="0" name="OptionsMask" type="OptionsBitmap" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="OptionsOverride" type="OptionsBitmap" default="0">
+      <field fieldId="1" name="OptionsOverride" type="OptionsBitmap" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -309,7 +309,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="FQ"/>
       </mandatoryConform>
-      <field id="0" name="Frequency" type="uint16" default="0">
+      <field fieldId="0" name="Frequency" type="uint16" default="0">
         <mandatoryConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/MediaInput.xml
+++ b/zcl-builtin/matter/new-data-model/MediaInput.xml
@@ -110,17 +110,17 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="InputInfoStruct">
-      <field id="0" name="Index" type="uint8">
+      <field fieldId="0" name="Index" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InputType" type="InputTypeEnum">
+      <field fieldId="1" name="InputType" type="InputTypeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Name" type="string">
+      <field fieldId="2" name="Name" type="string">
         <mandatoryConform/>
       </field>
-      <field id="3" name="Description" type="string">
+      <field fieldId="3" name="Description" type="string">
         <mandatoryConform/>
       </field>
     </struct>
@@ -140,7 +140,7 @@ Davis, CA 95616, USA
     <command id="0x00" name="SelectInput" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Index" type="uint8">
+      <field fieldId="0" name="Index" type="uint8">
         <mandatoryConform/>
       </field>
     </command>
@@ -157,10 +157,10 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="NU"/>
       </mandatoryConform>
-      <field id="0" name="Index" type="uint8">
+      <field fieldId="0" name="Index" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Name" type="string">
+      <field fieldId="1" name="Name" type="string">
         <mandatoryConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/MediaPlayback.xml
+++ b/zcl-builtin/matter/new-data-model/MediaPlayback.xml
@@ -181,35 +181,35 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="PlaybackPositionStruct">
-      <field id="0" name="UpdatedAt" type="epoch-us">
+      <field fieldId="0" name="UpdatedAt" type="epoch-us">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Position" type="uint64">
+      <field fieldId="1" name="Position" type="uint64">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="TrackAttributesStruct">
-      <field id="0" name="LanguageCode" type="string">
+      <field fieldId="0" name="LanguageCode" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="1" name="Characteristics" type="list" default="null">
+      <field fieldId="1" name="Characteristics" type="list" default="null">
         <entry type="CharacteristicEnum"/>
         <quality nullable="true"/>
         <optionalConform/>
       </field>
-      <field id="2" name="DisplayName" type="string" default="null">
+      <field fieldId="2" name="DisplayName" type="string" default="null">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
     </struct>
     <struct name="TrackStruct">
-      <field id="0" name="ID" type="string">
+      <field fieldId="0" name="ID" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="1" name="TrackAttributes" type="TrackAttributesStruct">
+      <field fieldId="1" name="TrackAttributes" type="TrackAttributesStruct">
         <mandatoryConform/>
       </field>
     </struct>
@@ -332,7 +332,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="VS"/>
       </mandatoryConform>
-      <field id="0" name="AudioAdvanceUnmuted" type="bool" default="false">
+      <field fieldId="0" name="AudioAdvanceUnmuted" type="bool" default="false">
         <mandatoryConform>
           <feature name="AA"/>
         </mandatoryConform>
@@ -343,7 +343,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="VS"/>
       </mandatoryConform>
-      <field id="0" name="AudioAdvanceUnmuted" type="bool" default="false">
+      <field fieldId="0" name="AudioAdvanceUnmuted" type="bool" default="false">
         <mandatoryConform>
           <feature name="AA"/>
         </mandatoryConform>
@@ -352,24 +352,24 @@ Davis, CA 95616, USA
     <command id="0x08" name="SkipForward" direction="commandToServer" response="PlaybackResponse">
       <access invokePrivilege="operate"/>
       <optionalConform/>
-      <field id="0" name="DeltaPositionMilliseconds" type="uint64">
+      <field fieldId="0" name="DeltaPositionMilliseconds" type="uint64">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x09" name="SkipBackward" direction="commandToServer" response="PlaybackResponse">
       <access invokePrivilege="operate"/>
       <optionalConform/>
-      <field id="0" name="DeltaPositionMilliseconds" type="uint64">
+      <field fieldId="0" name="DeltaPositionMilliseconds" type="uint64">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x0A" name="PlaybackResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="StatusEnum">
+      <field fieldId="0" name="Status" type="StatusEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Data" type="string">
+      <field fieldId="1" name="Data" type="string">
         <optionalConform/>
       </field>
     </command>
@@ -378,7 +378,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="AS"/>
       </mandatoryConform>
-      <field id="0" name="Position" type="uint64">
+      <field fieldId="0" name="Position" type="uint64">
         <mandatoryConform/>
       </field>
     </command>
@@ -387,11 +387,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="AT"/>
       </mandatoryConform>
-      <field id="0" name="TrackID" type="string">
+      <field fieldId="0" name="TrackID" type="string">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="AudioOutputIndex" type="uint8">
+      <field fieldId="1" name="AudioOutputIndex" type="uint8">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
@@ -402,7 +402,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="TT"/>
       </mandatoryConform>
-      <field id="0" name="TrackID" type="string">
+      <field fieldId="0" name="TrackID" type="string">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -418,51 +418,51 @@ Davis, CA 95616, USA
     <event id="0x00" name="StateChanged" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="CurrentState" type="PlaybackStateEnum">
+      <field fieldId="0" name="CurrentState" type="PlaybackStateEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="StartTime" type="epoch-us">
+      <field fieldId="1" name="StartTime" type="epoch-us">
         <mandatoryConform>
           <feature name="AS"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Duration" type="uint64">
+      <field fieldId="2" name="Duration" type="uint64">
         <mandatoryConform>
           <feature name="AS"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="SampledPosition" type="PlaybackPositionStruct">
+      <field fieldId="3" name="SampledPosition" type="PlaybackPositionStruct">
         <mandatoryConform>
           <feature name="AS"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="PlaybackSpeed" type="single">
+      <field fieldId="4" name="PlaybackSpeed" type="single">
         <mandatoryConform>
           <feature name="AS"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="5" name="SeekRangeEnd" type="uint64">
+      <field fieldId="5" name="SeekRangeEnd" type="uint64">
         <mandatoryConform>
           <feature name="AS"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="6" name="SeekRangeStart" type="uint64">
+      <field fieldId="6" name="SeekRangeStart" type="uint64">
         <mandatoryConform>
           <feature name="AS"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="7" name="Data" type="octstr">
+      <field fieldId="7" name="Data" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="900"/>
       </field>
-      <field id="8" name="AudioAdvanceUnmuted" type="bool" default="false">
+      <field fieldId="8" name="AudioAdvanceUnmuted" type="bool" default="false">
         <mandatoryConform>
           <feature name="AA"/>
         </mandatoryConform>

--- a/zcl-builtin/matter/new-data-model/Messages.xml
+++ b/zcl-builtin/matter/new-data-model/Messages.xml
@@ -185,13 +185,13 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="MessageResponseOptionStruct">
-      <field id="0" name="MessageResponseID" type="uint32">
+      <field fieldId="0" name="MessageResponseID" type="uint32">
         <mandatoryConform>
           <feature name="RESP"/>
         </mandatoryConform>
         <constraint type="min" value="1"/>
       </field>
-      <field id="1" name="Label" type="string">
+      <field fieldId="1" name="Label" type="string">
         <mandatoryConform>
           <feature name="RPLY"/>
         </mandatoryConform>
@@ -199,34 +199,34 @@ Davis, CA 95616, USA
       </field>
     </struct>
     <struct name="MessageStruct">
-      <field id="0" name="MessageID" type="MessageID">
+      <field fieldId="0" name="MessageID" type="MessageID">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="Priority" type="MessagePriorityEnum" default="0">
+      <field fieldId="1" name="Priority" type="MessagePriorityEnum" default="0">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="MessageControl" type="MessageControlBitmap" default="0">
+      <field fieldId="2" name="MessageControl" type="MessageControlBitmap" default="0">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="StartTime" type="epoch-s" default="0">
-        <access fabricSensitive="true"/>
-        <quality nullable="true"/>
-        <mandatoryConform/>
-      </field>
-      <field id="4" name="Duration" type="uint16" default="0">
+      <field fieldId="3" name="StartTime" type="epoch-s" default="0">
         <access fabricSensitive="true"/>
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="5" name="MessageText" type="string">
+      <field fieldId="4" name="Duration" type="uint16" default="0">
+        <access fabricSensitive="true"/>
+        <quality nullable="true"/>
+        <mandatoryConform/>
+      </field>
+      <field fieldId="5" name="MessageText" type="string">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="256"/>
       </field>
-      <field id="6" name="Responses" type="list" default="empty">
+      <field fieldId="6" name="Responses" type="list" default="empty">
         <entry type="MessageResponseOptionStruct"/>
         <access fabricSensitive="true"/>
         <mandatoryConform>
@@ -255,27 +255,27 @@ Davis, CA 95616, USA
     <command id="0x00" name="PresentMessagesRequest" direction="commandToServer" response="Y">
       <access invokePrivilege="operate" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="MessageID" type="MessageID">
+      <field fieldId="0" name="MessageID" type="MessageID">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Priority" type="MessagePriorityEnum" default="0">
+      <field fieldId="1" name="Priority" type="MessagePriorityEnum" default="0">
         <mandatoryConform/>
       </field>
-      <field id="2" name="MessageControl" type="MessageControlBitmap" default="0">
+      <field fieldId="2" name="MessageControl" type="MessageControlBitmap" default="0">
         <mandatoryConform/>
       </field>
-      <field id="3" name="StartTime" type="epoch-s" default="0">
+      <field fieldId="3" name="StartTime" type="epoch-s" default="0">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="Duration" type="uint16" default="0">
+      <field fieldId="4" name="Duration" type="uint16" default="0">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="5" name="MessageText" type="string">
+      <field fieldId="5" name="MessageText" type="string">
         <mandatoryConform/>
       </field>
-      <field id="6" name="Responses" type="list" default="empty">
+      <field fieldId="6" name="Responses" type="list" default="empty">
         <entry type="MessageResponseOptionStruct"/>
         <mandatoryConform>
           <feature name="RESP"/>
@@ -285,7 +285,7 @@ Davis, CA 95616, USA
     <command id="0x01" name="CancelMessagesRequest" direction="commandToServer" response="Y">
       <access invokePrivilege="operate" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="MessageIDs" type="list">
+      <field fieldId="0" name="MessageIDs" type="list">
         <entry type="MessageID"/>
         <mandatoryConform/>
       </field>
@@ -295,37 +295,37 @@ Davis, CA 95616, USA
     <event id="0x00" name="MessageQueued" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="MessageID" type="MessageID">
+      <field fieldId="0" name="MessageID" type="MessageID">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x01" name="MessagePresented" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="MessageID" type="MessageID">
+      <field fieldId="0" name="MessageID" type="MessageID">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x02" name="MessageComplete" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="MessageID" type="MessageID">
+      <field fieldId="0" name="MessageID" type="MessageID">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ResponseID" type="uint32" default="null">
+      <field fieldId="1" name="ResponseID" type="uint32" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="RESP"/>
         </mandatoryConform>
       </field>
-      <field id="2" name="Reply" type="string" default="null">
+      <field fieldId="2" name="Reply" type="string" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="RPLY"/>
         </mandatoryConform>
         <constraint type="maxLength" value="256"/>
       </field>
-      <field id="3" name="FutureMessagesPreference" type="FutureMessagePreferenceEnum" default="null">
+      <field fieldId="3" name="FutureMessagesPreference" type="FutureMessagePreferenceEnum" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/MicrowaveOvenControl.xml
+++ b/zcl-builtin/matter/new-data-model/MicrowaveOvenControl.xml
@@ -147,34 +147,34 @@ Davis, CA 95616, USA
     <command id="0x00" name="SetCookingParameters" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="CookMode" type="uint8" default="desc">
+      <field fieldId="0" name="CookMode" type="uint8" default="desc">
         <optionalConform choice="a" more="true"/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="CookTime" type="elapsed-s" default="30">
+      <field fieldId="1" name="CookTime" type="elapsed-s" default="30">
         <optionalConform choice="a" more="true"/>
         <constraint type="between" from="1" to="MaxCookTime"/>
       </field>
-      <field id="2" name="PowerSetting" type="uint8" default="MaxPower">
+      <field fieldId="2" name="PowerSetting" type="uint8" default="MaxPower">
         <optionalConform choice="a" more="true">
           <feature name="PWRNUM"/>
         </optionalConform>
         <constraint type="between" from="MinPower" to="MaxPower"/>
       </field>
-      <field id="3" name="WattSettingIndex" type="uint8" default="MS">
+      <field fieldId="3" name="WattSettingIndex" type="uint8" default="MS">
         <optionalConform choice="a" more="true">
           <feature name="WATTS"/>
         </optionalConform>
         <constraint type="between" from="0" to="len(SupportedWatts)-1"/>
       </field>
-      <field id="4" name="StartAfterSetting" type="bool" default="false">
+      <field fieldId="4" name="StartAfterSetting" type="bool" default="false">
         <optionalConform/>
       </field>
     </command>
     <command id="0x01" name="AddMoreTime" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <optionalConform/>
-      <field id="0" name="TimeToAdd" type="elapsed-s">
+      <field fieldId="0" name="TimeToAdd" type="elapsed-s">
         <mandatoryConform/>
         <constraint type="between" from="1" to="MaxCookTime"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ModeBase.xml
+++ b/zcl-builtin/matter/new-data-model/ModeBase.xml
@@ -72,25 +72,25 @@ Require at least one standard mode tag. Define reserved ranges for base/derived 
   </features>
   <dataTypes>
     <struct name="ModeOptionStruct">
-      <field id="0" name="Label" type="string" default="MS">
+      <field fieldId="0" name="Label" type="string" default="MS">
         <mandatoryConform/>
         <constraint type="maxLength" value="64"/>
       </field>
-      <field id="1" name="Mode" type="uint8" default="MS">
+      <field fieldId="1" name="Mode" type="uint8" default="MS">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ModeTags" type="list" default="MS">
+      <field fieldId="2" name="ModeTags" type="list" default="MS">
         <entry type="ModeTagStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="8"/>
       </field>
     </struct>
     <struct name="ModeTagStruct">
-      <field id="0" name="MfgCode" type="vendor-id">
+      <field fieldId="0" name="MfgCode" type="vendor-id">
         <optionalConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Value" type="enum16">
+      <field fieldId="1" name="Value" type="enum16">
         <mandatoryConform/>
       </field>
     </struct>
@@ -128,7 +128,7 @@ Require at least one standard mode tag. Define reserved ranges for base/derived 
     <command id="0x00" name="ChangeToMode" direction="commandToServer" response="ChangeToModeResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="NewMode" type="uint8">
+      <field fieldId="0" name="NewMode" type="uint8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -136,7 +136,7 @@ Require at least one standard mode tag. Define reserved ranges for base/derived 
     <command id="0x01" name="ChangeToModeResponse" direction="responseFromServer">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Status" type="enum8">
+      <field fieldId="0" name="Status" type="enum8">
         <enum>
           <item from="0x00" to="0x3F" name="CommonCodes" summary="Common standard values defined in the generic Mode Base cluster specification.">
             <mandatoryConform/>
@@ -151,7 +151,7 @@ Require at least one standard mode tag. Define reserved ranges for base/derived 
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="StatusText" type="string">
+      <field fieldId="1" name="StatusText" type="string">
         <constraint type="maxLength" value="64"/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/ModeSelect.xml
+++ b/zcl-builtin/matter/new-data-model/ModeSelect.xml
@@ -71,25 +71,25 @@ Davis, CA 95616, USA
   </features>
   <dataTypes>
     <struct name="ModeOptionStruct">
-      <field id="0" name="Label" type="string" default="MS">
+      <field fieldId="0" name="Label" type="string" default="MS">
         <mandatoryConform/>
         <constraint type="maxLength" value="64"/>
       </field>
-      <field id="1" name="Mode" type="uint8" default="MS">
+      <field fieldId="1" name="Mode" type="uint8" default="MS">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SemanticTags" type="list" default="MS">
+      <field fieldId="2" name="SemanticTags" type="list" default="MS">
         <entry type="SemanticTagStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="64"/>
       </field>
     </struct>
     <struct name="SemanticTagStruct">
-      <field id="0" name="MfgCode" type="vendor-id">
+      <field fieldId="0" name="MfgCode" type="vendor-id">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Value" type="enum16">
+      <field fieldId="1" name="Value" type="enum16">
         <mandatoryConform/>
       </field>
     </struct>
@@ -139,7 +139,7 @@ Davis, CA 95616, USA
     <command id="0x00" name="ChangeToMode" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="NewMode" type="uint8">
+      <field fieldId="0" name="NewMode" type="uint8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Mode_DeviceEnergyManagement.xml
+++ b/zcl-builtin/matter/new-data-model/Mode_DeviceEnergyManagement.xml
@@ -67,7 +67,7 @@ Davis, CA 95616, USA
   <classification hierarchy="derived" baseCluster="Mode Base" role="application" picsCode="DEMM" scope="Endpoint"/>
   <dataTypes>
     <struct name="ModeOptionStruct">
-      <field id="2" name="ModeTags">
+      <field fieldId="2" name="ModeTags">
         <mandatoryConform/>
         <constraint type="between" from="1" to="8"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Mode_Dishwasher.xml
+++ b/zcl-builtin/matter/new-data-model/Mode_Dishwasher.xml
@@ -68,13 +68,13 @@ Davis, CA 95616, USA
   <classification hierarchy="derived" baseCluster="Mode Base" role="application" picsCode="DISHM" scope="Endpoint"/>
   <dataTypes>
     <struct name="ModeOptionStruct">
-      <field id="0" name="Label">
+      <field fieldId="0" name="Label">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Mode">
+      <field fieldId="1" name="Mode">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ModeTags">
+      <field fieldId="2" name="ModeTags">
         <mandatoryConform/>
         <constraint type="between" from="1" to="8"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Mode_LaundryWasher.xml
+++ b/zcl-builtin/matter/new-data-model/Mode_LaundryWasher.xml
@@ -68,13 +68,13 @@ Davis, CA 95616, USA
   <classification hierarchy="derived" baseCluster="Mode Base" role="application" picsCode="LWM" scope="Endpoint"/>
   <dataTypes>
     <struct name="ModeOptionStruct">
-      <field id="0" name="Label">
+      <field fieldId="0" name="Label">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Mode">
+      <field fieldId="1" name="Mode">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ModeTags">
+      <field fieldId="2" name="ModeTags">
         <mandatoryConform/>
         <constraint type="between" from="1" to="8"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Mode_RVCClean.xml
+++ b/zcl-builtin/matter/new-data-model/Mode_RVCClean.xml
@@ -82,13 +82,13 @@ Davis, CA 95616, USA
   </attributes>
   <dataTypes>
     <struct name="ModeOptionStruct">
-      <field id="0" name="Label">
+      <field fieldId="0" name="Label">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Mode">
+      <field fieldId="1" name="Mode">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ModeTags">
+      <field fieldId="2" name="ModeTags">
         <mandatoryConform/>
         <constraint type="between" from="1" to="8"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Mode_RVCRun.xml
+++ b/zcl-builtin/matter/new-data-model/Mode_RVCRun.xml
@@ -82,13 +82,13 @@ Davis, CA 95616, USA
   </attributes>
   <dataTypes>
     <struct name="ModeOptionStruct">
-      <field id="0" name="Label">
+      <field fieldId="0" name="Label">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Mode">
+      <field fieldId="1" name="Mode">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ModeTags">
+      <field fieldId="2" name="ModeTags">
         <mandatoryConform/>
         <constraint type="between" from="1" to="8"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Mode_Refrigerator.xml
+++ b/zcl-builtin/matter/new-data-model/Mode_Refrigerator.xml
@@ -68,13 +68,13 @@ Davis, CA 95616, USA
   <classification hierarchy="derived" baseCluster="Mode Base" role="application" picsCode="TCCM" scope="Endpoint"/>
   <dataTypes>
     <struct name="ModeOptionStruct">
-      <field id="0" name="Label">
+      <field fieldId="0" name="Label">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Mode">
+      <field fieldId="1" name="Mode">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ModeTags">
+      <field fieldId="2" name="ModeTags">
         <mandatoryConform/>
         <constraint type="between" from="1" to="8"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/NetworkCommissioningCluster.xml
+++ b/zcl-builtin/matter/new-data-model/NetworkCommissioningCluster.xml
@@ -182,14 +182,14 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
       </bitfield>
     </bitmap>
     <struct name="NetworkInfoStruct">
-      <field id="0" name="NetworkID" type="octstr">
+      <field fieldId="0" name="NetworkID" type="octstr">
         <mandatoryConform/>
         <constraint type="lengthBetween" from="1" to="32"/>
       </field>
-      <field id="1" name="Connected" type="bool">
+      <field fieldId="1" name="Connected" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="2" name="NetworkIdentifier" type="octstr" default="null">
+      <field fieldId="2" name="NetworkIdentifier" type="octstr" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="PDC"/>
@@ -197,7 +197,7 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
         <constraint type="maxLength" value="20"/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="ClientIdentifier" type="octstr" default="null">
+      <field fieldId="3" name="ClientIdentifier" type="octstr" default="null">
         <quality nullable="true"/>
         <mandatoryConform>
           <feature name="PDC"/>
@@ -207,78 +207,78 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
       </field>
     </struct>
     <struct name="ThreadInterfaceScanResultStruct">
-      <field id="0" name="PanId" type="uint16">
+      <field fieldId="0" name="PanId" type="uint16">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>
         <constraint type="between" from="0" to="65534"/>
       </field>
-      <field id="1" name="ExtendedPanId" type="uint64">
+      <field fieldId="1" name="ExtendedPanId" type="uint64">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>
       </field>
-      <field id="2" name="NetworkName" type="string">
+      <field fieldId="2" name="NetworkName" type="string">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>
         <constraint type="lengthBetween" from="1" to="16"/>
       </field>
-      <field id="3" name="Channel" type="uint16">
+      <field fieldId="3" name="Channel" type="uint16">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>
       </field>
-      <field id="4" name="Version" type="uint8">
+      <field fieldId="4" name="Version" type="uint8">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>
       </field>
-      <field id="5" name="ExtendedAddress" type="hwadr">
+      <field fieldId="5" name="ExtendedAddress" type="hwadr">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>
       </field>
-      <field id="6" name="RSSI" type="int8">
+      <field fieldId="6" name="RSSI" type="int8">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>
       </field>
-      <field id="7" name="LQI" type="uint8">
+      <field fieldId="7" name="LQI" type="uint8">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>
       </field>
     </struct>
     <struct name="WiFiInterfaceScanResultStruct">
-      <field id="0" name="Security" type="WiFiSecurityBitmap">
+      <field fieldId="0" name="Security" type="WiFiSecurityBitmap">
         <mandatoryConform>
           <feature name="WI"/>
         </mandatoryConform>
       </field>
-      <field id="1" name="SSID" type="octstr">
+      <field fieldId="1" name="SSID" type="octstr">
         <mandatoryConform>
           <feature name="WI"/>
         </mandatoryConform>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="2" name="BSSID" type="octstr">
+      <field fieldId="2" name="BSSID" type="octstr">
         <mandatoryConform>
           <feature name="WI"/>
         </mandatoryConform>
         <constraint type="maxLength" value="6"/>
       </field>
-      <field id="3" name="Channel" type="uint16">
+      <field fieldId="3" name="Channel" type="uint16">
         <mandatoryConform>
           <feature name="WI"/>
         </mandatoryConform>
       </field>
-      <field id="4" name="WiFiBand" type="WiFiBandEnum">
+      <field fieldId="4" name="WiFiBand" type="WiFiBandEnum">
         <optionalConform>
           <feature name="WI"/>
         </optionalConform>
       </field>
-      <field id="5" name="RSSI" type="int8">
+      <field fieldId="5" name="RSSI" type="int8">
         <optionalConform>
           <feature name="WI"/>
         </optionalConform>
@@ -374,14 +374,14 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
           <feature name="TH"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="SSID" type="octstr" default="null">
+      <field fieldId="0" name="SSID" type="octstr" default="null">
         <quality nullable="true"/>
         <optionalConform>
           <feature name="WI"/>
         </optionalConform>
         <constraint type="lengthBetween" from="1" to="32"/>
       </field>
-      <field id="1" name="Breadcrumb" type="uint64">
+      <field fieldId="1" name="Breadcrumb" type="uint64">
         <optionalConform/>
       </field>
     </command>
@@ -392,22 +392,22 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
           <feature name="TH"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="NetworkingStatus" type="NetworkCommissioningStatusEnum">
+      <field fieldId="0" name="NetworkingStatus" type="NetworkCommissioningStatusEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="DebugText" type="string">
+      <field fieldId="1" name="DebugText" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="512"/>
       </field>
-      <field id="2" name="WiFiScanResults" type="list">
+      <field fieldId="2" name="WiFiScanResults" type="list">
         <entry type="WiFiInterfaceScanResultStruct"/>
         <mandatoryConform>
           <feature name="WI"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="ThreadScanResults" type="list">
+      <field fieldId="3" name="ThreadScanResults" type="list">
         <entry type="ThreadInterfaceScanResultStruct"/>
         <mandatoryConform>
           <feature name="TH"/>
@@ -420,27 +420,27 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
       <mandatoryConform>
         <feature name="WI"/>
       </mandatoryConform>
-      <field id="0" name="SSID" type="octstr">
+      <field fieldId="0" name="SSID" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="1" name="Credentials" type="octstr">
+      <field fieldId="1" name="Credentials" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="64"/>
       </field>
-      <field id="2" name="Breadcrumb" type="uint64">
+      <field fieldId="2" name="Breadcrumb" type="uint64">
         <optionalConform/>
       </field>
-      <field id="3" name="NetworkIdentity" type="octstr">
+      <field fieldId="3" name="NetworkIdentity" type="octstr">
         <optionalConform>
           <feature name="PDC"/>
         </optionalConform>
         <constraint type="maxLength" value="140"/>
       </field>
-      <field id="4" name="ClientIdentifier" type="octstr">
+      <field fieldId="4" name="ClientIdentifier" type="octstr">
         <constraint type="maxLength" value="20"/>
       </field>
-      <field id="5" name="PossessionNonce" type="octstr">
+      <field fieldId="5" name="PossessionNonce" type="octstr">
         <constraint type="maxLength" value="32"/>
       </field>
     </command>
@@ -449,11 +449,11 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
       <mandatoryConform>
         <feature name="TH"/>
       </mandatoryConform>
-      <field id="0" name="OperationalDataset" type="octstr">
+      <field fieldId="0" name="OperationalDataset" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="254"/>
       </field>
-      <field id="1" name="Breadcrumb" type="uint64">
+      <field fieldId="1" name="Breadcrumb" type="uint64">
         <optionalConform/>
       </field>
     </command>
@@ -465,11 +465,11 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
           <feature name="TH"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="NetworkID" type="octstr">
+      <field fieldId="0" name="NetworkID" type="octstr">
         <mandatoryConform/>
         <constraint type="lengthBetween" from="1" to="32"/>
       </field>
-      <field id="1" name="Breadcrumb" type="uint64">
+      <field fieldId="1" name="Breadcrumb" type="uint64">
         <optionalConform/>
       </field>
     </command>
@@ -480,25 +480,25 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
           <feature name="TH"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="NetworkingStatus" type="NetworkCommissioningStatusEnum">
+      <field fieldId="0" name="NetworkingStatus" type="NetworkCommissioningStatusEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="DebugText" type="string">
+      <field fieldId="1" name="DebugText" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="512"/>
       </field>
-      <field id="2" name="NetworkIndex" type="uint8">
+      <field fieldId="2" name="NetworkIndex" type="uint8">
         <optionalConform/>
         <constraint type="between" from="0" to="MaxNetworks - 1"/>
       </field>
-      <field id="3" name="ClientIdentity" type="octstr">
+      <field fieldId="3" name="ClientIdentity" type="octstr">
         <optionalConform>
           <feature name="PDC"/>
         </optionalConform>
         <constraint type="maxLength" value="140"/>
       </field>
-      <field id="4" name="PossessionSignature" type="octstr">
+      <field fieldId="4" name="PossessionSignature" type="octstr">
         <optionalConform>
           <feature name="PDC"/>
         </optionalConform>
@@ -513,11 +513,11 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
           <feature name="TH"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="NetworkID" type="octstr">
+      <field fieldId="0" name="NetworkID" type="octstr">
         <mandatoryConform/>
         <constraint type="lengthBetween" from="1" to="32"/>
       </field>
-      <field id="1" name="Breadcrumb" type="uint64">
+      <field fieldId="1" name="Breadcrumb" type="uint64">
         <optionalConform/>
       </field>
     </command>
@@ -528,13 +528,13 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
           <feature name="TH"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="NetworkingStatus" type="NetworkCommissioningStatusEnum">
+      <field fieldId="0" name="NetworkingStatus" type="NetworkCommissioningStatusEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="DebugText" type="string">
+      <field fieldId="1" name="DebugText" type="string">
         <optionalConform/>
       </field>
-      <field id="2" name="ErrorValue" type="int32">
+      <field fieldId="2" name="ErrorValue" type="int32">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -547,15 +547,15 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
           <feature name="TH"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="NetworkID" type="octstr">
+      <field fieldId="0" name="NetworkID" type="octstr">
         <mandatoryConform/>
         <constraint type="lengthBetween" from="1" to="32"/>
       </field>
-      <field id="1" name="NetworkIndex" type="uint8">
+      <field fieldId="1" name="NetworkIndex" type="uint8">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Breadcrumb" type="uint64">
+      <field fieldId="2" name="Breadcrumb" type="uint64">
         <optionalConform/>
       </field>
     </command>
@@ -564,11 +564,11 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
       <mandatoryConform>
         <feature name="PDC"/>
       </mandatoryConform>
-      <field id="0" name="KeyIdentifier" type="octstr">
+      <field fieldId="0" name="KeyIdentifier" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="20"/>
       </field>
-      <field id="1" name="PossessionNonce" type="octstr">
+      <field fieldId="1" name="PossessionNonce" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="32"/>
       </field>
@@ -577,11 +577,11 @@ Added support for Wi-Fi Per-Device Credentials (PDC feature; QueryIdentity and Q
       <mandatoryConform>
         <feature name="PDC"/>
       </mandatoryConform>
-      <field id="0" name="Identity" type="octstr">
+      <field fieldId="0" name="Identity" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="140"/>
       </field>
-      <field id="1" name="PossessionSignature" type="octstr">
+      <field fieldId="1" name="PossessionSignature" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="64"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/NetworkIdentityManagement.xml
+++ b/zcl-builtin/matter/new-data-model/NetworkIdentityManagement.xml
@@ -73,7 +73,7 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="ClientEndorsementStruct">
-      <field id="0" name="NodeID" type="node-id" default="null">
+      <field fieldId="0" name="NodeID" type="node-id" default="null">
         <access fabricSensitive="true"/>
         <quality nullable="true"/>
         <mandatoryConform/>
@@ -81,15 +81,15 @@ Davis, CA 95616, USA
       <access fabricScoped="true"/>
     </struct>
     <struct name="ClientStruct">
-      <field id="0" name="ClientNumber" type="uint16">
+      <field fieldId="0" name="ClientNumber" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="1" to="2047"/>
       </field>
-      <field id="1" name="ClientIdentifier" type="octstr">
+      <field fieldId="1" name="ClientIdentifier" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="20"/>
       </field>
-      <field id="2" name="Endorsements" type="list">
+      <field fieldId="2" name="Endorsements" type="list">
         <entry type="ClientEndorsementStruct"/>
         <mandatoryConform/>
         <constraint type="countBetween" from="1" to="SupportedFabrics"/>
@@ -127,21 +127,21 @@ Davis, CA 95616, USA
     <command id="0x00" name="AddOrUpdateClient" direction="commandToServer" response="Y">
       <access invokePrivilege="admin" fabricScoped="true" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="ClientIdentity" type="octstr">
+      <field fieldId="0" name="ClientIdentity" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="140"/>
       </field>
-      <field id="1" name="NodeID" type="node-id">
+      <field fieldId="1" name="NodeID" type="node-id">
         <optionalConform/>
       </field>
     </command>
     <command id="0x01" name="RemoveClient" direction="commandToServer" response="Y">
       <access invokePrivilege="admin" fabricScoped="true" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="ClientNumber" type="uint16">
+      <field fieldId="0" name="ClientNumber" type="uint16">
         <optionalConform choice="a"/>
       </field>
-      <field id="1" name="ClientIdentifier" type="octstr">
+      <field fieldId="1" name="ClientIdentifier" type="octstr">
         <optionalConform choice="a"/>
         <constraint type="maxLength" value="20"/>
       </field>
@@ -149,18 +149,18 @@ Davis, CA 95616, USA
     <command id="0x40" name="EndorseNetworkIdentityUpdate" direction="commandToServer" response="Y">
       <access invokePrivilege="admin" fabricScoped="true" timed="true"/>
       <mandatoryConform/>
-      <field id="0" name="NetworkIdentifier" type="octstr">
+      <field fieldId="0" name="NetworkIdentifier" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="20"/>
       </field>
-      <field id="1" name="PreviousNetworkIdentifiers" type="list">
+      <field fieldId="1" name="PreviousNetworkIdentifiers" type="list">
         <entry type="octstr">
           <constraint type="maxLength" value="20"/>
         </entry>
         <mandatoryConform/>
         <constraint type="countBetween" from="1" to="3"/>
       </field>
-      <field id="2" name="Signature" type="octstr">
+      <field fieldId="2" name="Signature" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="64"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/OTAProvider.xml
+++ b/zcl-builtin/matter/new-data-model/OTAProvider.xml
@@ -108,62 +108,62 @@ Davis, CA 95616, USA
     <command id="0x00" name="QueryImage" direction="commandToServer" response="QueryImageResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="VendorID" type="vendor-id">
+      <field fieldId="0" name="VendorID" type="vendor-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ProductID" type="uint16">
+      <field fieldId="1" name="ProductID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SoftwareVersion" type="uint32">
+      <field fieldId="2" name="SoftwareVersion" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="3" name="ProtocolsSupported" type="list">
+      <field fieldId="3" name="ProtocolsSupported" type="list">
         <entry type="DownloadProtocolEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="8"/>
       </field>
-      <field id="4" name="HardwareVersion" type="uint16">
+      <field fieldId="4" name="HardwareVersion" type="uint16">
         <optionalConform/>
       </field>
-      <field id="5" name="Location" type="string">
+      <field fieldId="5" name="Location" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="2"/>
       </field>
-      <field id="6" name="RequestorCanConsent" type="bool" default="False">
+      <field fieldId="6" name="RequestorCanConsent" type="bool" default="False">
         <optionalConform/>
       </field>
-      <field id="7" name="MetadataForProvider" type="octstr">
+      <field fieldId="7" name="MetadataForProvider" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="512"/>
       </field>
     </command>
     <command id="0x01" name="QueryImageResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="StatusEnum">
+      <field fieldId="0" name="Status" type="StatusEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="DelayedActionTime" type="uint32">
+      <field fieldId="1" name="DelayedActionTime" type="uint32">
         <optionalConform/>
       </field>
-      <field id="2" name="ImageURI" type="string">
+      <field fieldId="2" name="ImageURI" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="256"/>
       </field>
-      <field id="3" name="SoftwareVersion" type="uint32">
+      <field fieldId="3" name="SoftwareVersion" type="uint32">
         <optionalConform/>
       </field>
-      <field id="4" name="SoftwareVersionString" type="string">
+      <field fieldId="4" name="SoftwareVersionString" type="string">
         <optionalConform/>
         <constraint type="lengthBetween" from="1" to="64"/>
       </field>
-      <field id="5" name="UpdateToken" type="octstr">
+      <field fieldId="5" name="UpdateToken" type="octstr">
         <optionalConform/>
         <constraint type="lengthBetween" from="8" to="32"/>
       </field>
-      <field id="6" name="UserConsentNeeded" type="bool" default="False">
+      <field fieldId="6" name="UserConsentNeeded" type="bool" default="False">
         <optionalConform/>
       </field>
-      <field id="7" name="MetadataForRequestor" type="octstr">
+      <field fieldId="7" name="MetadataForRequestor" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="512"/>
       </field>
@@ -171,31 +171,31 @@ Davis, CA 95616, USA
     <command id="0x02" name="ApplyUpdateRequest" direction="commandToServer" response="ApplyUpdateResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="UpdateToken" type="octstr">
+      <field fieldId="0" name="UpdateToken" type="octstr">
         <mandatoryConform/>
         <constraint type="lengthBetween" from="8" to="32"/>
       </field>
-      <field id="1" name="NewVersion" type="uint32">
+      <field fieldId="1" name="NewVersion" type="uint32">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x03" name="ApplyUpdateResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Action" type="ApplyUpdateActionEnum">
+      <field fieldId="0" name="Action" type="ApplyUpdateActionEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="DelayedActionTime" type="uint32">
+      <field fieldId="1" name="DelayedActionTime" type="uint32">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x04" name="NotifyUpdateApplied" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="UpdateToken" type="octstr">
+      <field fieldId="0" name="UpdateToken" type="octstr">
         <mandatoryConform/>
         <constraint type="lengthBetween" from="8" to="32"/>
       </field>
-      <field id="1" name="SoftwareVersion" type="uint32">
+      <field fieldId="1" name="SoftwareVersion" type="uint32">
         <mandatoryConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/OTARequestor.xml
+++ b/zcl-builtin/matter/new-data-model/OTARequestor.xml
@@ -123,10 +123,10 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="ProviderLocation">
-      <field id="1" name="ProviderNodeID" type="node-id">
+      <field fieldId="1" name="ProviderNodeID" type="node-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Endpoint" type="endpoint-no">
+      <field fieldId="2" name="Endpoint" type="endpoint-no">
         <mandatoryConform/>
       </field>
       <access fabricScoped="true"/>
@@ -158,20 +158,20 @@ Davis, CA 95616, USA
     <command id="0x00" name="AnnounceOTAProvider" direction="commandToServer" response="Y">
       <access invokePrivilege="admin"/>
       <optionalConform/>
-      <field id="0" name="ProviderNodeID" type="node-id">
+      <field fieldId="0" name="ProviderNodeID" type="node-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="VendorID" type="vendor-id">
+      <field fieldId="1" name="VendorID" type="vendor-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="AnnouncementReason" type="AnnouncementReasonEnum">
+      <field fieldId="2" name="AnnouncementReason" type="AnnouncementReasonEnum">
         <mandatoryConform/>
       </field>
-      <field id="3" name="MetadataForNode" type="octstr">
+      <field fieldId="3" name="MetadataForNode" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="512"/>
       </field>
-      <field id="4" name="Endpoint" type="endpoint-no">
+      <field fieldId="4" name="Endpoint" type="endpoint-no">
         <mandatoryConform/>
       </field>
     </command>
@@ -180,16 +180,16 @@ Davis, CA 95616, USA
     <event id="0x00" name="StateTransition" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="PreviousState" type="UpdateStateEnum" default="Unknown">
+      <field fieldId="0" name="PreviousState" type="UpdateStateEnum" default="Unknown">
         <mandatoryConform/>
       </field>
-      <field id="1" name="NewState" type="UpdateStateEnum">
+      <field fieldId="1" name="NewState" type="UpdateStateEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Reason" type="ChangeReasonEnum">
+      <field fieldId="2" name="Reason" type="ChangeReasonEnum">
         <mandatoryConform/>
       </field>
-      <field id="3" name="TargetSoftwareVersion" type="uint32" default="null">
+      <field fieldId="3" name="TargetSoftwareVersion" type="uint32" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -197,28 +197,28 @@ Davis, CA 95616, USA
     <event id="0x01" name="VersionApplied" priority="critical">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="SoftwareVersion" type="uint32">
+      <field fieldId="0" name="SoftwareVersion" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ProductID" type="uint16">
+      <field fieldId="1" name="ProductID" type="uint16">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x02" name="DownloadError" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="SoftwareVersion" type="uint32">
+      <field fieldId="0" name="SoftwareVersion" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="1" name="BytesDownloaded" type="uint64">
+      <field fieldId="1" name="BytesDownloaded" type="uint64">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ProgressPercent" type="uint8" default="null">
+      <field fieldId="2" name="ProgressPercent" type="uint8" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="0" to="100"/>
       </field>
-      <field id="3" name="PlatformCode" type="int64" default="null">
+      <field fieldId="3" name="PlatformCode" type="int64" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/OnOff.xml
+++ b/zcl-builtin/matter/new-data-model/OnOff.xml
@@ -201,11 +201,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="LT"/>
       </mandatoryConform>
-      <field id="0" name="EffectIdentifier" type="EffectIdentifierEnum">
+      <field fieldId="0" name="EffectIdentifier" type="EffectIdentifierEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="EffectVariant" type="enum8" default="0">
+      <field fieldId="1" name="EffectVariant" type="enum8" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -221,15 +221,15 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="LT"/>
       </mandatoryConform>
-      <field id="0" name="OnOffControl" type="OnOffControlBitmap">
+      <field fieldId="0" name="OnOffControl" type="OnOffControlBitmap">
         <mandatoryConform/>
         <constraint type="between" from="0" to="1"/>
       </field>
-      <field id="1" name="OnTime" type="uint16">
+      <field fieldId="1" name="OnTime" type="uint16">
         <mandatoryConform/>
         <constraint type="max" value="0xFFFE"/>
       </field>
-      <field id="2" name="OffWaitTime" type="uint16">
+      <field fieldId="2" name="OffWaitTime" type="uint16">
         <mandatoryConform/>
         <constraint type="max" value="0xFFFE"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/OperationalCredentialCluster.xml
+++ b/zcl-builtin/matter/new-data-model/OperationalCredentialCluster.xml
@@ -116,33 +116,33 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="FabricDescriptorStruct">
-      <field id="1" name="RootPublicKey" type="octstr">
+      <field fieldId="1" name="RootPublicKey" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="65"/>
       </field>
-      <field id="2" name="VendorID" type="vendor-id">
+      <field fieldId="2" name="VendorID" type="vendor-id">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="FabricID" type="fabric-id">
+      <field fieldId="3" name="FabricID" type="fabric-id">
         <mandatoryConform/>
       </field>
-      <field id="4" name="NodeID" type="node-id">
+      <field fieldId="4" name="NodeID" type="node-id">
         <mandatoryConform/>
       </field>
-      <field id="5" name="Label" type="string" default="&quot;">
+      <field fieldId="5" name="Label" type="string" default="&quot;">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
       <access fabricScoped="true"/>
     </struct>
     <struct name="NOCStruct">
-      <field id="1" name="NOC" type="octstr">
+      <field fieldId="1" name="NOC" type="octstr">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="400"/>
       </field>
-      <field id="2" name="ICAC" type="octstr">
+      <field fieldId="2" name="ICAC" type="octstr">
         <access fabricSensitive="true"/>
         <quality nullable="true"/>
         <mandatoryConform/>
@@ -196,18 +196,18 @@ Davis, CA 95616, USA
     <command id="0x00" name="AttestationRequest" direction="commandToServer" response="AttestationResponse">
       <access invokePrivilege="admin"/>
       <mandatoryConform/>
-      <field id="0" name="AttestationNonce" type="octstr">
+      <field fieldId="0" name="AttestationNonce" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
     </command>
     <command id="0x01" name="AttestationResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="AttestationElements" type="octstr">
+      <field fieldId="0" name="AttestationElements" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="RESP_MAX Constant Type"/>
       </field>
-      <field id="1" name="AttestationSignature" type="octstr">
+      <field fieldId="1" name="AttestationSignature" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="64"/>
       </field>
@@ -215,14 +215,14 @@ Davis, CA 95616, USA
     <command id="0x02" name="CertificateChainRequest" direction="commandToServer" response="CertificateChainResponse">
       <access invokePrivilege="admin"/>
       <mandatoryConform/>
-      <field id="0" name="CertificateType" type="CertificateChainTypeEnum">
+      <field fieldId="0" name="CertificateType" type="CertificateChainTypeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
     </command>
     <command id="0x03" name="CertificateChainResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Certificate" type="octstr">
+      <field fieldId="0" name="Certificate" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="600"/>
       </field>
@@ -230,21 +230,21 @@ Davis, CA 95616, USA
     <command id="0x04" name="CSRRequest" direction="commandToServer" response="CSRResponse">
       <access invokePrivilege="admin"/>
       <mandatoryConform/>
-      <field id="0" name="CSRNonce" type="octstr">
+      <field fieldId="0" name="CSRNonce" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
-      <field id="1" name="IsForUpdateNOC" type="bool" default="false">
+      <field fieldId="1" name="IsForUpdateNOC" type="bool" default="false">
         <optionalConform/>
       </field>
     </command>
     <command id="0x05" name="CSRResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="NOCSRElements" type="octstr">
+      <field fieldId="0" name="NOCSRElements" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="RESP_MAX Constant Type"/>
       </field>
-      <field id="1" name="AttestationSignature" type="octstr">
+      <field fieldId="1" name="AttestationSignature" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="64"/>
       </field>
@@ -252,47 +252,47 @@ Davis, CA 95616, USA
     <command id="0x06" name="AddNOC" direction="commandToServer" response="NOCResponse">
       <access invokePrivilege="admin"/>
       <mandatoryConform/>
-      <field id="0" name="NOCValue" type="octstr">
+      <field fieldId="0" name="NOCValue" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="400"/>
       </field>
-      <field id="1" name="ICACValue" type="octstr">
+      <field fieldId="1" name="ICACValue" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="400"/>
       </field>
-      <field id="2" name="IPKValue" type="octstr">
+      <field fieldId="2" name="IPKValue" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="3" name="CaseAdminSubject" type="SubjectID">
+      <field fieldId="3" name="CaseAdminSubject" type="SubjectID">
         <mandatoryConform/>
       </field>
-      <field id="4" name="AdminVendorId" type="vendor-id">
+      <field fieldId="4" name="AdminVendorId" type="vendor-id">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x07" name="UpdateNOC" direction="commandToServer" response="NOCResponse">
       <access invokePrivilege="admin" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="NOCValue" type="octstr">
+      <field fieldId="0" name="NOCValue" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="400"/>
       </field>
-      <field id="1" name="ICACValue" type="octstr">
+      <field fieldId="1" name="ICACValue" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="400"/>
       </field>
     </command>
     <command id="0x08" name="NOCResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="StatusCode" type="NodeOperationalCertStatusEnum">
+      <field fieldId="0" name="StatusCode" type="NodeOperationalCertStatusEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="FabricIndex" type="fabric-idx">
+      <field fieldId="1" name="FabricIndex" type="fabric-idx">
         <optionalConform/>
         <constraint type="between" from="1" to="254"/>
       </field>
-      <field id="2" name="DebugText" type="string">
+      <field fieldId="2" name="DebugText" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="128"/>
       </field>
@@ -300,7 +300,7 @@ Davis, CA 95616, USA
     <command id="0x09" name="UpdateFabricLabel" direction="commandToServer" response="NOCResponse">
       <access invokePrivilege="admin" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="Label" type="string">
+      <field fieldId="0" name="Label" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="32"/>
       </field>
@@ -308,7 +308,7 @@ Davis, CA 95616, USA
     <command id="0x0A" name="RemoveFabric" direction="commandToServer" response="NOCResponse">
       <access invokePrivilege="admin"/>
       <mandatoryConform/>
-      <field id="0" name="FabricIndex" type="fabric-idx">
+      <field fieldId="0" name="FabricIndex" type="fabric-idx">
         <mandatoryConform/>
         <constraint type="between" from="1" to="254"/>
       </field>
@@ -316,7 +316,7 @@ Davis, CA 95616, USA
     <command id="0x0B" name="AddTrustedRootCertificate" direction="commandToServer" response="Y">
       <access invokePrivilege="admin"/>
       <mandatoryConform/>
-      <field id="0" name="RootCACertificate" type="octstr">
+      <field fieldId="0" name="RootCACertificate" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="400"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/OperationalState.xml
+++ b/zcl-builtin/matter/new-data-model/OperationalState.xml
@@ -77,7 +77,7 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="ErrorStateStruct">
-      <field id="0" name="ErrorStateID" type="enum8" default="0">
+      <field fieldId="0" name="ErrorStateID" type="enum8" default="0">
         <enum>
           <item from="0x00" to="0x3F" name="GeneralErrors" summary="Generally applicable values for error, defined herein">
             <mandatoryConform/>
@@ -91,19 +91,19 @@ Davis, CA 95616, USA
         </enum>
         <mandatoryConform/>
       </field>
-      <field id="1" name="ErrorStateLabel" type="string" default="empty">
+      <field fieldId="1" name="ErrorStateLabel" type="string" default="empty">
         <constraint type="maxLength" value="64"/>
       </field>
-      <field id="2" name="ErrorStateDetails" type="string" default="empty">
+      <field fieldId="2" name="ErrorStateDetails" type="string" default="empty">
         <optionalConform/>
         <constraint type="maxLength" value="64"/>
       </field>
     </struct>
     <struct name="OperationalStateStruct">
-      <field id="0" name="OperationalStateID" type="OperationalStateEnum" default="0">
+      <field fieldId="0" name="OperationalStateID" type="OperationalStateEnum" default="0">
         <mandatoryConform/>
       </field>
-      <field id="1" name="OperationalStateLabel" type="string">
+      <field fieldId="1" name="OperationalStateLabel" type="string">
         <constraint type="maxLength" value="64"/>
       </field>
     </struct>
@@ -188,7 +188,7 @@ Davis, CA 95616, USA
           <command name="Resume"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="CommandResponseState" type="ErrorStateStruct">
+      <field fieldId="0" name="CommandResponseState" type="ErrorStateStruct">
         <mandatoryConform/>
       </field>
     </command>
@@ -197,21 +197,21 @@ Davis, CA 95616, USA
     <event id="0x00" name="OperationalError" priority="critical">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="ErrorState" type="ErrorStateStruct">
+      <field fieldId="0" name="ErrorState" type="ErrorStateStruct">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x01" name="OperationCompletion" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="CompletionErrorCode" type="enum8">
+      <field fieldId="0" name="CompletionErrorCode" type="enum8">
         <mandatoryConform/>
       </field>
-      <field id="1" name="TotalOperationalTime" type="elapsed-s">
+      <field fieldId="1" name="TotalOperationalTime" type="elapsed-s">
         <quality nullable="true"/>
         <optionalConform/>
       </field>
-      <field id="2" name="PausedTime" type="elapsed-s">
+      <field fieldId="2" name="PausedTime" type="elapsed-s">
         <quality nullable="true"/>
         <optionalConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/PowerSourceCluster.xml
+++ b/zcl-builtin/matter/new-data-model/PowerSourceCluster.xml
@@ -925,15 +925,15 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CHGM"/>
       </mandatoryConform>
-      <field id="0" name="EnableTime" type="uint16" default="null">
+      <field fieldId="0" name="EnableTime" type="uint16" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="MinimumChargeCurrent" type="uint16">
+      <field fieldId="1" name="MinimumChargeCurrent" type="uint16">
         <mandatoryConform/>
         <constraint type="allowed" value="6-32"/>
       </field>
-      <field id="2" name="MaximumChargeCurrent" type="uint16">
+      <field fieldId="2" name="MaximumChargeCurrent" type="uint16">
         <mandatoryConform/>
         <constraint type="allowed" value="6-32"/>
       </field>
@@ -943,11 +943,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="DCHGM"/>
       </mandatoryConform>
-      <field id="0" name="EnableTime" type="uint16" default="null">
+      <field fieldId="0" name="EnableTime" type="uint16" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="MaximumDischargeCurrent" type="uint16">
+      <field fieldId="1" name="MaximumDischargeCurrent" type="uint16">
         <mandatoryConform/>
         <constraint type="allowed" value="6-32"/>
       </field>
@@ -963,12 +963,12 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="WIRED"/>
       </optionalConform>
-      <field id="0" name="Current" type="list" default="empty">
+      <field fieldId="0" name="Current" type="list" default="empty">
         <entry type="WiredFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="8"/>
       </field>
-      <field id="1" name="Previous" type="list" default="empty">
+      <field fieldId="1" name="Previous" type="list" default="empty">
         <entry type="WiredFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="8"/>
@@ -979,12 +979,12 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="BAT"/>
       </optionalConform>
-      <field id="0" name="Current" type="list" default="empty">
+      <field fieldId="0" name="Current" type="list" default="empty">
         <entry type="BatFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="8"/>
       </field>
-      <field id="1" name="Previous" type="list" default="empty">
+      <field fieldId="1" name="Previous" type="list" default="empty">
         <entry type="BatFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="8"/>
@@ -995,12 +995,12 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="RECHG"/>
       </optionalConform>
-      <field id="0" name="Current" type="list" default="empty">
+      <field fieldId="0" name="Current" type="list" default="empty">
         <entry type="BatChargeFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="16"/>
       </field>
-      <field id="1" name="Previous" type="list" default="empty">
+      <field fieldId="1" name="Previous" type="list" default="empty">
         <entry type="BatChargeFaultEnum"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="16"/>
@@ -1011,11 +1011,11 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="BAT"/>
       </optionalConform>
-      <field id="0" name="SessionID" type="uint32" default="null">
+      <field fieldId="0" name="SessionID" type="uint32" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="ChargeState" type="BatChargeStateEnum">
+      <field fieldId="1" name="ChargeState" type="BatChargeStateEnum">
         <mandatoryConform/>
       </field>
     </event>
@@ -1024,22 +1024,22 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="BAT"/>
       </optionalConform>
-      <field id="0" name="SessionID" type="uint32" default="null">
+      <field fieldId="0" name="SessionID" type="uint32" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="ChargeState" type="BatChargeStateEnum">
+      <field fieldId="1" name="ChargeState" type="BatChargeStateEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SessionDuration" type="elapsed-s" default="null">
+      <field fieldId="2" name="SessionDuration" type="elapsed-s" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="SessionEnergyCharged" type="int64" default="null">
+      <field fieldId="3" name="SessionEnergyCharged" type="int64" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="SessionEnergyDischarged" type="int64" default="null">
+      <field fieldId="4" name="SessionEnergyDischarged" type="int64" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -1049,11 +1049,11 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="RECHG"/>
       </optionalConform>
-      <field id="0" name="SessionID" type="uint32" default="null">
+      <field fieldId="0" name="SessionID" type="uint32" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="ChargeState" type="BatChargeStateEnum">
+      <field fieldId="1" name="ChargeState" type="BatChargeStateEnum">
         <mandatoryConform/>
       </field>
     </event>
@@ -1062,18 +1062,18 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="RECHG"/>
       </optionalConform>
-      <field id="0" name="SessionID" type="uint32" default="null">
+      <field fieldId="0" name="SessionID" type="uint32" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="ChargeState" type="BatChargeStateEnum">
+      <field fieldId="1" name="ChargeState" type="BatChargeStateEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Reason" type="BatEnergyTransferStopReasonEnum" default="null">
+      <field fieldId="2" name="Reason" type="BatEnergyTransferStopReasonEnum" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="EnergyTransferred" type="int64" default="null">
+      <field fieldId="3" name="EnergyTransferred" type="int64" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ResourceMonitoring.xml
+++ b/zcl-builtin/matter/new-data-model/ResourceMonitoring.xml
@@ -117,11 +117,11 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="ReplacementProductStruct">
-      <field id="0" name="ProductIdentifierType" type="ProductIdentifierTypeEnum">
+      <field fieldId="0" name="ProductIdentifierType" type="ProductIdentifierTypeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="ProductIdentifierValue" type="string">
+      <field fieldId="1" name="ProductIdentifierValue" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="20"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/Scenes.xml
+++ b/zcl-builtin/matter/new-data-model/Scenes.xml
@@ -77,82 +77,82 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="AttributeValuePairStruct">
-      <field id="0" name="AttributeID" type="attribute-id">
+      <field fieldId="0" name="AttributeID" type="attribute-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ValueUnsigned8" type="uint8">
+      <field fieldId="1" name="ValueUnsigned8" type="uint8">
         <optionalConform choice="a"/>
       </field>
-      <field id="2" name="ValueSigned8" type="int8">
+      <field fieldId="2" name="ValueSigned8" type="int8">
         <optionalConform choice="a"/>
       </field>
-      <field id="3" name="ValueUnsigned16" type="uint16">
+      <field fieldId="3" name="ValueUnsigned16" type="uint16">
         <optionalConform choice="a"/>
       </field>
-      <field id="4" name="ValueSigned16" type="int16">
+      <field fieldId="4" name="ValueSigned16" type="int16">
         <optionalConform choice="a"/>
       </field>
-      <field id="5" name="ValueUnsigned32" type="uint32">
+      <field fieldId="5" name="ValueUnsigned32" type="uint32">
         <optionalConform choice="a"/>
       </field>
-      <field id="6" name="ValueSigned32" type="int32">
+      <field fieldId="6" name="ValueSigned32" type="int32">
         <optionalConform choice="a"/>
       </field>
-      <field id="7" name="ValueUnsigned64" type="uint64">
+      <field fieldId="7" name="ValueUnsigned64" type="uint64">
         <optionalConform choice="a"/>
       </field>
-      <field id="8" name="ValueSigned64" type="int64">
+      <field fieldId="8" name="ValueSigned64" type="int64">
         <optionalConform choice="a"/>
       </field>
     </struct>
     <struct name="ExtensionFieldSetStruct">
-      <field id="0" name="ClusterID" type="cluster-id">
+      <field fieldId="0" name="ClusterID" type="cluster-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="AttributeValueList" type="list">
+      <field fieldId="1" name="AttributeValueList" type="list">
         <entry type="AttributeValuePairStruct"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
     </struct>
     <struct name="Logical Scene Table">
-      <field id="0" name="SceneGroupID" type="group-id">
+      <field fieldId="0" name="SceneGroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="SceneID" type="uint8">
+      <field fieldId="1" name="SceneID" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SceneName" type="string">
+      <field fieldId="2" name="SceneName" type="string">
         <mandatoryConform>
           <feature name="SN"/>
         </mandatoryConform>
       </field>
-      <field id="3" name="SceneTransitionTime" type="uint32" default="0">
+      <field fieldId="3" name="SceneTransitionTime" type="uint32" default="0">
         <mandatoryConform/>
       </field>
-      <field id="4" name="ExtensionFields" type="list" default="empty">
+      <field fieldId="4" name="ExtensionFields" type="list" default="empty">
         <entry type="ExtensionFieldSetStruct"/>
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="SceneInfoStruct">
-      <field id="0" name="SceneCount" type="uint8" default="0">
+      <field fieldId="0" name="SceneCount" type="uint8" default="0">
         <mandatoryConform/>
       </field>
-      <field id="1" name="CurrentScene" type="uint8" default="0xFF">
+      <field fieldId="1" name="CurrentScene" type="uint8" default="0xFF">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="CurrentGroup" type="group-id" default="0">
+      <field fieldId="2" name="CurrentGroup" type="group-id" default="0">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="SceneValid" type="bool" default="False">
+      <field fieldId="3" name="SceneValid" type="bool" default="False">
         <access fabricSensitive="true"/>
         <mandatoryConform/>
       </field>
-      <field id="4" name="RemainingCapacity" type="uint8" default="MS">
+      <field fieldId="4" name="RemainingCapacity" type="uint8" default="MS">
         <mandatoryConform/>
         <constraint type="max" value="253"/>
       </field>
@@ -182,22 +182,22 @@ Davis, CA 95616, USA
     <command id="0x00" name="AddScene" direction="commandToServer" response="AddSceneResponse">
       <access invokePrivilege="manage" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="SceneID" type="uint8">
+      <field fieldId="1" name="SceneID" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
-      <field id="2" name="TransitionTime" type="uint32">
+      <field fieldId="2" name="TransitionTime" type="uint32">
         <mandatoryConform/>
         <constraint type="max" value="60000000"/>
       </field>
-      <field id="3" name="SceneName" type="string">
+      <field fieldId="3" name="SceneName" type="string">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="4" name="ExtensionFieldSetStructs" type="list">
+      <field fieldId="4" name="ExtensionFieldSetStructs" type="list">
         <entry type="ExtensionFieldSetStruct"/>
         <mandatoryConform/>
         <constraint type="desc"/>
@@ -205,14 +205,14 @@ Davis, CA 95616, USA
     </command>
     <command id="0x00" name="AddSceneResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="status">
+      <field fieldId="0" name="Status" type="status">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupID" type="group-id">
+      <field fieldId="1" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SceneID" type="uint8">
+      <field fieldId="2" name="SceneID" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
@@ -220,58 +220,58 @@ Davis, CA 95616, USA
     <command id="0x01" name="ViewScene" direction="commandToServer" response="ViewSceneResponse">
       <access invokePrivilege="operate" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="SceneID" type="uint8">
+      <field fieldId="1" name="SceneID" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
     </command>
     <command id="0x01" name="ViewSceneResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="status">
+      <field fieldId="0" name="Status" type="status">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupID" type="group-id">
+      <field fieldId="1" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SceneID" type="uint8">
+      <field fieldId="2" name="SceneID" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
-      <field id="3" name="TransitionTime" type="uint32">
+      <field fieldId="3" name="TransitionTime" type="uint32">
         <constraint type="max" value="60000000"/>
       </field>
-      <field id="4" name="SceneName" type="string">
+      <field fieldId="4" name="SceneName" type="string">
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="5" name="ExtensionFieldSetStructs" type="list">
+      <field fieldId="5" name="ExtensionFieldSetStructs" type="list">
         <entry type="ExtensionFieldSetStruct"/>
       </field>
     </command>
     <command id="0x02" name="RemoveScene" direction="commandToServer" response="RemoveSceneResponse">
       <access invokePrivilege="manage" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="SceneID" type="uint8">
+      <field fieldId="1" name="SceneID" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
     </command>
     <command id="0x02" name="RemoveSceneResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="status">
+      <field fieldId="0" name="Status" type="status">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupID" type="group-id">
+      <field fieldId="1" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SceneID" type="uint8">
+      <field fieldId="2" name="SceneID" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
@@ -279,41 +279,41 @@ Davis, CA 95616, USA
     <command id="0x03" name="RemoveAllScenes" direction="commandToServer" response="RemoveAllScenesResponse">
       <access invokePrivilege="manage" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x03" name="RemoveAllScenesResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="status">
+      <field fieldId="0" name="Status" type="status">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupID" type="group-id">
+      <field fieldId="1" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x04" name="StoreScene" direction="commandToServer" response="StoreSceneResponse">
       <access invokePrivilege="manage" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="SceneID" type="uint8">
+      <field fieldId="1" name="SceneID" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
     </command>
     <command id="0x04" name="StoreSceneResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="status">
+      <field fieldId="0" name="Status" type="status">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupID" type="group-id">
+      <field fieldId="1" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SceneID" type="uint8">
+      <field fieldId="2" name="SceneID" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
@@ -321,14 +321,14 @@ Davis, CA 95616, USA
     <command id="0x05" name="RecallScene" direction="commandToServer" response="Y">
       <access invokePrivilege="operate" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="SceneID" type="uint8">
+      <field fieldId="1" name="SceneID" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
-      <field id="2" name="TransitionTime" type="uint32">
+      <field fieldId="2" name="TransitionTime" type="uint32">
         <quality nullable="true"/>
         <optionalConform/>
         <constraint type="max" value="60000000"/>
@@ -337,44 +337,44 @@ Davis, CA 95616, USA
     <command id="0x06" name="GetSceneMembership" direction="commandToServer" response="GetSceneMembershipResponse">
       <access invokePrivilege="operate" fabricScoped="true"/>
       <mandatoryConform/>
-      <field id="0" name="GroupID" type="group-id">
+      <field fieldId="0" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x06" name="GetSceneMembershipResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="status">
+      <field fieldId="0" name="Status" type="status">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Capacity" type="uint8">
+      <field fieldId="1" name="Capacity" type="uint8">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="GroupID" type="group-id">
+      <field fieldId="2" name="GroupID" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="3" name="SceneList" type="list">
+      <field fieldId="3" name="SceneList" type="list">
         <entry type="uint8"/>
       </field>
     </command>
     <command id="0x40" name="CopyScene" direction="commandToServer" response="CopySceneResponse">
       <access invokePrivilege="manage" fabricScoped="true"/>
       <optionalConform/>
-      <field id="0" name="Mode" type="CopyModeBitmap">
+      <field fieldId="0" name="Mode" type="CopyModeBitmap">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupIdentifierFrom" type="group-id">
+      <field fieldId="1" name="GroupIdentifierFrom" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SceneIdentifierFrom" type="max 254">
+      <field fieldId="2" name="SceneIdentifierFrom" type="max 254">
         <mandatoryConform/>
       </field>
-      <field id="3" name="GroupIdentifierTo" type="group-id">
+      <field fieldId="3" name="GroupIdentifierTo" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="4" name="SceneIdentifierTo" type="max 254">
+      <field fieldId="4" name="SceneIdentifierTo" type="max 254">
         <mandatoryConform/>
       </field>
     </command>
@@ -382,14 +382,14 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <command name="CopyScene"/>
       </mandatoryConform>
-      <field id="0" name="Status" type="status">
+      <field fieldId="0" name="Status" type="status">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="GroupIdentifierFrom" type="group-id">
+      <field fieldId="1" name="GroupIdentifierFrom" type="group-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="SceneIdentifierFrom" type="uint8">
+      <field fieldId="2" name="SceneIdentifierFrom" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/SmokeCOAlarm.xml
+++ b/zcl-builtin/matter/new-data-model/SmokeCOAlarm.xml
@@ -242,7 +242,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="SMOKE"/>
       </mandatoryConform>
-      <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
+      <field fieldId="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
         <mandatoryConform/>
       </field>
     </event>
@@ -251,14 +251,14 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="CO"/>
       </mandatoryConform>
-      <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
+      <field fieldId="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x02" name="LowBattery" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
+      <field fieldId="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
         <mandatoryConform/>
       </field>
     </event>
@@ -287,7 +287,7 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="SMOKE"/>
       </optionalConform>
-      <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
+      <field fieldId="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
         <mandatoryConform/>
       </field>
     </event>
@@ -296,7 +296,7 @@ Davis, CA 95616, USA
       <optionalConform>
         <feature name="CO"/>
       </optionalConform>
-      <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
+      <field fieldId="0" name="AlarmSeverityLevel" type="AlarmStateEnum">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/Switch.xml
+++ b/zcl-builtin/matter/new-data-model/Switch.xml
@@ -120,7 +120,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="LS"/>
       </mandatoryConform>
-      <field id="0" name="NewPosition" type="uint8">
+      <field fieldId="0" name="NewPosition" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="NumberOfPositions-1"/>
       </field>
@@ -130,7 +130,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="MS"/>
       </mandatoryConform>
-      <field id="0" name="NewPosition" type="uint8">
+      <field fieldId="0" name="NewPosition" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="NumberOfPositions-1"/>
       </field>
@@ -140,7 +140,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="MSL"/>
       </mandatoryConform>
-      <field id="0" name="NewPosition" type="uint8">
+      <field fieldId="0" name="NewPosition" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="NumberOfPositions-1"/>
       </field>
@@ -150,7 +150,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="MSR"/>
       </mandatoryConform>
-      <field id="0" name="PreviousPosition" type="uint8">
+      <field fieldId="0" name="PreviousPosition" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="NumberOfPositions-1"/>
       </field>
@@ -160,7 +160,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="MSL"/>
       </mandatoryConform>
-      <field id="0" name="PreviousPosition" type="uint8">
+      <field fieldId="0" name="PreviousPosition" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="NumberOfPositions-1"/>
       </field>
@@ -170,11 +170,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="MSM"/>
       </mandatoryConform>
-      <field id="0" name="NewPosition" type="uint8">
+      <field fieldId="0" name="NewPosition" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="NumberOfPositions-1"/>
       </field>
-      <field id="1" name="CurrentNumberOfPressesCounted" type="uint8">
+      <field fieldId="1" name="CurrentNumberOfPressesCounted" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="2" to="MultiPressMax"/>
       </field>
@@ -184,11 +184,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="MSM"/>
       </mandatoryConform>
-      <field id="0" name="PreviousPosition" type="uint8">
+      <field fieldId="0" name="PreviousPosition" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="0" to="NumberOfPositions-1"/>
       </field>
-      <field id="1" name="TotalNumberOfPressesCounted" type="uint8">
+      <field fieldId="1" name="TotalNumberOfPressesCounted" type="uint8">
         <mandatoryConform/>
         <constraint type="between" from="1" to="MultiPressMax"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/TargetNavigator.xml
+++ b/zcl-builtin/matter/new-data-model/TargetNavigator.xml
@@ -79,11 +79,11 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="TargetInfoStruct">
-      <field id="0" name="Identifier" type="uint8">
+      <field fieldId="0" name="Identifier" type="uint8">
         <mandatoryConform/>
         <constraint type="max" value="254"/>
       </field>
-      <field id="1" name="Name" type="string">
+      <field fieldId="1" name="Name" type="string">
         <mandatoryConform/>
       </field>
     </struct>
@@ -104,19 +104,19 @@ Davis, CA 95616, USA
     <command id="0x00" name="NavigateTarget" direction="commandToServer" response="NavigateTargetResponse">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Target" type="uint8">
+      <field fieldId="0" name="Target" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Data" type="string" default="MS">
+      <field fieldId="1" name="Data" type="string" default="MS">
         <optionalConform/>
       </field>
     </command>
     <command id="0x01" name="NavigateTargetResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="Status" type="StatusEnum">
+      <field fieldId="0" name="Status" type="StatusEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Data" type="string" default="MS">
+      <field fieldId="1" name="Data" type="string" default="MS">
         <optionalConform/>
       </field>
     </command>
@@ -125,15 +125,15 @@ Davis, CA 95616, USA
     <event id="0x00" name="TargetUpdated" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="TargetList" type="list">
+      <field fieldId="0" name="TargetList" type="list">
         <entry type="TargetInfoStruct"/>
         <optionalConform/>
       </field>
-      <field id="1" name="CurrentTarget" type="uint8" default="0xFF">
+      <field fieldId="1" name="CurrentTarget" type="uint8" default="0xFF">
         <optionalConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Data" type="octstr">
+      <field fieldId="2" name="Data" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="900"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/TemperatureControl.xml
+++ b/zcl-builtin/matter/new-data-model/TemperatureControl.xml
@@ -130,13 +130,13 @@ Davis, CA 95616, USA
     <command id="0x00" name="SetTemperature" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="TargetTemperature" type="temperature">
+      <field fieldId="0" name="TargetTemperature" type="temperature">
         <mandatoryConform>
           <feature name="TN"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="TargetTemperatureLevel" type="uint8">
+      <field fieldId="1" name="TargetTemperatureLevel" type="uint8">
         <mandatoryConform>
           <feature name="TL"/>
         </mandatoryConform>

--- a/zcl-builtin/matter/new-data-model/Thermostat.xml
+++ b/zcl-builtin/matter/new-data-model/Thermostat.xml
@@ -514,112 +514,112 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="PresetStruct">
-      <field id="0" name="PresetHandle" type="octstr">
+      <field fieldId="0" name="PresetHandle" type="octstr">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="PresetScenario" type="PresetScenarioEnum">
+      <field fieldId="1" name="PresetScenario" type="PresetScenarioEnum">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Name" type="string" default="null">
+      <field fieldId="2" name="Name" type="string" default="null">
         <quality nullable="true"/>
         <optionalConform/>
         <constraint type="maxLength" value="64"/>
       </field>
-      <field id="3" name="CoolingSetpoint" type="temperature" default="26°C">
+      <field fieldId="3" name="CoolingSetpoint" type="temperature" default="26°C">
         <mandatoryConform>
           <feature name="COOL"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="HeatingSetpoint" type="temperature" default="20°C">
+      <field fieldId="4" name="HeatingSetpoint" type="temperature" default="20°C">
         <mandatoryConform>
           <feature name="HEAT"/>
         </mandatoryConform>
         <constraint type="desc"/>
       </field>
-      <field id="5" name="BuiltIn" type="bool" default="false">
+      <field fieldId="5" name="BuiltIn" type="bool" default="false">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="PresetTypeStruct">
-      <field id="0" name="PresetScenario" type="PresetScenarioEnum">
+      <field fieldId="0" name="PresetScenario" type="PresetScenarioEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="NumberOfPresets" type="uint8" default="0">
+      <field fieldId="1" name="NumberOfPresets" type="uint8" default="0">
         <mandatoryConform/>
       </field>
-      <field id="2" name="PresetTypeFeatures" type="PresetTypeFeaturesBitmap" default="0">
+      <field fieldId="2" name="PresetTypeFeatures" type="PresetTypeFeaturesBitmap" default="0">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="QueuedPresetStruct">
-      <field id="0" name="PresetHandle" type="octstr">
+      <field fieldId="0" name="PresetHandle" type="octstr">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="TransitionTimestamp" type="utc" default="null">
+      <field fieldId="1" name="TransitionTimestamp" type="utc" default="null">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="ScheduleStruct">
-      <field id="0" name="ScheduleHandle" type="octstr">
+      <field fieldId="0" name="ScheduleHandle" type="octstr">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="SystemMode" type="SystemModeEnum">
+      <field fieldId="1" name="SystemMode" type="SystemModeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="Name" type="string">
+      <field fieldId="2" name="Name" type="string">
         <optionalConform/>
         <constraint type="maxLength" value="64"/>
       </field>
-      <field id="3" name="PresetHandle" type="octstr">
+      <field fieldId="3" name="PresetHandle" type="octstr">
         <optionalConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="4" name="Transitions" type="list" default="empty">
+      <field fieldId="4" name="Transitions" type="list" default="empty">
         <entry type="ScheduleTransitionStruct"/>
         <mandatoryConform/>
         <constraint type="countBetween" from="1" to="NumberOfScheduleTransitions Attribute"/>
       </field>
-      <field id="5" name="BuiltIn" type="bool" default="false">
+      <field fieldId="5" name="BuiltIn" type="bool" default="false">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="ScheduleTransitionStruct">
-      <field id="0" name="DayOfWeek" type="ScheduleDayOfWeekBitmap">
+      <field fieldId="0" name="DayOfWeek" type="ScheduleDayOfWeekBitmap">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="TransitionTime" type="uint16">
+      <field fieldId="1" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="between" from="0" to="1439"/>
       </field>
-      <field id="2" name="PresetHandle" type="octstr">
+      <field fieldId="2" name="PresetHandle" type="octstr">
         <optionalConform>
           <feature name="PRES"/>
         </optionalConform>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="3" name="SystemMode" type="SystemModeEnum">
+      <field fieldId="3" name="SystemMode" type="SystemModeEnum">
         <optionalConform/>
         <constraint type="desc"/>
       </field>
-      <field id="4" name="CoolingSetpoint" type="temperature">
+      <field fieldId="4" name="CoolingSetpoint" type="temperature">
         <optionalConform>
           <feature name="COOL"/>
         </optionalConform>
         <constraint type="desc"/>
       </field>
-      <field id="5" name="HeatingSetpoint" type="temperature">
+      <field fieldId="5" name="HeatingSetpoint" type="temperature">
         <optionalConform>
           <feature name="HEAT"/>
         </optionalConform>
@@ -627,29 +627,29 @@ Davis, CA 95616, USA
       </field>
     </struct>
     <struct name="ScheduleTypeStruct">
-      <field id="0" name="SystemMode" type="SystemModeEnum">
+      <field fieldId="0" name="SystemMode" type="SystemModeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="NumberOfSchedules" type="uint8" default="0">
+      <field fieldId="1" name="NumberOfSchedules" type="uint8" default="0">
         <mandatoryConform/>
         <constraint type="max" value="NumberOfSchedules Attribute"/>
       </field>
-      <field id="2" name="ScheduleTypeFeatures" type="ScheduleTypeFeaturesBitmap" default="0">
+      <field fieldId="2" name="ScheduleTypeFeatures" type="ScheduleTypeFeaturesBitmap" default="0">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
     </struct>
     <struct name="WeeklyScheduleTransitionStruct">
-      <field id="0" name="TransitionTime" type="uint16">
+      <field fieldId="0" name="TransitionTime" type="uint16">
         <mandatoryConform/>
         <constraint type="max" value="1439"/>
       </field>
-      <field id="1" name="HeatSetpoint" type="temperature">
+      <field fieldId="1" name="HeatSetpoint" type="temperature">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="CoolSetpoint" type="temperature">
+      <field fieldId="2" name="CoolSetpoint" type="temperature">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
@@ -1118,11 +1118,11 @@ Davis, CA 95616, USA
     <command id="0x00" name="SetpointRaiseLower" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="Mode" type="SetpointRaiseLowerModeEnum">
+      <field fieldId="0" name="Mode" type="SetpointRaiseLowerModeEnum">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="Amount" type="int8">
+      <field fieldId="1" name="Amount" type="int8">
         <mandatoryConform/>
       </field>
     </command>
@@ -1130,18 +1130,18 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="SCH"/>
       </mandatoryConform>
-      <field id="0" name="NumberOfTransitionsForSequence" type="uint8">
+      <field fieldId="0" name="NumberOfTransitionsForSequence" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="1" name="DayOfWeekForSequence" type="ScheduleDayOfWeekBitmap">
-        <mandatoryConform/>
-        <constraint type="desc"/>
-      </field>
-      <field id="2" name="ModeForSequence" type="ScheduleModeBitmap">
+      <field fieldId="1" name="DayOfWeekForSequence" type="ScheduleDayOfWeekBitmap">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="Transitions" type="list">
+      <field fieldId="2" name="ModeForSequence" type="ScheduleModeBitmap">
+        <mandatoryConform/>
+        <constraint type="desc"/>
+      </field>
+      <field fieldId="3" name="Transitions" type="list">
         <entry type="WeeklyScheduleTransitionStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="10"/>
@@ -1152,18 +1152,18 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="SCH"/>
       </mandatoryConform>
-      <field id="0" name="NumberOfTransitionsForSequence" type="uint8">
+      <field fieldId="0" name="NumberOfTransitionsForSequence" type="uint8">
         <mandatoryConform/>
       </field>
-      <field id="1" name="DayOfWeekForSequence" type="ScheduleDayOfWeekBitmap">
-        <mandatoryConform/>
-        <constraint type="desc"/>
-      </field>
-      <field id="2" name="ModeForSequence" type="ScheduleModeBitmap">
+      <field fieldId="1" name="DayOfWeekForSequence" type="ScheduleDayOfWeekBitmap">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="3" name="Transitions" type="list">
+      <field fieldId="2" name="ModeForSequence" type="ScheduleModeBitmap">
+        <mandatoryConform/>
+        <constraint type="desc"/>
+      </field>
+      <field fieldId="3" name="Transitions" type="list">
         <entry type="WeeklyScheduleTransitionStruct"/>
         <mandatoryConform/>
         <constraint type="maxCount" value="10"/>
@@ -1173,27 +1173,27 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <command name="GetRelayStatusLog"/>
       </mandatoryConform>
-      <field id="0" name="TimeOfDay" type="uint16">
+      <field fieldId="0" name="TimeOfDay" type="uint16">
         <mandatoryConform/>
         <constraint type="max" value="1439"/>
       </field>
-      <field id="1" name="RelayStatus" type="RelayStateBitmap">
+      <field fieldId="1" name="RelayStatus" type="RelayStateBitmap">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="2" name="LocalTemperature" type="temperature">
+      <field fieldId="2" name="LocalTemperature" type="temperature">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="HumidityInPercentage" type="uint8">
+      <field fieldId="3" name="HumidityInPercentage" type="uint8">
         <quality nullable="true"/>
         <mandatoryConform/>
         <constraint type="between" from="0%" to="100%"/>
       </field>
-      <field id="4" name="SetPoint" type="temperature">
+      <field fieldId="4" name="SetPoint" type="temperature">
         <mandatoryConform/>
       </field>
-      <field id="5" name="UnreadEntries" type="uint16">
+      <field fieldId="5" name="UnreadEntries" type="uint16">
         <mandatoryConform/>
       </field>
     </command>
@@ -1202,11 +1202,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="SCH"/>
       </mandatoryConform>
-      <field id="0" name="DaysToReturn" type="ScheduleDayOfWeekBitmap">
+      <field fieldId="0" name="DaysToReturn" type="ScheduleDayOfWeekBitmap">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="ModeToReturn" type="ScheduleModeBitmap">
+      <field fieldId="1" name="ModeToReturn" type="ScheduleModeBitmap">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -1228,7 +1228,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="MSCH"/>
       </mandatoryConform>
-      <field id="0" name="ScheduleHandle" type="octstr">
+      <field fieldId="0" name="ScheduleHandle" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
@@ -1238,11 +1238,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="PRES"/>
       </mandatoryConform>
-      <field id="0" name="PresetHandle" type="octstr">
+      <field fieldId="0" name="PresetHandle" type="octstr">
         <mandatoryConform/>
         <constraint type="maxLength" value="16"/>
       </field>
-      <field id="1" name="DelayMinutes" type="uint16" default="0">
+      <field fieldId="1" name="DelayMinutes" type="uint16" default="0">
         <optionalConform>
           <feature name="QDPRES"/>
         </optionalConform>
@@ -1256,7 +1256,7 @@ Davis, CA 95616, USA
           <feature name="PRES"/>
         </orTerm>
       </mandatoryConform>
-      <field id="0" name="TimeoutSeconds" type="uint16">
+      <field fieldId="0" name="TimeoutSeconds" type="uint16">
         <mandatoryConform/>
         <constraint type="max" value="120"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ThreadBorderRouterDiagnostics.xml
+++ b/zcl-builtin/matter/new-data-model/ThreadBorderRouterDiagnostics.xml
@@ -72,7 +72,7 @@ Davis, CA 95616, USA
     </command>
     <command id="0x01" name="OpDatasetResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="OperationalDataset" type="octstr">
+      <field fieldId="0" name="OperationalDataset" type="octstr">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>
@@ -85,7 +85,7 @@ Davis, CA 95616, USA
     </command>
     <command id="0x03" name="TopologyResponse" direction="responseFromServer">
       <mandatoryConform/>
-      <field id="0" name="ThreadTopology" type="TODO">
+      <field fieldId="0" name="ThreadTopology" type="TODO">
         <mandatoryConform>
           <feature name="TH"/>
         </mandatoryConform>

--- a/zcl-builtin/matter/new-data-model/TimeSync.xml
+++ b/zcl-builtin/matter/new-data-model/TimeSync.xml
@@ -112,47 +112,47 @@ Davis, CA 95616, USA
       </item>
     </enum>
     <struct name="DSTOffsetStruct">
-      <field id="0" name="Offset" type="int32">
+      <field fieldId="0" name="Offset" type="int32">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="ValidStarting" type="epoch-us">
+      <field fieldId="1" name="ValidStarting" type="epoch-us">
         <mandatoryConform/>
       </field>
-      <field id="2" name="ValidUntil" type="epoch-us">
+      <field fieldId="2" name="ValidUntil" type="epoch-us">
         <quality nullable="true"/>
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="FabricScopedTrustedTimeSourceStruct">
-      <field id="0" name="NodeID" type="node-id">
+      <field fieldId="0" name="NodeID" type="node-id">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Endpoint" type="endpoint-no">
+      <field fieldId="1" name="Endpoint" type="endpoint-no">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="TimeZoneStruct">
-      <field id="0" name="Offset" type="int32">
+      <field fieldId="0" name="Offset" type="int32">
         <mandatoryConform/>
         <constraint type="between" from="-43200" to="50400"/>
       </field>
-      <field id="1" name="ValidAt" type="epoch-us">
+      <field fieldId="1" name="ValidAt" type="epoch-us">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Name" type="string">
+      <field fieldId="2" name="Name" type="string">
         <optionalConform/>
         <constraint type="lengthBetween" from="0" to="64"/>
       </field>
     </struct>
     <struct name="TrustedTimeSourceStruct">
-      <field id="0" name="FabricIndex" type="fabric-idx">
+      <field fieldId="0" name="FabricIndex" type="fabric-idx">
         <mandatoryConform/>
       </field>
-      <field id="1" name="NodeID" type="node-id">
+      <field fieldId="1" name="NodeID" type="node-id">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Endpoint" type="endpoint-no">
+      <field fieldId="2" name="Endpoint" type="endpoint-no">
         <mandatoryConform/>
       </field>
     </struct>
@@ -169,7 +169,7 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="TZ"/>
       </mandatoryConform>
-      <field id="0" name="DSTOffsetActive" type="bool">
+      <field fieldId="0" name="DSTOffsetActive" type="bool">
         <mandatoryConform/>
       </field>
     </event>
@@ -178,11 +178,11 @@ Davis, CA 95616, USA
       <mandatoryConform>
         <feature name="TZ"/>
       </mandatoryConform>
-      <field id="0" name="Offset" type="int32">
+      <field fieldId="0" name="Offset" type="int32">
         <mandatoryConform/>
         <constraint type="between" from="-43200" to="50400"/>
       </field>
-      <field id="1" name="Name" type="string">
+      <field fieldId="1" name="Name" type="string">
         <optionalConform/>
         <constraint type="lengthBetween" from="0" to="64 bytes"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/ValveConfigurationControl.xml
+++ b/zcl-builtin/matter/new-data-model/ValveConfigurationControl.xml
@@ -179,12 +179,12 @@ Davis, CA 95616, USA
     <command id="0x00" name="Open" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
       <mandatoryConform/>
-      <field id="0" name="OpenDuration" type="elapsed-s">
+      <field fieldId="0" name="OpenDuration" type="elapsed-s">
         <quality nullable="true"/>
         <optionalConform/>
         <constraint type="min" value="1"/>
       </field>
-      <field id="1" name="TargetLevel" type="percent">
+      <field fieldId="1" name="TargetLevel" type="percent">
         <optionalConform>
           <feature name="LVL"/>
         </optionalConform>
@@ -200,10 +200,10 @@ Davis, CA 95616, USA
     <event id="0x00" name="ValveStateChanged" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="ValveState" type="ValveStateEnum">
+      <field fieldId="0" name="ValveState" type="ValveStateEnum">
         <mandatoryConform/>
       </field>
-      <field id="1" name="ValveLevel" type="percent">
+      <field fieldId="1" name="ValveLevel" type="percent">
         <mandatoryConform>
           <feature name="LVL"/>
         </mandatoryConform>
@@ -212,7 +212,7 @@ Davis, CA 95616, USA
     <event id="0x01" name="ValveFault" priority="info">
       <access readPrivilege="view"/>
       <optionalConform/>
-      <field id="0" name="ValveFault" type="ValveFaultBitmap">
+      <field fieldId="0" name="ValveFault" type="ValveFaultBitmap">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/matter/new-data-model/WaterHeaterManagement.xml
+++ b/zcl-builtin/matter/new-data-model/WaterHeaterManagement.xml
@@ -137,22 +137,22 @@ Davis, CA 95616, USA
     <command id="0x01" name="Boost" direction="commandToServer" response="Y">
       <access invokePrivilege="manage"/>
       <mandatoryConform/>
-      <field id="0" name="Duration" type="elapsed-s">
+      <field fieldId="0" name="Duration" type="elapsed-s">
         <mandatoryConform/>
       </field>
-      <field id="1" name="OneShot" type="bool">
+      <field fieldId="1" name="OneShot" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="2" name="EmergencyBoost" type="bool">
+      <field fieldId="2" name="EmergencyBoost" type="bool">
         <mandatoryConform/>
       </field>
-      <field id="3" name="TemporarySetpoint" type="temperature">
+      <field fieldId="3" name="TemporarySetpoint" type="temperature">
         <optionalConform/>
       </field>
-      <field id="4" name="TargetPercentage" type="percent">
+      <field fieldId="4" name="TargetPercentage" type="percent">
         <optionalConform/>
       </field>
-      <field id="5" name="TargetReheat" type="percent">
+      <field fieldId="5" name="TargetReheat" type="percent">
         <optionalConform/>
       </field>
     </command>

--- a/zcl-builtin/matter/new-data-model/WindowCovering.xml
+++ b/zcl-builtin/matter/new-data-model/WindowCovering.xml
@@ -633,7 +633,7 @@ Davis, CA 95616, USA
           <feature name="ABS"/>
         </andTerm>
       </optionalConform>
-      <field id="0" name="LiftValue" type="uint16">
+      <field fieldId="0" name="LiftValue" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -651,11 +651,11 @@ Davis, CA 95616, USA
           <feature name="LF"/>
         </optionalConform>
       </otherwiseConform>
-      <field id="0" name="LiftPercentageValue" type="percent">
+      <field fieldId="0" name="LiftPercentageValue" type="percent">
         <optionalConform choice="a"/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="LiftPercent100thsValue" type="percent100ths">
+      <field fieldId="1" name="LiftPercent100thsValue" type="percent100ths">
         <optionalConform choice="a"/>
         <constraint type="desc"/>
       </field>
@@ -668,7 +668,7 @@ Davis, CA 95616, USA
           <feature name="ABS"/>
         </andTerm>
       </optionalConform>
-      <field id="0" name="TiltValue" type="uint16">
+      <field fieldId="0" name="TiltValue" type="uint16">
         <mandatoryConform/>
         <constraint type="desc"/>
       </field>
@@ -686,11 +686,11 @@ Davis, CA 95616, USA
           <feature name="TL"/>
         </optionalConform>
       </otherwiseConform>
-      <field id="0" name="TiltPercentageValue" type="percent">
+      <field fieldId="0" name="TiltPercentageValue" type="percent">
         <optionalConform choice="a"/>
         <constraint type="desc"/>
       </field>
-      <field id="1" name="TiltPercent100thsValue" type="percent100ths">
+      <field fieldId="1" name="TiltPercent100thsValue" type="percent100ths">
         <optionalConform choice="a"/>
         <constraint type="desc"/>
       </field>

--- a/zcl-builtin/matter/new-data-model/bridge-clusters-ActionsCluster.xml
+++ b/zcl-builtin/matter/new-data-model/bridge-clusters-ActionsCluster.xml
@@ -161,40 +161,40 @@ Davis, CA 95616, USA
       </bitfield>
     </bitmap>
     <struct name="ActionStruct">
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="Name" type="string">
+      <field fieldId="1" name="Name" type="string">
         <mandatoryConform/>
       </field>
-      <field id="2" name="Type" type="ActionTypeEnum">
+      <field fieldId="2" name="Type" type="ActionTypeEnum">
         <mandatoryConform/>
       </field>
-      <field id="3" name="EndpointListID" type="uint16">
+      <field fieldId="3" name="EndpointListID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="4" name="SupportedCommands" type="CommandBits">
+      <field fieldId="4" name="SupportedCommands" type="CommandBits">
         <mandatoryConform/>
         <constraint type="between" from="0" to="0x0FFF"/>
       </field>
-      <field id="5" name="State" type="ActionStateEnum">
+      <field fieldId="5" name="State" type="ActionStateEnum">
         <mandatoryConform/>
       </field>
     </struct>
     <struct name="EndpointListStruct">
-      <field id="0" name="EndpointListID" type="uint16">
+      <field fieldId="0" name="EndpointListID" type="uint16">
         <access read="true"/>
         <mandatoryConform/>
       </field>
-      <field id="1" name="Name" type="string">
+      <field fieldId="1" name="Name" type="string">
         <access read="true"/>
         <mandatoryConform/>
       </field>
-      <field id="2" name="Type" type="EndpointListTypeEnum">
+      <field fieldId="2" name="Type" type="EndpointListTypeEnum">
         <access read="true"/>
         <mandatoryConform/>
       </field>
-      <field id="3" name="Endpoints" type="list">
+      <field fieldId="3" name="Endpoints" type="list">
         <entry type="endpoint-no"/>
         <access read="true"/>
         <mandatoryConform/>
@@ -224,124 +224,124 @@ Davis, CA 95616, USA
   <commands>
     <command id="0x00" name="InstantAction" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
     </command>
     <command id="0x01" name="InstantActionWithTransition" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
-      <field id="2" name="TransitionTime" type="uint16" default="MS">
+      <field fieldId="2" name="TransitionTime" type="uint16" default="MS">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x02" name="StartAction" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
     </command>
     <command id="0x03" name="StartActionWithDuration" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
-      <field id="2" name="Duration" type="uint32" default="MS">
+      <field fieldId="2" name="Duration" type="uint32" default="MS">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x04" name="StopAction" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
     </command>
     <command id="0x05" name="PauseAction" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
     </command>
     <command id="0x06" name="PauseActionWithDuration" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
-      <field id="2" name="Duration" type="uint32" default="MS">
+      <field fieldId="2" name="Duration" type="uint32" default="MS">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x07" name="ResumeAction" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
     </command>
     <command id="0x08" name="EnableAction" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
     </command>
     <command id="0x09" name="EnableActionWithDuration" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
-      <field id="2" name="Duration" type="uint32" default="MS">
+      <field fieldId="2" name="Duration" type="uint32" default="MS">
         <mandatoryConform/>
       </field>
     </command>
     <command id="0x0A" name="DisableAction" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
     </command>
     <command id="0x0B" name="DisableActionWithDuration" direction="commandToServer" response="Y">
       <access invokePrivilege="operate"/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <optionalConform/>
       </field>
-      <field id="2" name="Duration" type="uint32" default="MS">
+      <field fieldId="2" name="Duration" type="uint32" default="MS">
         <mandatoryConform/>
       </field>
     </command>
@@ -350,29 +350,29 @@ Davis, CA 95616, USA
     <event id="0x00" name="StateChanged" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="2" name="NewState" type="ActionStateEnum">
+      <field fieldId="2" name="NewState" type="ActionStateEnum">
         <mandatoryConform/>
       </field>
     </event>
     <event id="0x01" name="ActionFailed" priority="info">
       <access readPrivilege="view"/>
       <mandatoryConform/>
-      <field id="0" name="ActionID" type="uint16">
+      <field fieldId="0" name="ActionID" type="uint16">
         <mandatoryConform/>
       </field>
-      <field id="1" name="InvokeID" type="uint32">
+      <field fieldId="1" name="InvokeID" type="uint32">
         <mandatoryConform/>
       </field>
-      <field id="2" name="NewState" type="ActionStateEnum">
+      <field fieldId="2" name="NewState" type="ActionStateEnum">
         <mandatoryConform/>
       </field>
-      <field id="3" name="Error" type="ActionErrorEnum">
+      <field fieldId="3" name="Error" type="ActionErrorEnum">
         <mandatoryConform/>
       </field>
     </event>

--- a/zcl-builtin/shared/schema/zcl.xsd
+++ b/zcl-builtin/shared/schema/zcl.xsd
@@ -29,7 +29,7 @@ This schema describes the format of the XML files, that describe the ZCL specifi
     <xs:attribute name="modifier" type="xs:string"/>
   </xs:complexType>
   <xs:complexType name="eventField">
-    <xs:attribute name="id" use="required" type="xs:string"/>
+    <xs:attribute name="fieldId" type="xs:integer" use="required"/>
     <xs:attribute name="name" use="required" type="xs:string"/>
     <xs:attribute name="type" use="required" type="xs:string"/>
     <xs:attribute name="array" use="optional" type="xs:boolean"/>
@@ -61,7 +61,6 @@ This schema describes the format of the XML files, that describe the ZCL specifi
     <xs:attribute name="fieldId" type="xs:integer"/>
     <xs:attribute name="countArg" type="xs:string" use="optional"/>
     <xs:attribute name="isNullable" type="xs:boolean"/>
-    <xs:attribute name="id" type="xs:string" use="optional"/>
     <xs:attribute name="min" type="xs:string" use="optional"/>
     <xs:attribute name="max" type="xs:string" use="optional"/>
     <xs:attribute name="minLength" type="xs:integer" use="optional"/>

--- a/zcl-builtin/silabs/demo.xml
+++ b/zcl-builtin/silabs/demo.xml
@@ -21,9 +21,9 @@
     </command>
     <event code="0x0001" name="HelloEvent" priority="info" side="server">
       <description>Example test event</description>
-      <field id="1" name="arg1" type="INT8U"/>
-      <field id="2" name="arg2" type="INT32U"/>
-      <field id="3" name="arg3" type="CHAR_STRING"/>
+      <field fieldId="1" name="arg1" type="INT8U"/>
+      <field fieldId="2" name="arg2" type="INT32U"/>
+      <field fieldId="3" name="arg3" type="CHAR_STRING"/>
     </event>
   </cluster>
 </configurator>


### PR DESCRIPTION
- Rename event <field> attribute from id to fieldId in all ZCL/Matter XML
  to match zcl.xsd (eventField requires fieldId).
- In zcl-loader-silabs.js, read fieldId with fallback to id so existing
  XML using id still loads.
