### PR TITLE
Improve Extensions page UX

### DIFF
--- a/cypress/e2e/ui/extensions.cy.js
+++ b/cypress/e2e/ui/extensions.cy.js
@@ -36,7 +36,7 @@ describe('Extensions page functionality', () => {
     cy.dataCy('btn-extensions').click({ force: true })
     cy.wait(1000)
     cy.contains(
-      'You can use this functionality to add custom ZCL clusters to the ZCL Advanced Platform (ZAP). Click the button below to browse for an XML file containing only cluster definitions. JSON files are not currently supported for loading.'
+      'Use this to add custom ZCL elements to the ZCL Advanced Platform (ZAP). Click the button below to select an XML file.'
     ).should('be.visible')
   })
 
@@ -50,14 +50,14 @@ describe('Extensions page functionality', () => {
   it('Should display Added files section', () => {
     cy.dataCy('btn-extensions').click({ force: true })
     cy.wait(1000)
-    cy.contains('Built-in ZCL packages').should('be.visible')
+    cy.contains('Standard ZCL packages').should('be.visible')
   })
 
   it('Should handle empty extensions list', () => {
     cy.dataCy('btn-extensions').click({ force: true })
     cy.wait(1000)
     // Even with no extensions, the page structure should be visible
-    cy.contains('Custom XML extensions').should('be.visible')
+    cy.contains('Custom XML Extensions').should('be.visible')
     cy.get('.cluster-list').should('exist')
   })
 

--- a/cypress/e2e/ui/extensions.cy.js
+++ b/cypress/e2e/ui/extensions.cy.js
@@ -36,28 +36,28 @@ describe('Extensions page functionality', () => {
     cy.dataCy('btn-extensions').click({ force: true })
     cy.wait(1000)
     cy.contains(
-      'You can use this functionality to add custom ZCL clusters or commands'
+      'You can use this functionality to add custom ZCL clusters to the ZCL Advanced Platform (ZAP). Click the button below to browse for an XML file containing only cluster definitions. JSON files are not currently supported for loading.'
     ).should('be.visible')
   })
 
   it('Should display Browse file button', () => {
     cy.dataCy('btn-extensions').click({ force: true })
     cy.wait(1000)
-    cy.contains('Browse file').should('be.visible')
-    cy.get('button').contains('Browse file').should('exist')
+    cy.contains('Browse for XML file').should('be.visible')
+    cy.get('button').contains('Browse for XML file').should('exist')
   })
 
   it('Should display Added files section', () => {
     cy.dataCy('btn-extensions').click({ force: true })
     cy.wait(1000)
-    cy.contains('Added files').should('be.visible')
+    cy.contains('Built-in ZCL packages').should('be.visible')
   })
 
   it('Should handle empty extensions list', () => {
     cy.dataCy('btn-extensions').click({ force: true })
     cy.wait(1000)
     // Even with no extensions, the page structure should be visible
-    cy.contains('Added files').should('be.visible')
+    cy.contains('Custom XML extensions').should('be.visible')
     cy.get('.cluster-list').should('exist')
   })
 
@@ -79,8 +79,8 @@ describe('Extensions page functionality', () => {
     cy.dataCy('btn-extensions').click({ force: true })
     cy.wait(1000)
     // The browse button should exist and be clickable
-    cy.get('button').contains('Browse file').should('be.visible')
+    cy.get('button').contains('Browse for XML file').should('be.visible')
     // Note: Actual file browser can't be tested in Cypress without mocking
-    cy.get('button').contains('Browse file').should('exist')
+    cy.get('button').contains('Browse for XML file').should('exist')
   })
 })

--- a/src/components/PackagesList.vue
+++ b/src/components/PackagesList.vue
@@ -1,0 +1,118 @@
+<template>
+  <q-list class="cluster-list">
+    <div v-for="(pkg, index) in packages" :key="'custom-' + index">
+      <q-item dense class="q-px-none">
+        <q-item-section>
+          <q-expansion-item>
+            <template #header>
+              <q-item-section avatar class="q-pr-none">
+                <q-icon
+                  :class="{
+                    'cursor-pointer':
+                      iconName(pkg.pkg.id) == 'error' ||
+                      iconName(pkg.pkg.id) == 'warning'
+                  }"
+                  :name="iconName(pkg.pkg.id)"
+                  :color="iconColor(pkg.pkg.id)"
+                  size="1.5em"
+                  @click="() => handleIconClick(pkg.pkg.id)"
+                />
+              </q-item-section>
+              <div class="q-my-auto q-item__label q-item__label__popup">
+                <strong>{{ getFileName(pkg.pkg.path) }}</strong>
+              </div>
+              <q-space />
+              <q-btn
+                v-if="!builtIn"
+                class="q-mx-xl"
+                label="Delete"
+                icon="delete"
+                flat
+                dense
+                @click.stop="deletePackage(pkg)"
+                :disable="pkg.sessionPackage.required"
+              />
+            </template>
+            <q-card>
+              <q-card-section>
+                <div class="q-mx-lg q-px-lg">
+                  <strong> Full File path:</strong>
+                  {{ pkg.pkg.path }} <br />
+                  <strong> Package Type:</strong>
+                  {{ pkg.pkg.type }} <br />
+                  <strong> Version: </strong>{{ pkg.pkg.version }} <br />
+                  <strong> Required:</strong>
+                  {{ pkg.sessionPackage.required ? 'True' : 'False' }}
+                </div>
+              </q-card-section>
+            </q-card>
+          </q-expansion-item>
+        </q-item-section>
+      </q-item>
+    </div>
+  </q-list>
+</template>
+<script>
+export default {
+  name: 'PackagesList',
+  props: {
+    packages: {
+      type: Array,
+      required: true
+    },
+    builtIn: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    notisData: {
+      type: Object,
+      required: false,
+      default: () => ({})
+    }
+  },
+  data() {
+    return {
+      dialogData: {}
+    }
+  },
+  methods: {
+    async deletePackage(packageToDelete) {
+      await this.$store.dispatch(
+        'zap/deleteSessionPackage',
+        packageToDelete.sessionPackage
+      )
+      await this.$store.dispatch('zap/updateClusters')
+      await this.$store.dispatch('zap/updateAtomics')
+    },
+    iconName(packageId) {
+      if (this.notisData[packageId]?.hasError) {
+        return 'error'
+      } else if (this.notisData[packageId]?.hasWarning) {
+        return 'warning'
+      } else {
+        return 'check_circle'
+      }
+    },
+    iconColor(packageId) {
+      if (this.notisData[packageId]?.hasError) {
+        return 'red'
+      } else if (this.notisData[packageId]?.hasWarning) {
+        return 'orange'
+      } else {
+        return 'green'
+      }
+    },
+    handleIconClick(packageId) {
+      let iconName = this.iconName(packageId)
+      if (iconName === 'error' || iconName === 'warning') {
+        this.dialogData[packageId] = true
+      }
+    },
+    getFileName(path) {
+      let fileName = path.match(/[^/]+$/)
+      return fileName.length > 0 ? fileName[0] : path
+    }
+  }
+}
+</script>

--- a/src/pages/ExtensionsPage.vue
+++ b/src/pages/ExtensionsPage.vue
@@ -209,6 +209,7 @@ limitations under the License.
                   <div class="q-my-auto q-item__label q-item__label__popup">
                     <strong>{{ getFileName(sessionPackage.pkg.path) }}</strong>
                   </div>
+                  <q-space />
                 </template>
                 <q-card>
                   <q-card-section>

--- a/src/pages/ExtensionsPage.vue
+++ b/src/pages/ExtensionsPage.vue
@@ -52,10 +52,16 @@ limitations under the License.
     </q-card-section>
     <q-card-section class="q-pt-none">
       <div class="row items-center">
-        <strong>Added files</strong>
+        <strong>Custom XML extensions</strong>
+      </div>
+      <div v-if="customPackages.length === 0" class="text-grey-7 q-mt-sm">
+        No custom extensions added yet.
       </div>
       <q-list class="cluster-list">
-        <div v-for="(sessionPackage, index) in packages" :key="index">
+        <div
+          v-for="(sessionPackage, index) in customPackages"
+          :key="'custom-' + index"
+        >
           <q-item dense class="q-px-none">
             <q-item-section>
               <q-expansion-item>
@@ -78,9 +84,6 @@ limitations under the License.
                   </div>
                   <q-space />
                   <q-btn
-                    v-if="
-                      sessionPackage.sessionPackage.type == 'zcl-xml-standalone'
-                    "
                     class="q-mx-xl"
                     label="Delete"
                     icon="delete"
@@ -89,6 +92,123 @@ limitations under the License.
                     @click.stop="deletePackage(sessionPackage)"
                     :disable="sessionPackage.sessionPackage.required"
                   />
+                </template>
+                <q-card>
+                  <q-card-section>
+                    <div class="q-mx-lg q-px-lg">
+                      <strong> Full File path:</strong>
+                      {{ sessionPackage.pkg.path }} <br />
+                      <strong> Package Type:</strong>
+                      {{ sessionPackage.pkg.type }} <br />
+                      <strong> Version: </strong
+                      >{{ sessionPackage.pkg.version }} <br />
+                      <strong> Required:</strong>
+                      {{
+                        sessionPackage.sessionPackage.required
+                          ? 'True'
+                          : 'False'
+                      }}
+                    </div>
+                  </q-card-section>
+                </q-card>
+              </q-expansion-item>
+            </q-item-section>
+            <q-dialog v-model="dialogData[sessionPackage.pkg.id]">
+              <q-card>
+                <q-card-section>
+                  <div class="row items-center">
+                    <div class="col-1">
+                      <q-icon
+                        :name="iconName(sessionPackage.pkg.id)"
+                        :color="iconColor(sessionPackage.pkg.id)"
+                        size="2em"
+                      ></q-icon>
+                    </div>
+                    <div class="text-h6 col">
+                      {{ sessionPackage.pkg.path }}
+                    </div>
+                    <div class="col-1 text-right">
+                      <q-btn dense flat icon="close" v-close-popup>
+                        <q-tooltip>Close</q-tooltip>
+                      </q-btn>
+                    </div>
+                  </div>
+                  <div v-if="notisData[sessionPackage.pkg.id]?.hasError">
+                    <div
+                      class="text-h6"
+                      style="margin-top: 15px; padding-left: 20px"
+                    >
+                      Errors
+                    </div>
+                    <ul>
+                      <li
+                        v-for="(error, index) in populateNotifications(
+                          sessionPackage.pkg.id,
+                          'ERROR'
+                        )"
+                        :key="'error' + index"
+                        style="margin-bottom: 10px"
+                      >
+                        {{ error.message }}
+                      </li>
+                    </ul>
+                  </div>
+                  <div v-if="notisData[sessionPackage.pkg.id]?.hasWarning">
+                    <div
+                      class="text-h6"
+                      style="margin-top: 15px; padding-left: 20px"
+                    >
+                      Warnings
+                    </div>
+                    <ul>
+                      <li
+                        v-for="(warning, index) in populateNotifications(
+                          sessionPackage.pkg.id,
+                          'WARNING'
+                        )"
+                        :key="index"
+                        style="margin-bottom: 10px"
+                      >
+                        {{ warning.message }}
+                      </li>
+                    </ul>
+                  </div>
+                </q-card-section>
+              </q-card>
+            </q-dialog>
+          </q-item>
+        </div>
+      </q-list>
+    </q-card-section>
+    <q-card-section class="q-pt-none">
+      <div class="row items-center">
+        <strong>Built-in ZCL packages</strong>
+      </div>
+      <q-list class="cluster-list">
+        <div
+          v-for="(sessionPackage, index) in builtInPackages"
+          :key="'builtin-' + index"
+        >
+          <q-item dense class="q-px-none">
+            <q-item-section>
+              <q-expansion-item>
+                <template #header>
+                  <q-item-section avatar class="q-pr-none">
+                    <q-icon
+                      :class="{
+                        'cursor-pointer':
+                          iconName(sessionPackage.pkg.id) == 'error' ||
+                          iconName(sessionPackage.pkg.id) == 'warning'
+                      }"
+                      :name="iconName(sessionPackage.pkg.id)"
+                      :color="iconColor(sessionPackage.pkg.id)"
+                      size="1.5em"
+                      @click="() => handleIconClick(sessionPackage.pkg.id)"
+                    />
+                  </q-item-section>
+                  <div class="q-my-auto q-item__label q-item__label__popup">
+                    <strong>{{ getFileName(sessionPackage.pkg.path) }}</strong>
+                  </div>
                 </template>
                 <q-card>
                   <q-card-section>
@@ -201,6 +321,18 @@ export default {
       this.loadNewPackage().then(() => {
         this.$store.dispatch('zap/updateZclDeviceTypes')
       })
+    }
+  },
+  computed: {
+    customPackages() {
+      return this.packages.filter(
+        (p) => p.sessionPackage.type === 'zcl-xml-standalone'
+      )
+    },
+    builtInPackages() {
+      return this.packages.filter(
+        (p) => p.sessionPackage.type !== 'zcl-xml-standalone'
+      )
     }
   },
   methods: {

--- a/src/pages/ExtensionsPage.vue
+++ b/src/pages/ExtensionsPage.vue
@@ -22,10 +22,8 @@ limitations under the License.
       </div>
       <div class="column">
         <div class="col">
-          You can use this functionality to add custom ZCL clusters to the ZCL
-          Advanced Platform (ZAP). Click the button below to browse for an
-          <strong>XML file containing only cluster definitions</strong>. JSON
-          files are not currently supported for loading.
+          Use this to add custom ZCL elements to the ZCL Advanced Platform
+          (ZAP). Click the button below to select an XML file.
         </div>
         <p
           class="text-center"
@@ -44,15 +42,14 @@ limitations under the License.
           label="Browse for XML file"
         >
           <q-tooltip>
-            Only XML files containing cluster definitions can be loaded. JSON
-            package files shown below are for reference only.
+            Only XML files containing custom ZCL elements can be loaded.
           </q-tooltip>
         </q-btn>
       </div>
     </q-card-section>
     <q-card-section class="q-pt-none">
       <div class="row items-center">
-        <strong>Custom XML extensions</strong>
+        <strong>Custom XML Extensions</strong>
       </div>
       <div v-if="customPackages.length === 0" class="text-grey-7 q-mt-sm">
         No custom extensions added yet.
@@ -61,7 +58,7 @@ limitations under the License.
     </q-card-section>
     <q-card-section class="q-pt-none">
       <div class="row items-center">
-        <strong>Built-in ZCL packages</strong>
+        <strong>Standard ZCL packages</strong>
       </div>
       <PackagesList
         :packages="builtInPackages"

--- a/src/pages/ExtensionsPage.vue
+++ b/src/pages/ExtensionsPage.vue
@@ -22,8 +22,10 @@ limitations under the License.
       </div>
       <div class="column">
         <div class="col">
-          You can use this functionality to add custom ZCL clusters or commands
-          to the ZCL Advanced Platform (ZAP)
+          You can use this functionality to add custom ZCL clusters to the ZCL
+          Advanced Platform (ZAP). Click the button below to browse for an
+          <strong>XML file containing only cluster definitions</strong>. JSON
+          files are not currently supported for loading.
         </div>
         <p
           class="text-center"
@@ -39,8 +41,13 @@ limitations under the License.
           class="v-step-17 col q-mx-auto q-mt-md"
           @click="browseForFile()"
           rounded
-          label="Browse file"
-        />
+          label="Browse for XML file"
+        >
+          <q-tooltip>
+            Only XML files containing cluster definitions can be loaded. JSON
+            package files shown below are for reference only.
+          </q-tooltip>
+        </q-btn>
       </div>
     </q-card-section>
     <q-card-section class="q-pt-none">

--- a/src/pages/ExtensionsPage.vue
+++ b/src/pages/ExtensionsPage.vue
@@ -57,246 +57,17 @@ limitations under the License.
       <div v-if="customPackages.length === 0" class="text-grey-7 q-mt-sm">
         No custom extensions added yet.
       </div>
-      <q-list class="cluster-list">
-        <div
-          v-for="(sessionPackage, index) in customPackages"
-          :key="'custom-' + index"
-        >
-          <q-item dense class="q-px-none">
-            <q-item-section>
-              <q-expansion-item>
-                <template #header>
-                  <q-item-section avatar class="q-pr-none">
-                    <q-icon
-                      :class="{
-                        'cursor-pointer':
-                          iconName(sessionPackage.pkg.id) == 'error' ||
-                          iconName(sessionPackage.pkg.id) == 'warning'
-                      }"
-                      :name="iconName(sessionPackage.pkg.id)"
-                      :color="iconColor(sessionPackage.pkg.id)"
-                      size="1.5em"
-                      @click="() => handleIconClick(sessionPackage.pkg.id)"
-                    />
-                  </q-item-section>
-                  <div class="q-my-auto q-item__label q-item__label__popup">
-                    <strong>{{ getFileName(sessionPackage.pkg.path) }}</strong>
-                  </div>
-                  <q-space />
-                  <q-btn
-                    class="q-mx-xl"
-                    label="Delete"
-                    icon="delete"
-                    flat
-                    dense
-                    @click.stop="deletePackage(sessionPackage)"
-                    :disable="sessionPackage.sessionPackage.required"
-                  />
-                </template>
-                <q-card>
-                  <q-card-section>
-                    <div class="q-mx-lg q-px-lg">
-                      <strong> Full File path:</strong>
-                      {{ sessionPackage.pkg.path }} <br />
-                      <strong> Package Type:</strong>
-                      {{ sessionPackage.pkg.type }} <br />
-                      <strong> Version: </strong
-                      >{{ sessionPackage.pkg.version }} <br />
-                      <strong> Required:</strong>
-                      {{
-                        sessionPackage.sessionPackage.required
-                          ? 'True'
-                          : 'False'
-                      }}
-                    </div>
-                  </q-card-section>
-                </q-card>
-              </q-expansion-item>
-            </q-item-section>
-            <q-dialog v-model="dialogData[sessionPackage.pkg.id]">
-              <q-card>
-                <q-card-section>
-                  <div class="row items-center">
-                    <div class="col-1">
-                      <q-icon
-                        :name="iconName(sessionPackage.pkg.id)"
-                        :color="iconColor(sessionPackage.pkg.id)"
-                        size="2em"
-                      ></q-icon>
-                    </div>
-                    <div class="text-h6 col">
-                      {{ sessionPackage.pkg.path }}
-                    </div>
-                    <div class="col-1 text-right">
-                      <q-btn dense flat icon="close" v-close-popup>
-                        <q-tooltip>Close</q-tooltip>
-                      </q-btn>
-                    </div>
-                  </div>
-                  <div v-if="notisData[sessionPackage.pkg.id]?.hasError">
-                    <div
-                      class="text-h6"
-                      style="margin-top: 15px; padding-left: 20px"
-                    >
-                      Errors
-                    </div>
-                    <ul>
-                      <li
-                        v-for="(error, index) in populateNotifications(
-                          sessionPackage.pkg.id,
-                          'ERROR'
-                        )"
-                        :key="'error' + index"
-                        style="margin-bottom: 10px"
-                      >
-                        {{ error.message }}
-                      </li>
-                    </ul>
-                  </div>
-                  <div v-if="notisData[sessionPackage.pkg.id]?.hasWarning">
-                    <div
-                      class="text-h6"
-                      style="margin-top: 15px; padding-left: 20px"
-                    >
-                      Warnings
-                    </div>
-                    <ul>
-                      <li
-                        v-for="(warning, index) in populateNotifications(
-                          sessionPackage.pkg.id,
-                          'WARNING'
-                        )"
-                        :key="index"
-                        style="margin-bottom: 10px"
-                      >
-                        {{ warning.message }}
-                      </li>
-                    </ul>
-                  </div>
-                </q-card-section>
-              </q-card>
-            </q-dialog>
-          </q-item>
-        </div>
-      </q-list>
+      <PackagesList :packages="customPackages" :notisData="notisData" v-else />
     </q-card-section>
     <q-card-section class="q-pt-none">
       <div class="row items-center">
         <strong>Built-in ZCL packages</strong>
       </div>
-      <q-list class="cluster-list">
-        <div
-          v-for="(sessionPackage, index) in builtInPackages"
-          :key="'builtin-' + index"
-        >
-          <q-item dense class="q-px-none">
-            <q-item-section>
-              <q-expansion-item>
-                <template #header>
-                  <q-item-section avatar class="q-pr-none">
-                    <q-icon
-                      :class="{
-                        'cursor-pointer':
-                          iconName(sessionPackage.pkg.id) == 'error' ||
-                          iconName(sessionPackage.pkg.id) == 'warning'
-                      }"
-                      :name="iconName(sessionPackage.pkg.id)"
-                      :color="iconColor(sessionPackage.pkg.id)"
-                      size="1.5em"
-                      @click="() => handleIconClick(sessionPackage.pkg.id)"
-                    />
-                  </q-item-section>
-                  <div class="q-my-auto q-item__label q-item__label__popup">
-                    <strong>{{ getFileName(sessionPackage.pkg.path) }}</strong>
-                  </div>
-                  <q-space />
-                </template>
-                <q-card>
-                  <q-card-section>
-                    <div class="q-mx-lg q-px-lg">
-                      <strong> Full File path:</strong>
-                      {{ sessionPackage.pkg.path }} <br />
-                      <strong> Package Type:</strong>
-                      {{ sessionPackage.pkg.type }} <br />
-                      <strong> Version: </strong
-                      >{{ sessionPackage.pkg.version }} <br />
-                      <strong> Required:</strong>
-                      {{
-                        sessionPackage.sessionPackage.required
-                          ? 'True'
-                          : 'False'
-                      }}
-                    </div>
-                  </q-card-section>
-                </q-card>
-              </q-expansion-item>
-            </q-item-section>
-            <q-dialog v-model="dialogData[sessionPackage.pkg.id]">
-              <q-card>
-                <q-card-section>
-                  <div class="row items-center">
-                    <div class="col-1">
-                      <q-icon
-                        :name="iconName(sessionPackage.pkg.id)"
-                        :color="iconColor(sessionPackage.pkg.id)"
-                        size="2em"
-                      ></q-icon>
-                    </div>
-                    <div class="text-h6 col">
-                      {{ sessionPackage.pkg.path }}
-                    </div>
-                    <div class="col-1 text-right">
-                      <q-btn dense flat icon="close" v-close-popup>
-                        <q-tooltip>Close</q-tooltip>
-                      </q-btn>
-                    </div>
-                  </div>
-                  <div v-if="notisData[sessionPackage.pkg.id]?.hasError">
-                    <div
-                      class="text-h6"
-                      style="margin-top: 15px; padding-left: 20px"
-                    >
-                      Errors
-                    </div>
-                    <ul>
-                      <li
-                        v-for="(error, index) in populateNotifications(
-                          sessionPackage.pkg.id,
-                          'ERROR'
-                        )"
-                        :key="'error' + index"
-                        style="margin-bottom: 10px"
-                      >
-                        {{ error.message }}
-                      </li>
-                    </ul>
-                  </div>
-                  <div v-if="notisData[sessionPackage.pkg.id]?.hasWarning">
-                    <div
-                      class="text-h6"
-                      style="margin-top: 15px; padding-left: 20px"
-                    >
-                      Warnings
-                    </div>
-                    <ul>
-                      <li
-                        v-for="(warning, index) in populateNotifications(
-                          sessionPackage.pkg.id,
-                          'WARNING'
-                        )"
-                        :key="index"
-                        style="margin-bottom: 10px"
-                      >
-                        {{ warning.message }}
-                      </li>
-                    </ul>
-                  </div>
-                </q-card-section>
-              </q-card>
-            </q-dialog>
-          </q-item>
-        </div>
-      </q-list>
+      <PackagesList
+        :packages="builtInPackages"
+        :notisData="notisData"
+        builtIn
+      />
     </q-card-section>
   </PreferencePageLayout>
 </template>
@@ -306,13 +77,15 @@ import CommonMixin from '../util/common-mixin'
 import rendApi from '../../src-shared/rend-api.js'
 import restApi from '../../src-shared/rest-api.js'
 import PreferencePageLayout from '../layouts/PreferencePageLayout.vue'
+import PackagesList from '../components/PackagesList.vue'
 const observable = require('../util/observable.js')
 import { Notify } from 'quasar'
 
 export default {
   mixins: [CommonMixin],
   components: {
-    PreferencePageLayout
+    PreferencePageLayout,
+    PackagesList
   },
   watch: {
     packages(newPackages) {
@@ -337,10 +110,6 @@ export default {
     }
   },
   methods: {
-    getFileName(path) {
-      let fileName = path.match(/[^/]+$/)
-      return fileName.length > 0 ? fileName[0] : path
-    },
     browseForFile() {
       window[rendApi.GLOBAL_SYMBOL_NOTIFY](rendApi.notifyKey.fileBrowse, {
         context: 'customXml',
@@ -377,18 +146,9 @@ export default {
           let packageId = packageFile.pkg.id
           if (packageId) {
             this.getPackageNotifications(packageId)
-            this.dialogData[packageId] = false
           }
         })
       }
-    },
-    async deletePackage(packageToDelete) {
-      await this.$store.dispatch(
-        'zap/deleteSessionPackage',
-        packageToDelete.sessionPackage
-      )
-      await this.$store.dispatch('zap/updateClusters')
-      await this.$store.dispatch('zap/updateAtomics')
     },
     async getPackageNotifications(packageId) {
       this.$serverGet(
@@ -409,36 +169,8 @@ export default {
             currentPackage.warnings.push(notification)
           }
         })
-        this.notisData[packageId] = currentPackage
+        this.$set(this.notisData, packageId, currentPackage)
       })
-    },
-    iconName(packageId) {
-      if (this.notisData[packageId]?.hasError) {
-        return 'error'
-      } else if (this.notisData[packageId]?.hasWarning) {
-        return 'warning'
-      } else {
-        return 'check_circle'
-      }
-    },
-    iconColor(packageId) {
-      if (this.notisData[packageId]?.hasError) {
-        return 'red'
-      } else if (this.notisData[packageId]?.hasWarning) {
-        return 'orange'
-      } else {
-        return 'green'
-      }
-    },
-    handleIconClick(packageId) {
-      let iconName = this.iconName(packageId)
-      if (iconName === 'error' || iconName === 'warning') {
-        this.dialogData[packageId] = true
-      }
-    },
-    populateNotifications(packageId, type) {
-      let key = type == 'ERROR' ? 'errors' : 'warnings'
-      return this.notisData[packageId][key]
     },
     // Custom xml currently not supported for multi-protocol
     enableExtensionsWarning() {
@@ -467,8 +199,7 @@ export default {
     return {
       packageToLoad: '',
       error: null,
-      notisData: {},
-      dialogData: {}
+      notisData: {}
     }
   }
 }


### PR DESCRIPTION
clarify XML-only support and separate package categories
<img width="1583" height="749" alt="Screenshot 2026-03-17 at 12 47 29" src="https://github.com/user-attachments/assets/ca6b8f79-c4cb-416e-b322-003b4c81f1b5" />

- Updated the description text to clearly state that only XML files containing cluster definitions are supported, and that JSON files cannot be loaded
- Renamed the "Browse file" button to "Browse for XML file" and added a tooltip reinforcing the XML-only requirement
- Separated the package list into two distinct sections: "Custom XML extensions" (user-uploaded, with delete button) and "Built-in ZCL packages" (pre-loaded, read-only)
- Added an empty state message ("No custom extensions added yet.") when no custom XML files have been uploaded
- Added customPackages and builtInPackages computed properties to split the package list by type (zcl-xml-standalone vs. everything else)
