### PR TITLE
JSDoc db-mapping keys for block helpers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9072,15 +9072,15 @@ For each element, context contains role, operation, accessModifier.
 Additionally it creates booleans hasRole, hasOperation and hasAccessModifier
 and hasAtLeastOneAccessElement and hasAllAccessElements
 From `exports.map.access` in `src-electron/db/db-mapping.js`:
+- accessModifier
 - operation
 - role
-- accessModifier
 Helper-added:
-- hasRole
-- hasOperation
 - hasAccessModifier
 - hasAllAccessElements
 - hasAtLeastOneAccessElement
+- hasOperation
+- hasRole
 
 **Kind**: inner method of [<code>Templating API: Access helpers</code>](#module_Templating API_ Access helpers)  
 
@@ -9093,15 +9093,15 @@ Helper-added:
 ### Templating API: Access helpers~default\_access(options) ⇒
 Get the access list information.
 From `exports.map.access` in `src-electron/db/db-mapping.js`:
+- accessModifier
 - operation
 - role
-- accessModifier
 Helper-added (same as `access`):
-- hasRole
-- hasOperation
 - hasAccessModifier
 - hasAllAccessElements
 - hasAtLeastOneAccessElement
+- hasOperation
+- hasRole
 
 **Kind**: inner method of [<code>Templating API: Access helpers</code>](#module_Templating API_ Access helpers)  
 **Returns**: access list  
@@ -10981,21 +10981,21 @@ Creates block iterator over the endpoints.
 Creates device type iterator over an endpoint type id.
 This works inside user_endpoints or user_endpoint_types.
 From `exports.map.endpointTypeDeviceExtended` in `src-electron/db/db-mapping.js`:
-- id
-- deviceTypeRef
-- endpointTypeRef
-- endpointTypeId
-- deviceTypeOrder
-- deviceIdentifier
-- deviceId
-- deviceVersion
-- featureId
-- featureCode
-- featureName
-- featureBit
 - clusterId
 - composition
 - conformance
+- deviceId
+- deviceIdentifier
+- deviceTypeOrder
+- deviceTypeRef
+- deviceVersion
+- endpointTypeId
+- endpointTypeRef
+- featureBit
+- featureCode
+- featureId
+- featureName
+- id
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -11010,13 +11010,13 @@ Creates iterator over endpoint composition requirements for a device type.
 This works inside user_device_types context where device type ref is available.
 Returns required device types that must be on separate endpoints.
 From `exports.map.endpointCompositionRequirement` in `src-electron/db/db-mapping.js`:
+- compositionType
+- conformance
+- deviceConstraint
+- endpointCompositionId
 - requiredDeviceCode
 - requiredDeviceName
 - requiredDeviceTypeRef
-- conformance
-- deviceConstraint
-- compositionType
-- endpointCompositionId
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -11029,19 +11029,19 @@ From `exports.map.endpointCompositionRequirement` in `src-electron/db/db-mapping
 ### Templating API: user-data specific helpers~user\_endpoint\_types(options)
 Creates block iterator helper over the endpoint types.
 From `exports.map.endpointType` in `src-electron/db/db-mapping.js`:
-- id
-- endpointTypeId
-- sessionRef
-- name
 - deviceTypeRef
 - deviceTypes
+- endpointTypeId
+- id
+- name
+- sessionRef
 Also populated in `query-endpoint-type.selectAllEndpointTypes`:
-- deviceVersion
-- deviceIdentifier
 - deviceCategory
+- deviceIdentifier
 - devicePackageRef
-- deviceTypeName
 - deviceTypeCode
+- deviceTypeName
+- deviceVersion
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -11838,24 +11838,24 @@ Check if multi-protocol is enabled for the application.
 ### Templating API: user-data specific helpers~all\_multi\_protocol\_attributes(options) ⇒
 Retrieve all the attribute-attribute associations for the current session.
 From `exports.map.attributeMapping` in `src-electron/db/db-mapping.js`:
-- attributeMappingId
-- attributeRef1
-- attributeRef2
 - attributeCode1
-- attributeMfgCode1
 - attributeCode2
+- attributeMappingId
+- attributeMfgCode1
 - attributeMfgCode2
 - attributeName1
 - attributeName2
+- attributeRef1
+- attributeRef2
 - clusterCode1
-- clusterMfgCode1
 - clusterCode2
+- clusterMappingIndex
+- clusterMfgCode1
 - clusterMfgCode2
 - clusterName1
 - clusterName2
-- clusterMappingIndex
-- totalClusterMappedAttributes
 - isLastPartition
+- totalClusterMappedAttributes
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 **Returns**: attribute-attribute mapping entries  
@@ -11967,6 +11967,7 @@ non-singleton attributes are returned per endpoint. However if used within
 an endpoint block helper it returns token_attributes for a given endpoint
 type.
 From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.js`:
+- apiMaturity
 - arrayType
 - attributeRef
 - bounded
@@ -11976,6 +11977,7 @@ From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.
 - clusterRef
 - clusterSide
 - code
+- conformance
 - defaultValue
 - define
 - endpointId
@@ -11987,19 +11989,20 @@ From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.
 - includedReportable
 - isArray
 - isBound
+- isChangeOmitted
 - isClusterEnabled
 - isGlobalAttribute
 - isIncluded
 - isManufacturingSpecific
 - isNullable
 - isOptionalAttribute
+- isReadable
+- isReadableAttribute
 - isReportableAttribute
 - isSceneRequired
 - isSingleton
 - isWritable
 - isWritableAttribute
-- isReadable
-- isReadableAttribute
 - manufacturerCode
 - max
 - maxInterval
@@ -12010,20 +12013,17 @@ From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.
 - minLength
 - mustUseTimedWrite
 - name
+- persistence
 - reportableChange
+- reportMaxInterval
+- reportMinInterval
 - side
 - singleton
 - smallestEndpointIdentifier
 - storage
 - storageOption
 - tokenId
-- type
-- apiMaturity
-- isChangeOmitted
-- persistence
-- reportMinInterval
-- reportMaxInterval
-- conformance  
+- type  
 
 | Param | Type |
 | --- | --- |
@@ -12045,29 +12045,29 @@ or non-singleton attributes.
 token associated clusters across endpoints.
 Per-endpoint mode (`selectTokenAttributeClustersForEndpoint`), from
 `exports.map.cluster` in `src-electron/db/db-mapping.js`:
-- id
-- packageRef
-- code
-- manufacturerCode
-- label
-- name
-- caption
-- description
-- define
-- domainName
-- isSingleton
-- revision
-- isManufacturingSpecific
 - apiMaturity
+- caption
+- code
+- define
+- description
+- domainName
+- id
+- isManufacturingSpecific
+- isSingleton
+- label
+- manufacturerCode
+- name
+- packageRef
+- revision
 Global mode (`selectAllUserClustersWithTokenAttributes`), from
 `exports.map.endpointTypeClusterExtended` in `src-electron/db/db-mapping.js`:
+- clusterRef
+- code
+- enabled
 - endpointTypeClusterId
 - endpointTypeRef
-- clusterRef
-- side
-- enabled
 - name
-- code
+- side
 - tokenAttributesCount  
 
 | Param | Type |
@@ -12169,10 +12169,10 @@ return back slash
 Block helper that iterates over the package options of a given category.
 From `exports.map.options` in `src-electron/db/db-mapping.js`:
 - id
-- packageRef
 - optionCategory
 - optionCode
 - optionLabel
+- packageRef
 
 **Kind**: inner method of [<code>Templating API: toplevel utility helpers</code>](#module_Templating API_ toplevel utility helpers)  
 
@@ -12582,17 +12582,17 @@ This module contains the API for templating. For more detailed instructions, rea
 ### Templating API: static zcl helpers~zcl\_bitmaps(options) ⇒
 Block helper iterating over all bitmaps.
 From `exports.map.bitmap` in `src-electron/db/db-mapping.js`:
+- apiMaturity
+- bitmapClusterCount
 - id
 - label
 - name
-- type
-- bitmapClusterCount
 - size
-- apiMaturity
+- type
 Helper-added:
+- has_more_than_one_cluster
 - has_no_clusters
 - has_one_cluster
-- has_more_than_one_cluster
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12606,13 +12606,13 @@ Helper-added:
 ### Templating API: static zcl helpers~zcl\_bitmap\_items(options)
 Iterates over bitmap fields. Valid only inside zcl_bitmaps.
 From `exports.map.bitmapField` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- mask
-- type
+- apiMaturity
 - bitmapRef
 - caption
-- apiMaturity
+- label
+- mask
+- name
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -12628,17 +12628,17 @@ If existing independently, it iterates over ALL the enums.
 Within a context of a cluster, it iterates only over the
 enums belonging to a cluster.
 From `exports.map.enum` in `src-electron/db/db-mapping.js`:
+- apiMaturity
+- caption
+- enumClusterCount
 - id
 - label
 - name
-- caption
-- enumClusterCount
 - size
-- apiMaturity
 Helper-added:
+- has_more_than_one_cluster
 - has_no_clusters
 - has_one_cluster
-- has_more_than_one_cluster
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12667,12 +12667,12 @@ structs belonging to a cluster.
 ### Templating API: static zcl helpers~zcl\_enum\_items(options)
 Iterates over enum items. Valid only inside zcl_enums.
 From `exports.map.enumItem` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- value
-- enumRef
-- caption
 - apiMaturity
+- caption
+- enumRef
+- label
+- name
+- value
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -12699,23 +12699,23 @@ mode="first_unused" (which is the default).
 ### Templating API: static zcl helpers~zcl\_struct\_items(options) ⇒
 Block helper iterating over all struct items. Valid only inside zcl_structs.
 From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- fieldIdentifier
-- structRef
-- type
-- minLength
-- maxLength
+- apiMaturity
+- dataTypeReference
 - defaultValue
+- discriminatorName
+- fieldIdentifier
 - isArray
 - isEnum
-- isWritable
+- isFabricSensitive
 - isNullable
 - isOptional
-- isFabricSensitive
-- dataTypeReference
-- discriminatorName
-- apiMaturity
+- isWritable
+- label
+- maxLength
+- minLength
+- name
+- structRef
+- type
 When `checkForDoubleNestedArray` is true, the helper may also set:
 - struct_item_contains_nested_array
 
@@ -12731,23 +12731,23 @@ When `checkForDoubleNestedArray` is true, the helper may also set:
 ### Templating API: static zcl helpers~zcl\_struct\_items\_by\_struct\_name(name, options) ⇒
 Block helper iterating over all struct items given the struct name.
 From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- fieldIdentifier
-- structRef
-- type
-- minLength
-- maxLength
+- apiMaturity
+- dataTypeReference
 - defaultValue
+- discriminatorName
+- fieldIdentifier
 - isArray
 - isEnum
-- isWritable
+- isFabricSensitive
 - isNullable
 - isOptional
-- isFabricSensitive
-- dataTypeReference
-- discriminatorName
-- apiMaturity
+- isWritable
+- label
+- maxLength
+- minLength
+- name
+- structRef
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12766,23 +12766,23 @@ struct name being used within the given cluster.  That means the struct name
 must be either a global struct (in which case the cluster name is just
 ignored), or a struct associated with the given cluster.
 From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- fieldIdentifier
-- structRef
-- type
-- minLength
-- maxLength
+- apiMaturity
+- dataTypeReference
 - defaultValue
+- discriminatorName
+- fieldIdentifier
 - isArray
 - isEnum
-- isWritable
+- isFabricSensitive
 - isNullable
 - isOptional
-- isFabricSensitive
-- dataTypeReference
-- discriminatorName
-- apiMaturity
+- isWritable
+- label
+- maxLength
+- minLength
+- name
+- structRef
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12798,16 +12798,16 @@ From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_device\_types(options) ⇒
 Block helper iterating over all deviceTypes.
 From `exports.map.deviceType` in `src-electron/db/db-mapping.js`:
-- id
-- revision
-- code
-- profileId
-- domain
-- label
-- name
 - caption
 - class
+- code
+- domain
+- id
+- label
+- name
 - packageRef
+- profileId
+- revision
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12821,10 +12821,10 @@ From `exports.map.deviceType` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_device\_type\_clusters(options) ⇒
 Block helper for use inside zcl_device_types
 From `exports.map.deviceTypeCluster` in `src-electron/db/db-mapping.js`:
-- id
-- deviceTypeRef
-- clusterRef
 - clusterName
+- clusterRef
+- deviceTypeRef
+- id
 - includeClient
 - includeServer
 - lockClient
@@ -12842,11 +12842,11 @@ From `exports.map.deviceTypeCluster` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_device\_type\_cluster\_commands(options) ⇒
 Block helper for use inside zcl_device_type_clusters
 From `exports.map.deviceTypeCommand` in `src-electron/db/db-mapping.js`:
-- deviceTypeClusterRef
-- commandRef
-- name
 - code
+- commandRef
+- deviceTypeClusterRef
 - manufacturerCode
+- name
 - source
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
@@ -12861,11 +12861,11 @@ From `exports.map.deviceTypeCommand` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_device\_type\_cluster\_attributes(options) ⇒
 Block helper for use inside zcl_device_type_clusters
 From `exports.map.deviceTypeAttribute` in `src-electron/db/db-mapping.js`:
-- deviceTypeClusterRef
 - attributeRef
-- name
 - code
+- deviceTypeClusterRef
 - manufacturerCode
+- name
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: blocks for attributes  
@@ -12879,20 +12879,20 @@ From `exports.map.deviceTypeAttribute` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_clusters(options) ⇒
 Block helper iterating over all clusters.
 From `exports.map.cluster` in `src-electron/db/db-mapping.js`:
-- id
-- packageRef
-- code
-- manufacturerCode
-- label
-- name
-- caption
-- description
-- define
-- domainName
-- isSingleton
-- revision
-- isManufacturingSpecific
 - apiMaturity
+- caption
+- code
+- define
+- description
+- domainName
+- id
+- isManufacturingSpecific
+- isSingleton
+- label
+- manufacturerCode
+- name
+- packageRef
+- revision
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12909,42 +12909,42 @@ There are two modes of this helper:
   when used in a global context, it iterates over ALL commands in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that cluster.
 From `exports.map.command` in `src-electron/db/db-mapping.js`:
-- id
-- clusterRef
-- packageRef
-- code
-- manufacturerCode
-- label
-- name
-- commandName
-- description
-- source
-- isOptional
-- conformance
-- mustUseTimedInvoke
-- isFabricScoped
-- clusterCode
-- clusterName
-- clusterDefineName
-- argName
-- argType
+- apiMaturity
+- argCountArg
 - argDefaultValue
 - argIsArray
-- argPresentIf
-- argCountArg
-- commandArgCount
-- requiredCommandArgCount
-- hasArguments
-- commandHasRequiredField
 - argIsNullable
-- responseRef
-- responseName
+- argName
+- argPresentIf
+- argType
+- clusterCode
+- clusterDefineName
+- clusterName
+- clusterRef
+- code
+- commandArgCount
+- commandHasRequiredField
+- commandName
+- conformance
+- description
+- hasArguments
 - hasSpecificResponse
-- isIncoming
-- isOutgoing
+- id
 - isDefaultResponseEnabled
+- isFabricScoped
+- isIncoming
 - isLargeMessage
-- apiMaturity
+- isOptional
+- isOutgoing
+- label
+- manufacturerCode
+- mustUseTimedInvoke
+- name
+- packageRef
+- requiredCommandArgCount
+- responseName
+- responseRef
+- source
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -13040,29 +13040,29 @@ There are two modes of this helper:
   when used in a global context, it iterates over ALL events in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the events for that cluster.
 From `exports.map.event` in `src-electron/db/db-mapping.js`:
-- id
-- clusterRef
+- apiMaturity
 - clusterCode
-- packageRef
+- clusterRef
 - code
+- conformance
+- description
+- id
+- isFabricSensitive
+- isOptional
 - manufacturerCode
 - name
-- description
-- side
-- conformance
-- isOptional
-- isFabricSensitive
+- packageRef
 - priority
-- apiMaturity
+- side
 The helper adds `items`, an array of `exports.map.eventField` objects:
-- fieldIdentifier
-- name
-- type
+- apiMaturity
 - defaultValue
+- fieldIdentifier
 - isArray
 - isNullable
 - isOptional
-- apiMaturity
+- name
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -13077,17 +13077,17 @@ The helper adds `items`, an array of `exports.map.eventField` objects:
 Block helper iterating over all commands, including their arguments and clusters.
 Starts from `exports.map.command` rows (see `zcl_commands` for the per-key list),
 then aggregates and adds:
-- commandArgs
 - argsstring
 - clientMacroName
+- commandArgs
 - isGlobal
 Each entry in `commandArgs` includes:
-- name
-- type
-- isArray
-- hasLength
-- nameLength
 - formatChar
+- hasLength
+- isArray
+- name
+- nameLength
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -13116,45 +13116,45 @@ Iterator over the attributes. If it is used at toplevel, if iterates over all th
 in the database. If used within zcl_cluster context, it iterates over all the attributes
 that belong to that cluster.
 From `exports.map.attribute` in `src-electron/db/db-mapping.js`:
-- id
-- clusterRef
-- packageRef
-- code
+- apiMaturity
 - clusterCode
-- manufacturerCode
-- name
-- label
-- type
-- side
-- define
+- clusterRef
+- code
 - conformance
-- min
-- max
-- minLength
-- maxLength
-- reportMinInterval
-- reportMaxInterval
-- reportableChange
-- reportableChangeLength
-- isWritable
-- isWritableAttribute
+- defaultValue
+- define
+- entryType
+- entryTypeElseType
+- id
+- isArray
+- isChangeOmitted
+- isNullable
+- isOptional
 - isReadable
 - isReadableAttribute
-- isNullable
-- defaultValue
-- isOptional
 - isReportable
 - isReportableAttribute
-- reportingPolicy
-- storagePolicy
 - isSceneRequired
-- entryType
-- isArray
+- isWritable
+- isWritableAttribute
+- label
+- manufacturerCode
+- max
+- maxLength
+- min
+- minLength
 - mustUseTimedWrite
-- apiMaturity
-- isChangeOmitted
+- name
+- packageRef
 - persistence
-- entryTypeElseType
+- reportableChange
+- reportableChangeLength
+- reportMaxInterval
+- reportMinInterval
+- reportingPolicy
+- side
+- storagePolicy
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of attribute iteration.  
@@ -13203,19 +13203,19 @@ Uses the same `exports.map.attribute` keys as `zcl_attributes` (see that helper)
 ### Templating API: static zcl helpers~zcl\_atomics(options) ⇒
 Block helper iterating over all atomic types.
 From `exports.map.atomic` in `src-electron/db/db-mapping.js`:
-- id
 - atomicId
-- name
-- description
-- size
-- isDiscrete
-- isString
-- isLong
-- isChar
-- isSigned
-- isComposite
-- isFloat
 - baseType
+- description
+- id
+- isChar
+- isComposite
+- isDiscrete
+- isFloat
+- isLong
+- isSigned
+- isString
+- name
+- size
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -13320,28 +13320,28 @@ returns an empty string.
 Block helper iterating over command arguments within a command
 or a command tree.
 From `exports.map.commandArgument` in `src-electron/db/db-mapping.js`:
-- commandRef
-- fieldIdentifier
-- label
-- name
-- type
-- typeSize
-- typeIsSigned
-- min
-- max
-- minLength
-- maxLength
-- defaultValue
+- apiMaturity
+- caption
 - code
+- commandRef
+- countArg
+- defaultValue
+- fieldIdentifier
+- introducedInRef
 - isArray
-- presentIf
 - isNullable
 - isOptional
-- introducedInRef
+- label
+- max
+- maxLength
+- min
+- minLength
+- name
+- presentIf
 - removedInRef
-- countArg
-- caption
-- apiMaturity
+- type
+- typeIsSigned
+- typeSize
 When arguments are loaded from the database, this helper refreshes `typeSize`
 and `typeIsSigned` from resolved ZCL types.
 
@@ -13357,14 +13357,14 @@ and `typeIsSigned` from resolved ZCL types.
 ### Templating API: static zcl helpers~zcl\_event\_fields(options)
 Block helper iterating over the event fields inside an event.
 From `exports.map.eventField` in `src-electron/db/db-mapping.js`:
-- fieldIdentifier
-- name
-- type
+- apiMaturity
 - defaultValue
+- fieldIdentifier
 - isArray
 - isNullable
 - isOptional
-- apiMaturity
+- name
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -14063,7 +14063,7 @@ Returns all structs which have clusters associated with them
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | <code>\*</code> | Available Options: - groupByStructName: Can group the query results based on struct name for structs which are present in more than one cluster eg Usage: {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}} From `exports.map.struct` in `src-electron/db/db-mapping.js`: - id - label - name - itemCnt - isFabricScoped - caption - structClusterCount - structCount - clusterName - apiMaturity |
+| options | <code>\*</code> | Available Options: - groupByStructName: Can group the query results based on struct name for structs which are present in more than one cluster eg Usage: {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}} From `exports.map.struct` in `src-electron/db/db-mapping.js`: - apiMaturity - caption - clusterName - id - isFabricScoped - itemCnt - label - name - structClusterCount - structCount |
 
 <a name="module_Templating API_ static zcl helpers..as_zcl_type_size"></a>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -9071,6 +9071,16 @@ Access helper iterates across all the access triplets associated with the elemen
 For each element, context contains role, operation, accessModifier.
 Additionally it creates booleans hasRole, hasOperation and hasAccessModifier
 and hasAtLeastOneAccessElement and hasAllAccessElements
+From `exports.map.access` in `src-electron/db/db-mapping.js`:
+- operation
+- role
+- accessModifier
+Helper-added:
+- hasRole
+- hasOperation
+- hasAccessModifier
+- hasAllAccessElements
+- hasAtLeastOneAccessElement
 
 **Kind**: inner method of [<code>Templating API: Access helpers</code>](#module_Templating API_ Access helpers)  
 
@@ -9082,6 +9092,16 @@ and hasAtLeastOneAccessElement and hasAllAccessElements
 
 ### Templating API: Access helpers~default\_access(options) ⇒
 Get the access list information.
+From `exports.map.access` in `src-electron/db/db-mapping.js`:
+- operation
+- role
+- accessModifier
+Helper-added (same as `access`):
+- hasRole
+- hasOperation
+- hasAccessModifier
+- hasAllAccessElements
+- hasAtLeastOneAccessElement
 
 **Kind**: inner method of [<code>Templating API: Access helpers</code>](#module_Templating API_ Access helpers)  
 **Returns**: access list  
@@ -10960,6 +10980,22 @@ Creates block iterator over the endpoints.
 ### Templating API: user-data specific helpers~user\_device\_types(options)
 Creates device type iterator over an endpoint type id.
 This works inside user_endpoints or user_endpoint_types.
+From `exports.map.endpointTypeDeviceExtended` in `src-electron/db/db-mapping.js`:
+- id
+- deviceTypeRef
+- endpointTypeRef
+- endpointTypeId
+- deviceTypeOrder
+- deviceIdentifier
+- deviceId
+- deviceVersion
+- featureId
+- featureCode
+- featureName
+- featureBit
+- clusterId
+- composition
+- conformance
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -10973,6 +11009,14 @@ This works inside user_endpoints or user_endpoint_types.
 Creates iterator over endpoint composition requirements for a device type.
 This works inside user_device_types context where device type ref is available.
 Returns required device types that must be on separate endpoints.
+From `exports.map.endpointCompositionRequirement` in `src-electron/db/db-mapping.js`:
+- requiredDeviceCode
+- requiredDeviceName
+- requiredDeviceTypeRef
+- conformance
+- deviceConstraint
+- compositionType
+- endpointCompositionId
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -10984,6 +11028,20 @@ Returns required device types that must be on separate endpoints.
 
 ### Templating API: user-data specific helpers~user\_endpoint\_types(options)
 Creates block iterator helper over the endpoint types.
+From `exports.map.endpointType` in `src-electron/db/db-mapping.js`:
+- id
+- endpointTypeId
+- sessionRef
+- name
+- deviceTypeRef
+- deviceTypes
+Also populated in `query-endpoint-type.selectAllEndpointTypes`:
+- deviceVersion
+- deviceIdentifier
+- deviceCategory
+- devicePackageRef
+- deviceTypeName
+- deviceTypeCode
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -11779,6 +11837,25 @@ Check if multi-protocol is enabled for the application.
 
 ### Templating API: user-data specific helpers~all\_multi\_protocol\_attributes(options) ⇒
 Retrieve all the attribute-attribute associations for the current session.
+From `exports.map.attributeMapping` in `src-electron/db/db-mapping.js`:
+- attributeMappingId
+- attributeRef1
+- attributeRef2
+- attributeCode1
+- attributeMfgCode1
+- attributeCode2
+- attributeMfgCode2
+- attributeName1
+- attributeName2
+- clusterCode1
+- clusterMfgCode1
+- clusterCode2
+- clusterMfgCode2
+- clusterName1
+- clusterName2
+- clusterMappingIndex
+- totalClusterMappedAttributes
+- isLastPartition
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 **Returns**: attribute-attribute mapping entries  
@@ -11888,7 +11965,65 @@ or non-singleton(Available with endpointTypeRef only)
 endpoint information. Singleton attributes are only returned once whereas
 non-singleton attributes are returned per endpoint. However if used within
 an endpoint block helper it returns token_attributes for a given endpoint
-type.  
+type.
+From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.js`:
+- arrayType
+- attributeRef
+- bounded
+- clusterDefine
+- clusterMfgCode
+- clusterName
+- clusterRef
+- clusterSide
+- code
+- defaultValue
+- define
+- endpointId
+- endpointTypeRef
+- entryType
+- hexCode
+- id
+- included
+- includedReportable
+- isArray
+- isBound
+- isClusterEnabled
+- isGlobalAttribute
+- isIncluded
+- isManufacturingSpecific
+- isNullable
+- isOptionalAttribute
+- isReportableAttribute
+- isSceneRequired
+- isSingleton
+- isWritable
+- isWritableAttribute
+- isReadable
+- isReadableAttribute
+- manufacturerCode
+- max
+- maxInterval
+- maxLength
+- mfgCode
+- min
+- minInterval
+- minLength
+- mustUseTimedWrite
+- name
+- reportableChange
+- side
+- singleton
+- smallestEndpointIdentifier
+- storage
+- storageOption
+- tokenId
+- type
+- apiMaturity
+- isChangeOmitted
+- persistence
+- reportMinInterval
+- reportMaxInterval
+- conformance  
 
 | Param | Type |
 | --- | --- |
@@ -11907,7 +12042,33 @@ or non-singleton attributes.
 
 **Kind**: inner method of [<code>Templating API: Token helpers</code>](#module_Templating API_ Token helpers)  
 **Returns**: Token associated clusters for a particular endpoint type or all
-token associated clusters across endpoints.  
+token associated clusters across endpoints.
+Per-endpoint mode (`selectTokenAttributeClustersForEndpoint`), from
+`exports.map.cluster` in `src-electron/db/db-mapping.js`:
+- id
+- packageRef
+- code
+- manufacturerCode
+- label
+- name
+- caption
+- description
+- define
+- domainName
+- isSingleton
+- revision
+- isManufacturingSpecific
+- apiMaturity
+Global mode (`selectAllUserClustersWithTokenAttributes`), from
+`exports.map.endpointTypeClusterExtended` in `src-electron/db/db-mapping.js`:
+- endpointTypeClusterId
+- endpointTypeRef
+- clusterRef
+- side
+- enabled
+- name
+- code
+- tokenAttributesCount  
 
 | Param | Type |
 | --- | --- |
@@ -12006,6 +12167,12 @@ return back slash
 
 ### Templating API: toplevel utility helpers~template\_options(category, options)
 Block helper that iterates over the package options of a given category.
+From `exports.map.options` in `src-electron/db/db-mapping.js`:
+- id
+- packageRef
+- optionCategory
+- optionCode
+- optionLabel
 
 **Kind**: inner method of [<code>Templating API: toplevel utility helpers</code>](#module_Templating API_ toplevel utility helpers)  
 
@@ -12414,6 +12581,18 @@ This module contains the API for templating. For more detailed instructions, rea
 
 ### Templating API: static zcl helpers~zcl\_bitmaps(options) ⇒
 Block helper iterating over all bitmaps.
+From `exports.map.bitmap` in `src-electron/db/db-mapping.js`:
+- id
+- label
+- name
+- type
+- bitmapClusterCount
+- size
+- apiMaturity
+Helper-added:
+- has_no_clusters
+- has_one_cluster
+- has_more_than_one_cluster
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12425,7 +12604,15 @@ Block helper iterating over all bitmaps.
 <a name="module_Templating API_ static zcl helpers..zcl_bitmap_items"></a>
 
 ### Templating API: static zcl helpers~zcl\_bitmap\_items(options)
-Iterates over enum items. Valid only inside zcl_enums.
+Iterates over bitmap fields. Valid only inside zcl_bitmaps.
+From `exports.map.bitmapField` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- mask
+- type
+- bitmapRef
+- caption
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -12440,6 +12627,18 @@ Block helper iterating over all enums.
 If existing independently, it iterates over ALL the enums.
 Within a context of a cluster, it iterates only over the
 enums belonging to a cluster.
+From `exports.map.enum` in `src-electron/db/db-mapping.js`:
+- id
+- label
+- name
+- caption
+- enumClusterCount
+- size
+- apiMaturity
+Helper-added:
+- has_no_clusters
+- has_one_cluster
+- has_more_than_one_cluster
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12467,6 +12666,13 @@ structs belonging to a cluster.
 
 ### Templating API: static zcl helpers~zcl\_enum\_items(options)
 Iterates over enum items. Valid only inside zcl_enums.
+From `exports.map.enumItem` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- value
+- enumRef
+- caption
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -12492,6 +12698,26 @@ mode="first_unused" (which is the default).
 
 ### Templating API: static zcl helpers~zcl\_struct\_items(options) ⇒
 Block helper iterating over all struct items. Valid only inside zcl_structs.
+From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- fieldIdentifier
+- structRef
+- type
+- minLength
+- maxLength
+- defaultValue
+- isArray
+- isEnum
+- isWritable
+- isNullable
+- isOptional
+- isFabricSensitive
+- dataTypeReference
+- discriminatorName
+- apiMaturity
+When `checkForDoubleNestedArray` is true, the helper may also set:
+- struct_item_contains_nested_array
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12504,6 +12730,24 @@ Block helper iterating over all struct items. Valid only inside zcl_structs.
 
 ### Templating API: static zcl helpers~zcl\_struct\_items\_by\_struct\_name(name, options) ⇒
 Block helper iterating over all struct items given the struct name.
+From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- fieldIdentifier
+- structRef
+- type
+- minLength
+- maxLength
+- defaultValue
+- isArray
+- isEnum
+- isWritable
+- isNullable
+- isOptional
+- isFabricSensitive
+- dataTypeReference
+- discriminatorName
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12521,6 +12765,24 @@ cluster name.  The items iterated will be those that correspond to that
 struct name being used within the given cluster.  That means the struct name
 must be either a global struct (in which case the cluster name is just
 ignored), or a struct associated with the given cluster.
+From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- fieldIdentifier
+- structRef
+- type
+- minLength
+- maxLength
+- defaultValue
+- isArray
+- isEnum
+- isWritable
+- isNullable
+- isOptional
+- isFabricSensitive
+- dataTypeReference
+- discriminatorName
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12535,6 +12797,17 @@ ignored), or a struct associated with the given cluster.
 
 ### Templating API: static zcl helpers~zcl\_device\_types(options) ⇒
 Block helper iterating over all deviceTypes.
+From `exports.map.deviceType` in `src-electron/db/db-mapping.js`:
+- id
+- revision
+- code
+- profileId
+- domain
+- label
+- name
+- caption
+- class
+- packageRef
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12547,6 +12820,15 @@ Block helper iterating over all deviceTypes.
 
 ### Templating API: static zcl helpers~zcl\_device\_type\_clusters(options) ⇒
 Block helper for use inside zcl_device_types
+From `exports.map.deviceTypeCluster` in `src-electron/db/db-mapping.js`:
+- id
+- deviceTypeRef
+- clusterRef
+- clusterName
+- includeClient
+- includeServer
+- lockClient
+- lockServer
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: blocks for clusters  
@@ -12559,6 +12841,13 @@ Block helper for use inside zcl_device_types
 
 ### Templating API: static zcl helpers~zcl\_device\_type\_cluster\_commands(options) ⇒
 Block helper for use inside zcl_device_type_clusters
+From `exports.map.deviceTypeCommand` in `src-electron/db/db-mapping.js`:
+- deviceTypeClusterRef
+- commandRef
+- name
+- code
+- manufacturerCode
+- source
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: blocks for commands  
@@ -12571,6 +12860,12 @@ Block helper for use inside zcl_device_type_clusters
 
 ### Templating API: static zcl helpers~zcl\_device\_type\_cluster\_attributes(options) ⇒
 Block helper for use inside zcl_device_type_clusters
+From `exports.map.deviceTypeAttribute` in `src-electron/db/db-mapping.js`:
+- deviceTypeClusterRef
+- attributeRef
+- name
+- code
+- manufacturerCode
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: blocks for attributes  
@@ -12583,6 +12878,21 @@ Block helper for use inside zcl_device_type_clusters
 
 ### Templating API: static zcl helpers~zcl\_clusters(options) ⇒
 Block helper iterating over all clusters.
+From `exports.map.cluster` in `src-electron/db/db-mapping.js`:
+- id
+- packageRef
+- code
+- manufacturerCode
+- label
+- name
+- caption
+- description
+- define
+- domainName
+- isSingleton
+- revision
+- isManufacturingSpecific
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12598,6 +12908,43 @@ Block helper iterating over all commands.
 There are two modes of this helper:
   when used in a global context, it iterates over ALL commands in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that cluster.
+From `exports.map.command` in `src-electron/db/db-mapping.js`:
+- id
+- clusterRef
+- packageRef
+- code
+- manufacturerCode
+- label
+- name
+- commandName
+- description
+- source
+- isOptional
+- conformance
+- mustUseTimedInvoke
+- isFabricScoped
+- clusterCode
+- clusterName
+- clusterDefineName
+- argName
+- argType
+- argDefaultValue
+- argIsArray
+- argPresentIf
+- argCountArg
+- commandArgCount
+- requiredCommandArgCount
+- hasArguments
+- commandHasRequiredField
+- argIsNullable
+- responseRef
+- responseName
+- hasSpecificResponse
+- isIncoming
+- isOutgoing
+- isDefaultResponseEnabled
+- isLargeMessage
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12619,6 +12966,7 @@ There are two modes of this helper:
 the database.
 - when used inside a `zcl_cluster` block helper, it iterates only over the
 commands responses for that cluster.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: all command responses  
@@ -12632,6 +12980,7 @@ commands responses for that cluster.
 ### Templating API: static zcl helpers~zcl\_commands\_with\_cluster\_info(options) ⇒
 Block helper iterating over all commands with cluster information.
 Note: Similar to zcl_commands but has cluster information as well.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12658,6 +13007,7 @@ Block helper iterating over all client commands.
 There are two modes of this helper:
   when used in a global context, it iterates over ALL client commands in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that client cluster.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12673,6 +13023,7 @@ Block helper iterating over all server commands.
 There are two modes of this helper:
   when used in a global context, it iterates over ALL server commands in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that server cluster.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12688,6 +13039,30 @@ Block helper iterating over all events.
 There are two modes of this helper:
   when used in a global context, it iterates over ALL events in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the events for that cluster.
+From `exports.map.event` in `src-electron/db/db-mapping.js`:
+- id
+- clusterRef
+- clusterCode
+- packageRef
+- code
+- manufacturerCode
+- name
+- description
+- side
+- conformance
+- isOptional
+- isFabricSensitive
+- priority
+- apiMaturity
+The helper adds `items`, an array of `exports.map.eventField` objects:
+- fieldIdentifier
+- name
+- type
+- defaultValue
+- isArray
+- isNullable
+- isOptional
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12700,6 +13075,19 @@ There are two modes of this helper:
 
 ### Templating API: static zcl helpers~zcl\_command\_tree(options) ⇒
 Block helper iterating over all commands, including their arguments and clusters.
+Starts from `exports.map.command` rows (see `zcl_commands` for the per-key list),
+then aggregates and adds:
+- commandArgs
+- argsstring
+- clientMacroName
+- isGlobal
+Each entry in `commandArgs` includes:
+- name
+- type
+- isArray
+- hasLength
+- nameLength
+- formatChar
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12712,6 +13100,7 @@ Block helper iterating over all commands, including their arguments and clusters
 
 ### Templating API: static zcl helpers~zcl\_global\_commands(options) ⇒
 Helper to iterate over all global commands.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of global command iteration.  
@@ -12726,6 +13115,46 @@ Helper to iterate over all global commands.
 Iterator over the attributes. If it is used at toplevel, if iterates over all the attributes
 in the database. If used within zcl_cluster context, it iterates over all the attributes
 that belong to that cluster.
+From `exports.map.attribute` in `src-electron/db/db-mapping.js`:
+- id
+- clusterRef
+- packageRef
+- code
+- clusterCode
+- manufacturerCode
+- name
+- label
+- type
+- side
+- define
+- conformance
+- min
+- max
+- minLength
+- maxLength
+- reportMinInterval
+- reportMaxInterval
+- reportableChange
+- reportableChangeLength
+- isWritable
+- isWritableAttribute
+- isReadable
+- isReadableAttribute
+- isNullable
+- defaultValue
+- isOptional
+- isReportable
+- isReportableAttribute
+- reportingPolicy
+- storagePolicy
+- isSceneRequired
+- entryType
+- isArray
+- mustUseTimedWrite
+- apiMaturity
+- isChangeOmitted
+- persistence
+- entryTypeElseType
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of attribute iteration.  
@@ -12740,6 +13169,7 @@ that belong to that cluster.
 Iterator over the client attributes. If it is used at toplevel, if iterates over all the client attributes
 in the database. If used within zcl_cluster context, it iterates over all the client attributes
 that belong to that cluster.
+Uses the same `exports.map.attribute` keys as `zcl_attributes` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of attribute iteration.  
@@ -12758,6 +13188,8 @@ Available Options:
 - removeKeys: Removes one or more keys from the map(for eg keys in db-mapping.js)
 for eg: (#zcl_attributes_server removeKeys='isOptional, isNullable') will remove 'isOptional'
 from the results
+Uses the same `exports.map.attribute` keys as `zcl_attributes` (see that helper);
+`removeKeys` may delete some of those keys before iteration.
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of attribute iteration.  
@@ -12770,6 +13202,20 @@ from the results
 
 ### Templating API: static zcl helpers~zcl\_atomics(options) ⇒
 Block helper iterating over all atomic types.
+From `exports.map.atomic` in `src-electron/db/db-mapping.js`:
+- id
+- atomicId
+- name
+- description
+- size
+- isDiscrete
+- isString
+- isLong
+- isChar
+- isSigned
+- isComposite
+- isFloat
+- baseType
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -12873,6 +13319,31 @@ returns an empty string.
 ### Templating API: static zcl helpers~zcl\_command\_arguments(options) ⇒
 Block helper iterating over command arguments within a command
 or a command tree.
+From `exports.map.commandArgument` in `src-electron/db/db-mapping.js`:
+- commandRef
+- fieldIdentifier
+- label
+- name
+- type
+- typeSize
+- typeIsSigned
+- min
+- max
+- minLength
+- maxLength
+- defaultValue
+- code
+- isArray
+- presentIf
+- isNullable
+- isOptional
+- introducedInRef
+- removedInRef
+- countArg
+- caption
+- apiMaturity
+When arguments are loaded from the database, this helper refreshes `typeSize`
+and `typeIsSigned` from resolved ZCL types.
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of command argument iteration.  
@@ -12885,6 +13356,15 @@ or a command tree.
 
 ### Templating API: static zcl helpers~zcl\_event\_fields(options)
 Block helper iterating over the event fields inside an event.
+From `exports.map.eventField` in `src-electron/db/db-mapping.js`:
+- fieldIdentifier
+- name
+- type
+- defaultValue
+- isArray
+- isNullable
+- isOptional
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -13583,7 +14063,7 @@ Returns all structs which have clusters associated with them
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | <code>\*</code> | Available Options: - groupByStructName: Can group the query results based on struct name for structs which are present in more than one cluster eg Usage: {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}} |
+| options | <code>\*</code> | Available Options: - groupByStructName: Can group the query results based on struct name for structs which are present in more than one cluster eg Usage: {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}} From `exports.map.struct` in `src-electron/db/db-mapping.js`: - id - label - name - itemCnt - isFabricScoped - caption - structClusterCount - structCount - clusterName - apiMaturity |
 
 <a name="module_Templating API_ static zcl helpers..as_zcl_type_size"></a>
 

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -101,15 +101,15 @@ For each element, context contains role, operation, accessModifier.
 Additionally it creates booleans hasRole, hasOperation and hasAccessModifier
 and hasAtLeastOneAccessElement and hasAllAccessElements
 From `exports.map.access` in `src-electron/db/db-mapping.js`:
+- accessModifier
 - operation
 - role
-- accessModifier
 Helper-added:
-- hasRole
-- hasOperation
 - hasAccessModifier
 - hasAllAccessElements
 - hasAtLeastOneAccessElement
+- hasOperation
+- hasRole
 
 **Kind**: inner method of [<code>Templating API: Access helpers</code>](#module_Templating API_ Access helpers)  
 
@@ -122,15 +122,15 @@ Helper-added:
 ### Templating API: Access helpers~default\_access(options) ⇒
 Get the access list information.
 From `exports.map.access` in `src-electron/db/db-mapping.js`:
+- accessModifier
 - operation
 - role
-- accessModifier
 Helper-added (same as `access`):
-- hasRole
-- hasOperation
 - hasAccessModifier
 - hasAllAccessElements
 - hasAtLeastOneAccessElement
+- hasOperation
+- hasRole
 
 **Kind**: inner method of [<code>Templating API: Access helpers</code>](#module_Templating API_ Access helpers)  
 **Returns**: access list  
@@ -2010,21 +2010,21 @@ Creates block iterator over the endpoints.
 Creates device type iterator over an endpoint type id.
 This works inside user_endpoints or user_endpoint_types.
 From `exports.map.endpointTypeDeviceExtended` in `src-electron/db/db-mapping.js`:
-- id
-- deviceTypeRef
-- endpointTypeRef
-- endpointTypeId
-- deviceTypeOrder
-- deviceIdentifier
-- deviceId
-- deviceVersion
-- featureId
-- featureCode
-- featureName
-- featureBit
 - clusterId
 - composition
 - conformance
+- deviceId
+- deviceIdentifier
+- deviceTypeOrder
+- deviceTypeRef
+- deviceVersion
+- endpointTypeId
+- endpointTypeRef
+- featureBit
+- featureCode
+- featureId
+- featureName
+- id
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -2039,13 +2039,13 @@ Creates iterator over endpoint composition requirements for a device type.
 This works inside user_device_types context where device type ref is available.
 Returns required device types that must be on separate endpoints.
 From `exports.map.endpointCompositionRequirement` in `src-electron/db/db-mapping.js`:
+- compositionType
+- conformance
+- deviceConstraint
+- endpointCompositionId
 - requiredDeviceCode
 - requiredDeviceName
 - requiredDeviceTypeRef
-- conformance
-- deviceConstraint
-- compositionType
-- endpointCompositionId
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -2058,19 +2058,19 @@ From `exports.map.endpointCompositionRequirement` in `src-electron/db/db-mapping
 ### Templating API: user-data specific helpers~user\_endpoint\_types(options)
 Creates block iterator helper over the endpoint types.
 From `exports.map.endpointType` in `src-electron/db/db-mapping.js`:
-- id
-- endpointTypeId
-- sessionRef
-- name
 - deviceTypeRef
 - deviceTypes
+- endpointTypeId
+- id
+- name
+- sessionRef
 Also populated in `query-endpoint-type.selectAllEndpointTypes`:
-- deviceVersion
-- deviceIdentifier
 - deviceCategory
+- deviceIdentifier
 - devicePackageRef
-- deviceTypeName
 - deviceTypeCode
+- deviceTypeName
+- deviceVersion
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -2867,24 +2867,24 @@ Check if multi-protocol is enabled for the application.
 ### Templating API: user-data specific helpers~all\_multi\_protocol\_attributes(options) ⇒
 Retrieve all the attribute-attribute associations for the current session.
 From `exports.map.attributeMapping` in `src-electron/db/db-mapping.js`:
-- attributeMappingId
-- attributeRef1
-- attributeRef2
 - attributeCode1
-- attributeMfgCode1
 - attributeCode2
+- attributeMappingId
+- attributeMfgCode1
 - attributeMfgCode2
 - attributeName1
 - attributeName2
+- attributeRef1
+- attributeRef2
 - clusterCode1
-- clusterMfgCode1
 - clusterCode2
+- clusterMappingIndex
+- clusterMfgCode1
 - clusterMfgCode2
 - clusterName1
 - clusterName2
-- clusterMappingIndex
-- totalClusterMappedAttributes
 - isLastPartition
+- totalClusterMappedAttributes
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 **Returns**: attribute-attribute mapping entries  
@@ -2996,6 +2996,7 @@ non-singleton attributes are returned per endpoint. However if used within
 an endpoint block helper it returns token_attributes for a given endpoint
 type.
 From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.js`:
+- apiMaturity
 - arrayType
 - attributeRef
 - bounded
@@ -3005,6 +3006,7 @@ From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.
 - clusterRef
 - clusterSide
 - code
+- conformance
 - defaultValue
 - define
 - endpointId
@@ -3016,19 +3018,20 @@ From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.
 - includedReportable
 - isArray
 - isBound
+- isChangeOmitted
 - isClusterEnabled
 - isGlobalAttribute
 - isIncluded
 - isManufacturingSpecific
 - isNullable
 - isOptionalAttribute
+- isReadable
+- isReadableAttribute
 - isReportableAttribute
 - isSceneRequired
 - isSingleton
 - isWritable
 - isWritableAttribute
-- isReadable
-- isReadableAttribute
 - manufacturerCode
 - max
 - maxInterval
@@ -3039,20 +3042,17 @@ From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.
 - minLength
 - mustUseTimedWrite
 - name
+- persistence
 - reportableChange
+- reportMaxInterval
+- reportMinInterval
 - side
 - singleton
 - smallestEndpointIdentifier
 - storage
 - storageOption
 - tokenId
-- type
-- apiMaturity
-- isChangeOmitted
-- persistence
-- reportMinInterval
-- reportMaxInterval
-- conformance  
+- type  
 
 | Param | Type |
 | --- | --- |
@@ -3074,29 +3074,29 @@ or non-singleton attributes.
 token associated clusters across endpoints.
 Per-endpoint mode (`selectTokenAttributeClustersForEndpoint`), from
 `exports.map.cluster` in `src-electron/db/db-mapping.js`:
-- id
-- packageRef
-- code
-- manufacturerCode
-- label
-- name
-- caption
-- description
-- define
-- domainName
-- isSingleton
-- revision
-- isManufacturingSpecific
 - apiMaturity
+- caption
+- code
+- define
+- description
+- domainName
+- id
+- isManufacturingSpecific
+- isSingleton
+- label
+- manufacturerCode
+- name
+- packageRef
+- revision
 Global mode (`selectAllUserClustersWithTokenAttributes`), from
 `exports.map.endpointTypeClusterExtended` in `src-electron/db/db-mapping.js`:
+- clusterRef
+- code
+- enabled
 - endpointTypeClusterId
 - endpointTypeRef
-- clusterRef
-- side
-- enabled
 - name
-- code
+- side
 - tokenAttributesCount  
 
 | Param | Type |
@@ -3198,10 +3198,10 @@ return back slash
 Block helper that iterates over the package options of a given category.
 From `exports.map.options` in `src-electron/db/db-mapping.js`:
 - id
-- packageRef
 - optionCategory
 - optionCode
 - optionLabel
+- packageRef
 
 **Kind**: inner method of [<code>Templating API: toplevel utility helpers</code>](#module_Templating API_ toplevel utility helpers)  
 
@@ -3611,17 +3611,17 @@ This module contains the API for templating. For more detailed instructions, rea
 ### Templating API: static zcl helpers~zcl\_bitmaps(options) ⇒
 Block helper iterating over all bitmaps.
 From `exports.map.bitmap` in `src-electron/db/db-mapping.js`:
+- apiMaturity
+- bitmapClusterCount
 - id
 - label
 - name
-- type
-- bitmapClusterCount
 - size
-- apiMaturity
+- type
 Helper-added:
+- has_more_than_one_cluster
 - has_no_clusters
 - has_one_cluster
-- has_more_than_one_cluster
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3635,13 +3635,13 @@ Helper-added:
 ### Templating API: static zcl helpers~zcl\_bitmap\_items(options)
 Iterates over bitmap fields. Valid only inside zcl_bitmaps.
 From `exports.map.bitmapField` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- mask
-- type
+- apiMaturity
 - bitmapRef
 - caption
-- apiMaturity
+- label
+- mask
+- name
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -3657,17 +3657,17 @@ If existing independently, it iterates over ALL the enums.
 Within a context of a cluster, it iterates only over the
 enums belonging to a cluster.
 From `exports.map.enum` in `src-electron/db/db-mapping.js`:
+- apiMaturity
+- caption
+- enumClusterCount
 - id
 - label
 - name
-- caption
-- enumClusterCount
 - size
-- apiMaturity
 Helper-added:
+- has_more_than_one_cluster
 - has_no_clusters
 - has_one_cluster
-- has_more_than_one_cluster
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3696,12 +3696,12 @@ structs belonging to a cluster.
 ### Templating API: static zcl helpers~zcl\_enum\_items(options)
 Iterates over enum items. Valid only inside zcl_enums.
 From `exports.map.enumItem` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- value
-- enumRef
-- caption
 - apiMaturity
+- caption
+- enumRef
+- label
+- name
+- value
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -3728,23 +3728,23 @@ mode="first_unused" (which is the default).
 ### Templating API: static zcl helpers~zcl\_struct\_items(options) ⇒
 Block helper iterating over all struct items. Valid only inside zcl_structs.
 From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- fieldIdentifier
-- structRef
-- type
-- minLength
-- maxLength
+- apiMaturity
+- dataTypeReference
 - defaultValue
+- discriminatorName
+- fieldIdentifier
 - isArray
 - isEnum
-- isWritable
+- isFabricSensitive
 - isNullable
 - isOptional
-- isFabricSensitive
-- dataTypeReference
-- discriminatorName
-- apiMaturity
+- isWritable
+- label
+- maxLength
+- minLength
+- name
+- structRef
+- type
 When `checkForDoubleNestedArray` is true, the helper may also set:
 - struct_item_contains_nested_array
 
@@ -3760,23 +3760,23 @@ When `checkForDoubleNestedArray` is true, the helper may also set:
 ### Templating API: static zcl helpers~zcl\_struct\_items\_by\_struct\_name(name, options) ⇒
 Block helper iterating over all struct items given the struct name.
 From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- fieldIdentifier
-- structRef
-- type
-- minLength
-- maxLength
+- apiMaturity
+- dataTypeReference
 - defaultValue
+- discriminatorName
+- fieldIdentifier
 - isArray
 - isEnum
-- isWritable
+- isFabricSensitive
 - isNullable
 - isOptional
-- isFabricSensitive
-- dataTypeReference
-- discriminatorName
-- apiMaturity
+- isWritable
+- label
+- maxLength
+- minLength
+- name
+- structRef
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3795,23 +3795,23 @@ struct name being used within the given cluster.  That means the struct name
 must be either a global struct (in which case the cluster name is just
 ignored), or a struct associated with the given cluster.
 From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
-- name
-- label
-- fieldIdentifier
-- structRef
-- type
-- minLength
-- maxLength
+- apiMaturity
+- dataTypeReference
 - defaultValue
+- discriminatorName
+- fieldIdentifier
 - isArray
 - isEnum
-- isWritable
+- isFabricSensitive
 - isNullable
 - isOptional
-- isFabricSensitive
-- dataTypeReference
-- discriminatorName
-- apiMaturity
+- isWritable
+- label
+- maxLength
+- minLength
+- name
+- structRef
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3827,16 +3827,16 @@ From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_device\_types(options) ⇒
 Block helper iterating over all deviceTypes.
 From `exports.map.deviceType` in `src-electron/db/db-mapping.js`:
-- id
-- revision
-- code
-- profileId
-- domain
-- label
-- name
 - caption
 - class
+- code
+- domain
+- id
+- label
+- name
 - packageRef
+- profileId
+- revision
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3850,10 +3850,10 @@ From `exports.map.deviceType` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_device\_type\_clusters(options) ⇒
 Block helper for use inside zcl_device_types
 From `exports.map.deviceTypeCluster` in `src-electron/db/db-mapping.js`:
-- id
-- deviceTypeRef
-- clusterRef
 - clusterName
+- clusterRef
+- deviceTypeRef
+- id
 - includeClient
 - includeServer
 - lockClient
@@ -3871,11 +3871,11 @@ From `exports.map.deviceTypeCluster` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_device\_type\_cluster\_commands(options) ⇒
 Block helper for use inside zcl_device_type_clusters
 From `exports.map.deviceTypeCommand` in `src-electron/db/db-mapping.js`:
-- deviceTypeClusterRef
-- commandRef
-- name
 - code
+- commandRef
+- deviceTypeClusterRef
 - manufacturerCode
+- name
 - source
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
@@ -3890,11 +3890,11 @@ From `exports.map.deviceTypeCommand` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_device\_type\_cluster\_attributes(options) ⇒
 Block helper for use inside zcl_device_type_clusters
 From `exports.map.deviceTypeAttribute` in `src-electron/db/db-mapping.js`:
-- deviceTypeClusterRef
 - attributeRef
-- name
 - code
+- deviceTypeClusterRef
 - manufacturerCode
+- name
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: blocks for attributes  
@@ -3908,20 +3908,20 @@ From `exports.map.deviceTypeAttribute` in `src-electron/db/db-mapping.js`:
 ### Templating API: static zcl helpers~zcl\_clusters(options) ⇒
 Block helper iterating over all clusters.
 From `exports.map.cluster` in `src-electron/db/db-mapping.js`:
-- id
-- packageRef
-- code
-- manufacturerCode
-- label
-- name
-- caption
-- description
-- define
-- domainName
-- isSingleton
-- revision
-- isManufacturingSpecific
 - apiMaturity
+- caption
+- code
+- define
+- description
+- domainName
+- id
+- isManufacturingSpecific
+- isSingleton
+- label
+- manufacturerCode
+- name
+- packageRef
+- revision
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3938,42 +3938,42 @@ There are two modes of this helper:
   when used in a global context, it iterates over ALL commands in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that cluster.
 From `exports.map.command` in `src-electron/db/db-mapping.js`:
-- id
-- clusterRef
-- packageRef
-- code
-- manufacturerCode
-- label
-- name
-- commandName
-- description
-- source
-- isOptional
-- conformance
-- mustUseTimedInvoke
-- isFabricScoped
-- clusterCode
-- clusterName
-- clusterDefineName
-- argName
-- argType
+- apiMaturity
+- argCountArg
 - argDefaultValue
 - argIsArray
-- argPresentIf
-- argCountArg
-- commandArgCount
-- requiredCommandArgCount
-- hasArguments
-- commandHasRequiredField
 - argIsNullable
-- responseRef
-- responseName
+- argName
+- argPresentIf
+- argType
+- clusterCode
+- clusterDefineName
+- clusterName
+- clusterRef
+- code
+- commandArgCount
+- commandHasRequiredField
+- commandName
+- conformance
+- description
+- hasArguments
 - hasSpecificResponse
-- isIncoming
-- isOutgoing
+- id
 - isDefaultResponseEnabled
+- isFabricScoped
+- isIncoming
 - isLargeMessage
-- apiMaturity
+- isOptional
+- isOutgoing
+- label
+- manufacturerCode
+- mustUseTimedInvoke
+- name
+- packageRef
+- requiredCommandArgCount
+- responseName
+- responseRef
+- source
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -4069,29 +4069,29 @@ There are two modes of this helper:
   when used in a global context, it iterates over ALL events in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the events for that cluster.
 From `exports.map.event` in `src-electron/db/db-mapping.js`:
-- id
-- clusterRef
+- apiMaturity
 - clusterCode
-- packageRef
+- clusterRef
 - code
+- conformance
+- description
+- id
+- isFabricSensitive
+- isOptional
 - manufacturerCode
 - name
-- description
-- side
-- conformance
-- isOptional
-- isFabricSensitive
+- packageRef
 - priority
-- apiMaturity
+- side
 The helper adds `items`, an array of `exports.map.eventField` objects:
-- fieldIdentifier
-- name
-- type
+- apiMaturity
 - defaultValue
+- fieldIdentifier
 - isArray
 - isNullable
 - isOptional
-- apiMaturity
+- name
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -4106,17 +4106,17 @@ The helper adds `items`, an array of `exports.map.eventField` objects:
 Block helper iterating over all commands, including their arguments and clusters.
 Starts from `exports.map.command` rows (see `zcl_commands` for the per-key list),
 then aggregates and adds:
-- commandArgs
 - argsstring
 - clientMacroName
+- commandArgs
 - isGlobal
 Each entry in `commandArgs` includes:
-- name
-- type
-- isArray
-- hasLength
-- nameLength
 - formatChar
+- hasLength
+- isArray
+- name
+- nameLength
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -4145,45 +4145,45 @@ Iterator over the attributes. If it is used at toplevel, if iterates over all th
 in the database. If used within zcl_cluster context, it iterates over all the attributes
 that belong to that cluster.
 From `exports.map.attribute` in `src-electron/db/db-mapping.js`:
-- id
-- clusterRef
-- packageRef
-- code
+- apiMaturity
 - clusterCode
-- manufacturerCode
-- name
-- label
-- type
-- side
-- define
+- clusterRef
+- code
 - conformance
-- min
-- max
-- minLength
-- maxLength
-- reportMinInterval
-- reportMaxInterval
-- reportableChange
-- reportableChangeLength
-- isWritable
-- isWritableAttribute
+- defaultValue
+- define
+- entryType
+- entryTypeElseType
+- id
+- isArray
+- isChangeOmitted
+- isNullable
+- isOptional
 - isReadable
 - isReadableAttribute
-- isNullable
-- defaultValue
-- isOptional
 - isReportable
 - isReportableAttribute
-- reportingPolicy
-- storagePolicy
 - isSceneRequired
-- entryType
-- isArray
+- isWritable
+- isWritableAttribute
+- label
+- manufacturerCode
+- max
+- maxLength
+- min
+- minLength
 - mustUseTimedWrite
-- apiMaturity
-- isChangeOmitted
+- name
+- packageRef
 - persistence
-- entryTypeElseType
+- reportableChange
+- reportableChangeLength
+- reportMaxInterval
+- reportMinInterval
+- reportingPolicy
+- side
+- storagePolicy
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of attribute iteration.  
@@ -4232,19 +4232,19 @@ Uses the same `exports.map.attribute` keys as `zcl_attributes` (see that helper)
 ### Templating API: static zcl helpers~zcl\_atomics(options) ⇒
 Block helper iterating over all atomic types.
 From `exports.map.atomic` in `src-electron/db/db-mapping.js`:
-- id
 - atomicId
-- name
-- description
-- size
-- isDiscrete
-- isString
-- isLong
-- isChar
-- isSigned
-- isComposite
-- isFloat
 - baseType
+- description
+- id
+- isChar
+- isComposite
+- isDiscrete
+- isFloat
+- isLong
+- isSigned
+- isString
+- name
+- size
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -4349,28 +4349,28 @@ returns an empty string.
 Block helper iterating over command arguments within a command
 or a command tree.
 From `exports.map.commandArgument` in `src-electron/db/db-mapping.js`:
-- commandRef
-- fieldIdentifier
-- label
-- name
-- type
-- typeSize
-- typeIsSigned
-- min
-- max
-- minLength
-- maxLength
-- defaultValue
+- apiMaturity
+- caption
 - code
+- commandRef
+- countArg
+- defaultValue
+- fieldIdentifier
+- introducedInRef
 - isArray
-- presentIf
 - isNullable
 - isOptional
-- introducedInRef
+- label
+- max
+- maxLength
+- min
+- minLength
+- name
+- presentIf
 - removedInRef
-- countArg
-- caption
-- apiMaturity
+- type
+- typeIsSigned
+- typeSize
 When arguments are loaded from the database, this helper refreshes `typeSize`
 and `typeIsSigned` from resolved ZCL types.
 
@@ -4386,14 +4386,14 @@ and `typeIsSigned` from resolved ZCL types.
 ### Templating API: static zcl helpers~zcl\_event\_fields(options)
 Block helper iterating over the event fields inside an event.
 From `exports.map.eventField` in `src-electron/db/db-mapping.js`:
-- fieldIdentifier
-- name
-- type
+- apiMaturity
 - defaultValue
+- fieldIdentifier
 - isArray
 - isNullable
 - isOptional
-- apiMaturity
+- name
+- type
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -5092,7 +5092,7 @@ Returns all structs which have clusters associated with them
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | <code>\*</code> | Available Options: - groupByStructName: Can group the query results based on struct name for structs which are present in more than one cluster eg Usage: {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}} From `exports.map.struct` in `src-electron/db/db-mapping.js`: - id - label - name - itemCnt - isFabricScoped - caption - structClusterCount - structCount - clusterName - apiMaturity |
+| options | <code>\*</code> | Available Options: - groupByStructName: Can group the query results based on struct name for structs which are present in more than one cluster eg Usage: {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}} From `exports.map.struct` in `src-electron/db/db-mapping.js`: - apiMaturity - caption - clusterName - id - isFabricScoped - itemCnt - label - name - structClusterCount - structCount |
 
 <a name="module_Templating API_ static zcl helpers..as_zcl_type_size"></a>
 

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -100,6 +100,16 @@ Access helper iterates across all the access triplets associated with the elemen
 For each element, context contains role, operation, accessModifier.
 Additionally it creates booleans hasRole, hasOperation and hasAccessModifier
 and hasAtLeastOneAccessElement and hasAllAccessElements
+From `exports.map.access` in `src-electron/db/db-mapping.js`:
+- operation
+- role
+- accessModifier
+Helper-added:
+- hasRole
+- hasOperation
+- hasAccessModifier
+- hasAllAccessElements
+- hasAtLeastOneAccessElement
 
 **Kind**: inner method of [<code>Templating API: Access helpers</code>](#module_Templating API_ Access helpers)  
 
@@ -111,6 +121,16 @@ and hasAtLeastOneAccessElement and hasAllAccessElements
 
 ### Templating API: Access helpers~default\_access(options) ⇒
 Get the access list information.
+From `exports.map.access` in `src-electron/db/db-mapping.js`:
+- operation
+- role
+- accessModifier
+Helper-added (same as `access`):
+- hasRole
+- hasOperation
+- hasAccessModifier
+- hasAllAccessElements
+- hasAtLeastOneAccessElement
 
 **Kind**: inner method of [<code>Templating API: Access helpers</code>](#module_Templating API_ Access helpers)  
 **Returns**: access list  
@@ -1989,6 +2009,22 @@ Creates block iterator over the endpoints.
 ### Templating API: user-data specific helpers~user\_device\_types(options)
 Creates device type iterator over an endpoint type id.
 This works inside user_endpoints or user_endpoint_types.
+From `exports.map.endpointTypeDeviceExtended` in `src-electron/db/db-mapping.js`:
+- id
+- deviceTypeRef
+- endpointTypeRef
+- endpointTypeId
+- deviceTypeOrder
+- deviceIdentifier
+- deviceId
+- deviceVersion
+- featureId
+- featureCode
+- featureName
+- featureBit
+- clusterId
+- composition
+- conformance
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -2002,6 +2038,14 @@ This works inside user_endpoints or user_endpoint_types.
 Creates iterator over endpoint composition requirements for a device type.
 This works inside user_device_types context where device type ref is available.
 Returns required device types that must be on separate endpoints.
+From `exports.map.endpointCompositionRequirement` in `src-electron/db/db-mapping.js`:
+- requiredDeviceCode
+- requiredDeviceName
+- requiredDeviceTypeRef
+- conformance
+- deviceConstraint
+- compositionType
+- endpointCompositionId
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -2013,6 +2057,20 @@ Returns required device types that must be on separate endpoints.
 
 ### Templating API: user-data specific helpers~user\_endpoint\_types(options)
 Creates block iterator helper over the endpoint types.
+From `exports.map.endpointType` in `src-electron/db/db-mapping.js`:
+- id
+- endpointTypeId
+- sessionRef
+- name
+- deviceTypeRef
+- deviceTypes
+Also populated in `query-endpoint-type.selectAllEndpointTypes`:
+- deviceVersion
+- deviceIdentifier
+- deviceCategory
+- devicePackageRef
+- deviceTypeName
+- deviceTypeCode
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 
@@ -2808,6 +2866,25 @@ Check if multi-protocol is enabled for the application.
 
 ### Templating API: user-data specific helpers~all\_multi\_protocol\_attributes(options) ⇒
 Retrieve all the attribute-attribute associations for the current session.
+From `exports.map.attributeMapping` in `src-electron/db/db-mapping.js`:
+- attributeMappingId
+- attributeRef1
+- attributeRef2
+- attributeCode1
+- attributeMfgCode1
+- attributeCode2
+- attributeMfgCode2
+- attributeName1
+- attributeName2
+- clusterCode1
+- clusterMfgCode1
+- clusterCode2
+- clusterMfgCode2
+- clusterName1
+- clusterName2
+- clusterMappingIndex
+- totalClusterMappedAttributes
+- isLastPartition
 
 **Kind**: inner method of [<code>Templating API: user-data specific helpers</code>](#module_Templating API_ user-data specific helpers)  
 **Returns**: attribute-attribute mapping entries  
@@ -2917,7 +2994,65 @@ or non-singleton(Available with endpointTypeRef only)
 endpoint information. Singleton attributes are only returned once whereas
 non-singleton attributes are returned per endpoint. However if used within
 an endpoint block helper it returns token_attributes for a given endpoint
-type.  
+type.
+From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.js`:
+- arrayType
+- attributeRef
+- bounded
+- clusterDefine
+- clusterMfgCode
+- clusterName
+- clusterRef
+- clusterSide
+- code
+- defaultValue
+- define
+- endpointId
+- endpointTypeRef
+- entryType
+- hexCode
+- id
+- included
+- includedReportable
+- isArray
+- isBound
+- isClusterEnabled
+- isGlobalAttribute
+- isIncluded
+- isManufacturingSpecific
+- isNullable
+- isOptionalAttribute
+- isReportableAttribute
+- isSceneRequired
+- isSingleton
+- isWritable
+- isWritableAttribute
+- isReadable
+- isReadableAttribute
+- manufacturerCode
+- max
+- maxInterval
+- maxLength
+- mfgCode
+- min
+- minInterval
+- minLength
+- mustUseTimedWrite
+- name
+- reportableChange
+- side
+- singleton
+- smallestEndpointIdentifier
+- storage
+- storageOption
+- tokenId
+- type
+- apiMaturity
+- isChangeOmitted
+- persistence
+- reportMinInterval
+- reportMaxInterval
+- conformance  
 
 | Param | Type |
 | --- | --- |
@@ -2936,7 +3071,33 @@ or non-singleton attributes.
 
 **Kind**: inner method of [<code>Templating API: Token helpers</code>](#module_Templating API_ Token helpers)  
 **Returns**: Token associated clusters for a particular endpoint type or all
-token associated clusters across endpoints.  
+token associated clusters across endpoints.
+Per-endpoint mode (`selectTokenAttributeClustersForEndpoint`), from
+`exports.map.cluster` in `src-electron/db/db-mapping.js`:
+- id
+- packageRef
+- code
+- manufacturerCode
+- label
+- name
+- caption
+- description
+- define
+- domainName
+- isSingleton
+- revision
+- isManufacturingSpecific
+- apiMaturity
+Global mode (`selectAllUserClustersWithTokenAttributes`), from
+`exports.map.endpointTypeClusterExtended` in `src-electron/db/db-mapping.js`:
+- endpointTypeClusterId
+- endpointTypeRef
+- clusterRef
+- side
+- enabled
+- name
+- code
+- tokenAttributesCount  
 
 | Param | Type |
 | --- | --- |
@@ -3035,6 +3196,12 @@ return back slash
 
 ### Templating API: toplevel utility helpers~template\_options(category, options)
 Block helper that iterates over the package options of a given category.
+From `exports.map.options` in `src-electron/db/db-mapping.js`:
+- id
+- packageRef
+- optionCategory
+- optionCode
+- optionLabel
 
 **Kind**: inner method of [<code>Templating API: toplevel utility helpers</code>](#module_Templating API_ toplevel utility helpers)  
 
@@ -3443,6 +3610,18 @@ This module contains the API for templating. For more detailed instructions, rea
 
 ### Templating API: static zcl helpers~zcl\_bitmaps(options) ⇒
 Block helper iterating over all bitmaps.
+From `exports.map.bitmap` in `src-electron/db/db-mapping.js`:
+- id
+- label
+- name
+- type
+- bitmapClusterCount
+- size
+- apiMaturity
+Helper-added:
+- has_no_clusters
+- has_one_cluster
+- has_more_than_one_cluster
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3454,7 +3633,15 @@ Block helper iterating over all bitmaps.
 <a name="module_Templating API_ static zcl helpers..zcl_bitmap_items"></a>
 
 ### Templating API: static zcl helpers~zcl\_bitmap\_items(options)
-Iterates over enum items. Valid only inside zcl_enums.
+Iterates over bitmap fields. Valid only inside zcl_bitmaps.
+From `exports.map.bitmapField` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- mask
+- type
+- bitmapRef
+- caption
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -3469,6 +3656,18 @@ Block helper iterating over all enums.
 If existing independently, it iterates over ALL the enums.
 Within a context of a cluster, it iterates only over the
 enums belonging to a cluster.
+From `exports.map.enum` in `src-electron/db/db-mapping.js`:
+- id
+- label
+- name
+- caption
+- enumClusterCount
+- size
+- apiMaturity
+Helper-added:
+- has_no_clusters
+- has_one_cluster
+- has_more_than_one_cluster
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3496,6 +3695,13 @@ structs belonging to a cluster.
 
 ### Templating API: static zcl helpers~zcl\_enum\_items(options)
 Iterates over enum items. Valid only inside zcl_enums.
+From `exports.map.enumItem` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- value
+- enumRef
+- caption
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -3521,6 +3727,26 @@ mode="first_unused" (which is the default).
 
 ### Templating API: static zcl helpers~zcl\_struct\_items(options) ⇒
 Block helper iterating over all struct items. Valid only inside zcl_structs.
+From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- fieldIdentifier
+- structRef
+- type
+- minLength
+- maxLength
+- defaultValue
+- isArray
+- isEnum
+- isWritable
+- isNullable
+- isOptional
+- isFabricSensitive
+- dataTypeReference
+- discriminatorName
+- apiMaturity
+When `checkForDoubleNestedArray` is true, the helper may also set:
+- struct_item_contains_nested_array
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3533,6 +3759,24 @@ Block helper iterating over all struct items. Valid only inside zcl_structs.
 
 ### Templating API: static zcl helpers~zcl\_struct\_items\_by\_struct\_name(name, options) ⇒
 Block helper iterating over all struct items given the struct name.
+From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- fieldIdentifier
+- structRef
+- type
+- minLength
+- maxLength
+- defaultValue
+- isArray
+- isEnum
+- isWritable
+- isNullable
+- isOptional
+- isFabricSensitive
+- dataTypeReference
+- discriminatorName
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3550,6 +3794,24 @@ cluster name.  The items iterated will be those that correspond to that
 struct name being used within the given cluster.  That means the struct name
 must be either a global struct (in which case the cluster name is just
 ignored), or a struct associated with the given cluster.
+From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
+- name
+- label
+- fieldIdentifier
+- structRef
+- type
+- minLength
+- maxLength
+- defaultValue
+- isArray
+- isEnum
+- isWritable
+- isNullable
+- isOptional
+- isFabricSensitive
+- dataTypeReference
+- discriminatorName
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3564,6 +3826,17 @@ ignored), or a struct associated with the given cluster.
 
 ### Templating API: static zcl helpers~zcl\_device\_types(options) ⇒
 Block helper iterating over all deviceTypes.
+From `exports.map.deviceType` in `src-electron/db/db-mapping.js`:
+- id
+- revision
+- code
+- profileId
+- domain
+- label
+- name
+- caption
+- class
+- packageRef
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3576,6 +3849,15 @@ Block helper iterating over all deviceTypes.
 
 ### Templating API: static zcl helpers~zcl\_device\_type\_clusters(options) ⇒
 Block helper for use inside zcl_device_types
+From `exports.map.deviceTypeCluster` in `src-electron/db/db-mapping.js`:
+- id
+- deviceTypeRef
+- clusterRef
+- clusterName
+- includeClient
+- includeServer
+- lockClient
+- lockServer
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: blocks for clusters  
@@ -3588,6 +3870,13 @@ Block helper for use inside zcl_device_types
 
 ### Templating API: static zcl helpers~zcl\_device\_type\_cluster\_commands(options) ⇒
 Block helper for use inside zcl_device_type_clusters
+From `exports.map.deviceTypeCommand` in `src-electron/db/db-mapping.js`:
+- deviceTypeClusterRef
+- commandRef
+- name
+- code
+- manufacturerCode
+- source
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: blocks for commands  
@@ -3600,6 +3889,12 @@ Block helper for use inside zcl_device_type_clusters
 
 ### Templating API: static zcl helpers~zcl\_device\_type\_cluster\_attributes(options) ⇒
 Block helper for use inside zcl_device_type_clusters
+From `exports.map.deviceTypeAttribute` in `src-electron/db/db-mapping.js`:
+- deviceTypeClusterRef
+- attributeRef
+- name
+- code
+- manufacturerCode
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: blocks for attributes  
@@ -3612,6 +3907,21 @@ Block helper for use inside zcl_device_type_clusters
 
 ### Templating API: static zcl helpers~zcl\_clusters(options) ⇒
 Block helper iterating over all clusters.
+From `exports.map.cluster` in `src-electron/db/db-mapping.js`:
+- id
+- packageRef
+- code
+- manufacturerCode
+- label
+- name
+- caption
+- description
+- define
+- domainName
+- isSingleton
+- revision
+- isManufacturingSpecific
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3627,6 +3937,43 @@ Block helper iterating over all commands.
 There are two modes of this helper:
   when used in a global context, it iterates over ALL commands in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that cluster.
+From `exports.map.command` in `src-electron/db/db-mapping.js`:
+- id
+- clusterRef
+- packageRef
+- code
+- manufacturerCode
+- label
+- name
+- commandName
+- description
+- source
+- isOptional
+- conformance
+- mustUseTimedInvoke
+- isFabricScoped
+- clusterCode
+- clusterName
+- clusterDefineName
+- argName
+- argType
+- argDefaultValue
+- argIsArray
+- argPresentIf
+- argCountArg
+- commandArgCount
+- requiredCommandArgCount
+- hasArguments
+- commandHasRequiredField
+- argIsNullable
+- responseRef
+- responseName
+- hasSpecificResponse
+- isIncoming
+- isOutgoing
+- isDefaultResponseEnabled
+- isLargeMessage
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3648,6 +3995,7 @@ There are two modes of this helper:
 the database.
 - when used inside a `zcl_cluster` block helper, it iterates only over the
 commands responses for that cluster.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: all command responses  
@@ -3661,6 +4009,7 @@ commands responses for that cluster.
 ### Templating API: static zcl helpers~zcl\_commands\_with\_cluster\_info(options) ⇒
 Block helper iterating over all commands with cluster information.
 Note: Similar to zcl_commands but has cluster information as well.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3687,6 +4036,7 @@ Block helper iterating over all client commands.
 There are two modes of this helper:
   when used in a global context, it iterates over ALL client commands in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that client cluster.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3702,6 +4052,7 @@ Block helper iterating over all server commands.
 There are two modes of this helper:
   when used in a global context, it iterates over ALL server commands in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that server cluster.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3717,6 +4068,30 @@ Block helper iterating over all events.
 There are two modes of this helper:
   when used in a global context, it iterates over ALL events in the database.
   when used inside a `zcl_cluster` block helper, it iterates only over the events for that cluster.
+From `exports.map.event` in `src-electron/db/db-mapping.js`:
+- id
+- clusterRef
+- clusterCode
+- packageRef
+- code
+- manufacturerCode
+- name
+- description
+- side
+- conformance
+- isOptional
+- isFabricSensitive
+- priority
+- apiMaturity
+The helper adds `items`, an array of `exports.map.eventField` objects:
+- fieldIdentifier
+- name
+- type
+- defaultValue
+- isArray
+- isNullable
+- isOptional
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3729,6 +4104,19 @@ There are two modes of this helper:
 
 ### Templating API: static zcl helpers~zcl\_command\_tree(options) ⇒
 Block helper iterating over all commands, including their arguments and clusters.
+Starts from `exports.map.command` rows (see `zcl_commands` for the per-key list),
+then aggregates and adds:
+- commandArgs
+- argsstring
+- clientMacroName
+- isGlobal
+Each entry in `commandArgs` includes:
+- name
+- type
+- isArray
+- hasLength
+- nameLength
+- formatChar
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3741,6 +4129,7 @@ Block helper iterating over all commands, including their arguments and clusters
 
 ### Templating API: static zcl helpers~zcl\_global\_commands(options) ⇒
 Helper to iterate over all global commands.
+Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of global command iteration.  
@@ -3755,6 +4144,46 @@ Helper to iterate over all global commands.
 Iterator over the attributes. If it is used at toplevel, if iterates over all the attributes
 in the database. If used within zcl_cluster context, it iterates over all the attributes
 that belong to that cluster.
+From `exports.map.attribute` in `src-electron/db/db-mapping.js`:
+- id
+- clusterRef
+- packageRef
+- code
+- clusterCode
+- manufacturerCode
+- name
+- label
+- type
+- side
+- define
+- conformance
+- min
+- max
+- minLength
+- maxLength
+- reportMinInterval
+- reportMaxInterval
+- reportableChange
+- reportableChangeLength
+- isWritable
+- isWritableAttribute
+- isReadable
+- isReadableAttribute
+- isNullable
+- defaultValue
+- isOptional
+- isReportable
+- isReportableAttribute
+- reportingPolicy
+- storagePolicy
+- isSceneRequired
+- entryType
+- isArray
+- mustUseTimedWrite
+- apiMaturity
+- isChangeOmitted
+- persistence
+- entryTypeElseType
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of attribute iteration.  
@@ -3769,6 +4198,7 @@ that belong to that cluster.
 Iterator over the client attributes. If it is used at toplevel, if iterates over all the client attributes
 in the database. If used within zcl_cluster context, it iterates over all the client attributes
 that belong to that cluster.
+Uses the same `exports.map.attribute` keys as `zcl_attributes` (see that helper).
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of attribute iteration.  
@@ -3787,6 +4217,8 @@ Available Options:
 - removeKeys: Removes one or more keys from the map(for eg keys in db-mapping.js)
 for eg: (#zcl_attributes_server removeKeys='isOptional, isNullable') will remove 'isOptional'
 from the results
+Uses the same `exports.map.attribute` keys as `zcl_attributes` (see that helper);
+`removeKeys` may delete some of those keys before iteration.
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of attribute iteration.  
@@ -3799,6 +4231,20 @@ from the results
 
 ### Templating API: static zcl helpers~zcl\_atomics(options) ⇒
 Block helper iterating over all atomic types.
+From `exports.map.atomic` in `src-electron/db/db-mapping.js`:
+- id
+- atomicId
+- name
+- description
+- size
+- isDiscrete
+- isString
+- isLong
+- isChar
+- isSigned
+- isComposite
+- isFloat
+- baseType
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of content.  
@@ -3902,6 +4348,31 @@ returns an empty string.
 ### Templating API: static zcl helpers~zcl\_command\_arguments(options) ⇒
 Block helper iterating over command arguments within a command
 or a command tree.
+From `exports.map.commandArgument` in `src-electron/db/db-mapping.js`:
+- commandRef
+- fieldIdentifier
+- label
+- name
+- type
+- typeSize
+- typeIsSigned
+- min
+- max
+- minLength
+- maxLength
+- defaultValue
+- code
+- isArray
+- presentIf
+- isNullable
+- isOptional
+- introducedInRef
+- removedInRef
+- countArg
+- caption
+- apiMaturity
+When arguments are loaded from the database, this helper refreshes `typeSize`
+and `typeIsSigned` from resolved ZCL types.
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 **Returns**: Promise of command argument iteration.  
@@ -3914,6 +4385,15 @@ or a command tree.
 
 ### Templating API: static zcl helpers~zcl\_event\_fields(options)
 Block helper iterating over the event fields inside an event.
+From `exports.map.eventField` in `src-electron/db/db-mapping.js`:
+- fieldIdentifier
+- name
+- type
+- defaultValue
+- isArray
+- isNullable
+- isOptional
+- apiMaturity
 
 **Kind**: inner method of [<code>Templating API: static zcl helpers</code>](#module_Templating API_ static zcl helpers)  
 
@@ -4612,7 +5092,7 @@ Returns all structs which have clusters associated with them
 
 | Param | Type | Description |
 | --- | --- | --- |
-| options | <code>\*</code> | Available Options: - groupByStructName: Can group the query results based on struct name for structs which are present in more than one cluster eg Usage: {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}} |
+| options | <code>\*</code> | Available Options: - groupByStructName: Can group the query results based on struct name for structs which are present in more than one cluster eg Usage: {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}} From `exports.map.struct` in `src-electron/db/db-mapping.js`: - id - label - name - itemCnt - isFabricScoped - caption - structClusterCount - structCount - clusterName - apiMaturity |
 
 <a name="module_Templating API_ static zcl helpers..as_zcl_type_size"></a>
 

--- a/src-electron/generator/helper-access.js
+++ b/src-electron/generator/helper-access.js
@@ -178,6 +178,16 @@ async function access_aggregate(options) {
  * For each element, context contains role, operation, accessModifier.
  * Additionally it creates booleans hasRole, hasOperation and hasAccessModifier
  * and hasAtLeastOneAccessElement and hasAllAccessElements
+ * From `exports.map.access` in `src-electron/db/db-mapping.js`:
+ * - operation
+ * - role
+ * - accessModifier
+ * Helper-added:
+ * - hasRole
+ * - hasOperation
+ * - hasAccessModifier
+ * - hasAllAccessElements
+ * - hasAtLeastOneAccessElement
  * @param {*} options
  */
 async function access(options) {
@@ -201,6 +211,16 @@ async function access(options) {
 
 /**
  * Get the access list information.
+ * From `exports.map.access` in `src-electron/db/db-mapping.js`:
+ * - operation
+ * - role
+ * - accessModifier
+ * Helper-added (same as `access`):
+ * - hasRole
+ * - hasOperation
+ * - hasAccessModifier
+ * - hasAllAccessElements
+ * - hasAtLeastOneAccessElement
  *
  * @param {*} options
  * @returns access list

--- a/src-electron/generator/helper-access.js
+++ b/src-electron/generator/helper-access.js
@@ -179,15 +179,15 @@ async function access_aggregate(options) {
  * Additionally it creates booleans hasRole, hasOperation and hasAccessModifier
  * and hasAtLeastOneAccessElement and hasAllAccessElements
  * From `exports.map.access` in `src-electron/db/db-mapping.js`:
+ * - accessModifier
  * - operation
  * - role
- * - accessModifier
  * Helper-added:
- * - hasRole
- * - hasOperation
  * - hasAccessModifier
  * - hasAllAccessElements
  * - hasAtLeastOneAccessElement
+ * - hasOperation
+ * - hasRole
  * @param {*} options
  */
 async function access(options) {
@@ -212,15 +212,15 @@ async function access(options) {
 /**
  * Get the access list information.
  * From `exports.map.access` in `src-electron/db/db-mapping.js`:
+ * - accessModifier
  * - operation
  * - role
- * - accessModifier
  * Helper-added (same as `access`):
- * - hasRole
- * - hasOperation
  * - hasAccessModifier
  * - hasAllAccessElements
  * - hasAtLeastOneAccessElement
+ * - hasOperation
+ * - hasRole
  *
  * @param {*} options
  * @returns access list

--- a/src-electron/generator/helper-session.js
+++ b/src-electron/generator/helper-session.js
@@ -112,6 +112,22 @@ function user_endpoints(options) {
 /**
  * Creates device type iterator over an endpoint type id.
  * This works inside user_endpoints or user_endpoint_types.
+ * From `exports.map.endpointTypeDeviceExtended` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - deviceTypeRef
+ * - endpointTypeRef
+ * - endpointTypeId
+ * - deviceTypeOrder
+ * - deviceIdentifier
+ * - deviceId
+ * - deviceVersion
+ * - featureId
+ * - featureCode
+ * - featureName
+ * - featureBit
+ * - clusterId
+ * - composition
+ * - conformance
  * @param {*} options
  */
 async function user_device_types(options) {
@@ -130,6 +146,14 @@ async function user_device_types(options) {
  * Creates iterator over endpoint composition requirements for a device type.
  * This works inside user_device_types context where device type ref is available.
  * Returns required device types that must be on separate endpoints.
+ * From `exports.map.endpointCompositionRequirement` in `src-electron/db/db-mapping.js`:
+ * - requiredDeviceCode
+ * - requiredDeviceName
+ * - requiredDeviceTypeRef
+ * - conformance
+ * - deviceConstraint
+ * - compositionType
+ * - endpointCompositionId
  * @param {*} options
  */
 async function user_endpoint_composition_requirements(options) {
@@ -151,6 +175,20 @@ async function user_endpoint_composition_requirements(options) {
 
 /**
  * Creates block iterator helper over the endpoint types.
+ * From `exports.map.endpointType` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - endpointTypeId
+ * - sessionRef
+ * - name
+ * - deviceTypeRef
+ * - deviceTypes
+ * Also populated in `query-endpoint-type.selectAllEndpointTypes`:
+ * - deviceVersion
+ * - deviceIdentifier
+ * - deviceCategory
+ * - devicePackageRef
+ * - deviceTypeName
+ * - deviceTypeCode
  *
  * @tutorial template-tutorial
  * @param {*} options
@@ -1670,6 +1708,25 @@ async function if_multi_protocol_attributes_enabled(options) {
 
 /**
  * Retrieve all the attribute-attribute associations for the current session.
+ * From `exports.map.attributeMapping` in `src-electron/db/db-mapping.js`:
+ * - attributeMappingId
+ * - attributeRef1
+ * - attributeRef2
+ * - attributeCode1
+ * - attributeMfgCode1
+ * - attributeCode2
+ * - attributeMfgCode2
+ * - attributeName1
+ * - attributeName2
+ * - clusterCode1
+ * - clusterMfgCode1
+ * - clusterCode2
+ * - clusterMfgCode2
+ * - clusterName1
+ * - clusterName2
+ * - clusterMappingIndex
+ * - totalClusterMappedAttributes
+ * - isLastPartition
  * @param {*} options
  * @returns attribute-attribute mapping entries
  */

--- a/src-electron/generator/helper-session.js
+++ b/src-electron/generator/helper-session.js
@@ -113,21 +113,21 @@ function user_endpoints(options) {
  * Creates device type iterator over an endpoint type id.
  * This works inside user_endpoints or user_endpoint_types.
  * From `exports.map.endpointTypeDeviceExtended` in `src-electron/db/db-mapping.js`:
- * - id
- * - deviceTypeRef
- * - endpointTypeRef
- * - endpointTypeId
- * - deviceTypeOrder
- * - deviceIdentifier
- * - deviceId
- * - deviceVersion
- * - featureId
- * - featureCode
- * - featureName
- * - featureBit
  * - clusterId
  * - composition
  * - conformance
+ * - deviceId
+ * - deviceIdentifier
+ * - deviceTypeOrder
+ * - deviceTypeRef
+ * - deviceVersion
+ * - endpointTypeId
+ * - endpointTypeRef
+ * - featureBit
+ * - featureCode
+ * - featureId
+ * - featureName
+ * - id
  * @param {*} options
  */
 async function user_device_types(options) {
@@ -147,13 +147,13 @@ async function user_device_types(options) {
  * This works inside user_device_types context where device type ref is available.
  * Returns required device types that must be on separate endpoints.
  * From `exports.map.endpointCompositionRequirement` in `src-electron/db/db-mapping.js`:
+ * - compositionType
+ * - conformance
+ * - deviceConstraint
+ * - endpointCompositionId
  * - requiredDeviceCode
  * - requiredDeviceName
  * - requiredDeviceTypeRef
- * - conformance
- * - deviceConstraint
- * - compositionType
- * - endpointCompositionId
  * @param {*} options
  */
 async function user_endpoint_composition_requirements(options) {
@@ -176,19 +176,19 @@ async function user_endpoint_composition_requirements(options) {
 /**
  * Creates block iterator helper over the endpoint types.
  * From `exports.map.endpointType` in `src-electron/db/db-mapping.js`:
- * - id
- * - endpointTypeId
- * - sessionRef
- * - name
  * - deviceTypeRef
  * - deviceTypes
+ * - endpointTypeId
+ * - id
+ * - name
+ * - sessionRef
  * Also populated in `query-endpoint-type.selectAllEndpointTypes`:
- * - deviceVersion
- * - deviceIdentifier
  * - deviceCategory
+ * - deviceIdentifier
  * - devicePackageRef
- * - deviceTypeName
  * - deviceTypeCode
+ * - deviceTypeName
+ * - deviceVersion
  *
  * @tutorial template-tutorial
  * @param {*} options
@@ -1709,24 +1709,24 @@ async function if_multi_protocol_attributes_enabled(options) {
 /**
  * Retrieve all the attribute-attribute associations for the current session.
  * From `exports.map.attributeMapping` in `src-electron/db/db-mapping.js`:
- * - attributeMappingId
- * - attributeRef1
- * - attributeRef2
  * - attributeCode1
- * - attributeMfgCode1
  * - attributeCode2
+ * - attributeMappingId
+ * - attributeMfgCode1
  * - attributeMfgCode2
  * - attributeName1
  * - attributeName2
+ * - attributeRef1
+ * - attributeRef2
  * - clusterCode1
- * - clusterMfgCode1
  * - clusterCode2
+ * - clusterMappingIndex
+ * - clusterMfgCode1
  * - clusterMfgCode2
  * - clusterName1
  * - clusterName2
- * - clusterMappingIndex
- * - totalClusterMappedAttributes
  * - isLastPartition
+ * - totalClusterMappedAttributes
  * @param {*} options
  * @returns attribute-attribute mapping entries
  */

--- a/src-electron/generator/helper-tokens.js
+++ b/src-electron/generator/helper-tokens.js
@@ -278,6 +278,64 @@ async function token_attribute_util(context, options) {
  * non-singleton attributes are returned per endpoint. However if used within
  * an endpoint block helper it returns token_attributes for a given endpoint
  * type.
+ * From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.js`:
+ * - arrayType
+ * - attributeRef
+ * - bounded
+ * - clusterDefine
+ * - clusterMfgCode
+ * - clusterName
+ * - clusterRef
+ * - clusterSide
+ * - code
+ * - defaultValue
+ * - define
+ * - endpointId
+ * - endpointTypeRef
+ * - entryType
+ * - hexCode
+ * - id
+ * - included
+ * - includedReportable
+ * - isArray
+ * - isBound
+ * - isClusterEnabled
+ * - isGlobalAttribute
+ * - isIncluded
+ * - isManufacturingSpecific
+ * - isNullable
+ * - isOptionalAttribute
+ * - isReportableAttribute
+ * - isSceneRequired
+ * - isSingleton
+ * - isWritable
+ * - isWritableAttribute
+ * - isReadable
+ * - isReadableAttribute
+ * - manufacturerCode
+ * - max
+ * - maxInterval
+ * - maxLength
+ * - mfgCode
+ * - min
+ * - minInterval
+ * - minLength
+ * - mustUseTimedWrite
+ * - name
+ * - reportableChange
+ * - side
+ * - singleton
+ * - smallestEndpointIdentifier
+ * - storage
+ * - storageOption
+ * - tokenId
+ * - type
+ * - apiMaturity
+ * - isChangeOmitted
+ * - persistence
+ * - reportMinInterval
+ * - reportMaxInterval
+ * - conformance
  */
 async function token_attributes(endpointTypeRef, options) {
   if (typeof endpointTypeRef != 'object') {
@@ -310,6 +368,32 @@ async function token_attributes(endpointTypeRef, options) {
  * @param {*} options
  * @returns Token associated clusters for a particular endpoint type or all
  * token associated clusters across endpoints.
+ * Per-endpoint mode (`selectTokenAttributeClustersForEndpoint`), from
+ * `exports.map.cluster` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - packageRef
+ * - code
+ * - manufacturerCode
+ * - label
+ * - name
+ * - caption
+ * - description
+ * - define
+ * - domainName
+ * - isSingleton
+ * - revision
+ * - isManufacturingSpecific
+ * - apiMaturity
+ * Global mode (`selectAllUserClustersWithTokenAttributes`), from
+ * `exports.map.endpointTypeClusterExtended` in `src-electron/db/db-mapping.js`:
+ * - endpointTypeClusterId
+ * - endpointTypeRef
+ * - clusterRef
+ * - side
+ * - enabled
+ * - name
+ * - code
+ * - tokenAttributesCount
  */
 async function token_attribute_clusters(endpointTypeRef, options) {
   let packageIds = await templateUtil.ensureZclPackageIds(this)

--- a/src-electron/generator/helper-tokens.js
+++ b/src-electron/generator/helper-tokens.js
@@ -279,6 +279,7 @@ async function token_attribute_util(context, options) {
  * an endpoint block helper it returns token_attributes for a given endpoint
  * type.
  * From `exports.map.endpointTypeAttributeExtended` in `src-electron/db/db-mapping.js`:
+ * - apiMaturity
  * - arrayType
  * - attributeRef
  * - bounded
@@ -288,6 +289,7 @@ async function token_attribute_util(context, options) {
  * - clusterRef
  * - clusterSide
  * - code
+ * - conformance
  * - defaultValue
  * - define
  * - endpointId
@@ -299,19 +301,20 @@ async function token_attribute_util(context, options) {
  * - includedReportable
  * - isArray
  * - isBound
+ * - isChangeOmitted
  * - isClusterEnabled
  * - isGlobalAttribute
  * - isIncluded
  * - isManufacturingSpecific
  * - isNullable
  * - isOptionalAttribute
+ * - isReadable
+ * - isReadableAttribute
  * - isReportableAttribute
  * - isSceneRequired
  * - isSingleton
  * - isWritable
  * - isWritableAttribute
- * - isReadable
- * - isReadableAttribute
  * - manufacturerCode
  * - max
  * - maxInterval
@@ -322,7 +325,10 @@ async function token_attribute_util(context, options) {
  * - minLength
  * - mustUseTimedWrite
  * - name
+ * - persistence
  * - reportableChange
+ * - reportMaxInterval
+ * - reportMinInterval
  * - side
  * - singleton
  * - smallestEndpointIdentifier
@@ -330,12 +336,6 @@ async function token_attribute_util(context, options) {
  * - storageOption
  * - tokenId
  * - type
- * - apiMaturity
- * - isChangeOmitted
- * - persistence
- * - reportMinInterval
- * - reportMaxInterval
- * - conformance
  */
 async function token_attributes(endpointTypeRef, options) {
   if (typeof endpointTypeRef != 'object') {
@@ -370,29 +370,29 @@ async function token_attributes(endpointTypeRef, options) {
  * token associated clusters across endpoints.
  * Per-endpoint mode (`selectTokenAttributeClustersForEndpoint`), from
  * `exports.map.cluster` in `src-electron/db/db-mapping.js`:
- * - id
- * - packageRef
- * - code
- * - manufacturerCode
- * - label
- * - name
- * - caption
- * - description
- * - define
- * - domainName
- * - isSingleton
- * - revision
- * - isManufacturingSpecific
  * - apiMaturity
+ * - caption
+ * - code
+ * - define
+ * - description
+ * - domainName
+ * - id
+ * - isManufacturingSpecific
+ * - isSingleton
+ * - label
+ * - manufacturerCode
+ * - name
+ * - packageRef
+ * - revision
  * Global mode (`selectAllUserClustersWithTokenAttributes`), from
  * `exports.map.endpointTypeClusterExtended` in `src-electron/db/db-mapping.js`:
+ * - clusterRef
+ * - code
+ * - enabled
  * - endpointTypeClusterId
  * - endpointTypeRef
- * - clusterRef
- * - side
- * - enabled
  * - name
- * - code
+ * - side
  * - tokenAttributesCount
  */
 async function token_attribute_clusters(endpointTypeRef, options) {

--- a/src-electron/generator/helper-zap.js
+++ b/src-electron/generator/helper-zap.js
@@ -71,6 +71,12 @@ function backslash() {
 
 /**
  * Block helper that iterates over the package options of a given category.
+ * From `exports.map.options` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - packageRef
+ * - optionCategory
+ * - optionCode
+ * - optionLabel
  *
  * @param {*} category
  * @param {*} options

--- a/src-electron/generator/helper-zap.js
+++ b/src-electron/generator/helper-zap.js
@@ -73,10 +73,10 @@ function backslash() {
  * Block helper that iterates over the package options of a given category.
  * From `exports.map.options` in `src-electron/db/db-mapping.js`:
  * - id
- * - packageRef
  * - optionCategory
  * - optionCode
  * - optionLabel
+ * - packageRef
  *
  * @param {*} category
  * @param {*} options

--- a/src-electron/generator/helper-zcl.js
+++ b/src-electron/generator/helper-zcl.js
@@ -42,6 +42,18 @@ const stringLongTypes = ['LONG_CHAR_STRING', 'LONG_OCTET_STRING']
 
 /**
  * Block helper iterating over all bitmaps.
+ * From `exports.map.bitmap` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - label
+ * - name
+ * - type
+ * - bitmapClusterCount
+ * - size
+ * - apiMaturity
+ * Helper-added:
+ * - has_no_clusters
+ * - has_one_cluster
+ * - has_more_than_one_cluster
  *
  * @param {*} options
  * @returns Promise of content.
@@ -76,7 +88,15 @@ async function zcl_bitmaps(options) {
 }
 
 /**
- * Iterates over enum items. Valid only inside zcl_enums.
+ * Iterates over bitmap fields. Valid only inside zcl_bitmaps.
+ * From `exports.map.bitmapField` in `src-electron/db/db-mapping.js`:
+ * - name
+ * - label
+ * - mask
+ * - type
+ * - bitmapRef
+ * - caption
+ * - apiMaturity
  * @param {*} options
  */
 function zcl_bitmap_items(options) {
@@ -91,6 +111,18 @@ function zcl_bitmap_items(options) {
  * If existing independently, it iterates over ALL the enums.
  * Within a context of a cluster, it iterates only over the
  * enums belonging to a cluster.
+ * From `exports.map.enum` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - label
+ * - name
+ * - caption
+ * - enumClusterCount
+ * - size
+ * - apiMaturity
+ * Helper-added:
+ * - has_no_clusters
+ * - has_one_cluster
+ * - has_more_than_one_cluster
  *
  * @param {*} options
  * @returns Promise of content.
@@ -208,6 +240,13 @@ async function zcl_structs(options) {
 
 /**
  * Iterates over enum items. Valid only inside zcl_enums.
+ * From `exports.map.enumItem` in `src-electron/db/db-mapping.js`:
+ * - name
+ * - label
+ * - value
+ * - enumRef
+ * - caption
+ * - apiMaturity
  * @param {*} options
  */
 async function zcl_enum_items(options) {
@@ -281,7 +320,26 @@ async function first_unused_enum_value(options) {
 
 /**
  * Block helper iterating over all struct items. Valid only inside zcl_structs.
-
+ * From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
+ * - name
+ * - label
+ * - fieldIdentifier
+ * - structRef
+ * - type
+ * - minLength
+ * - maxLength
+ * - defaultValue
+ * - isArray
+ * - isEnum
+ * - isWritable
+ * - isNullable
+ * - isOptional
+ * - isFabricSensitive
+ * - dataTypeReference
+ * - discriminatorName
+ * - apiMaturity
+ * When `checkForDoubleNestedArray` is true, the helper may also set:
+ * - struct_item_contains_nested_array
  * @param {*} options
  * @returns Promise of content.
  */
@@ -312,6 +370,24 @@ async function zcl_struct_items(options) {
 
 /**
  * Block helper iterating over all struct items given the struct name.
+ * From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
+ * - name
+ * - label
+ * - fieldIdentifier
+ * - structRef
+ * - type
+ * - minLength
+ * - maxLength
+ * - defaultValue
+ * - isArray
+ * - isEnum
+ * - isWritable
+ * - isNullable
+ * - isOptional
+ * - isFabricSensitive
+ * - dataTypeReference
+ * - discriminatorName
+ * - apiMaturity
  *
  * @param name
  * @param options
@@ -331,6 +407,24 @@ async function zcl_struct_items_by_struct_name(name, options) {
  * struct name being used within the given cluster.  That means the struct name
  * must be either a global struct (in which case the cluster name is just
  * ignored), or a struct associated with the given cluster.
+ * From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
+ * - name
+ * - label
+ * - fieldIdentifier
+ * - structRef
+ * - type
+ * - minLength
+ * - maxLength
+ * - defaultValue
+ * - isArray
+ * - isEnum
+ * - isWritable
+ * - isNullable
+ * - isOptional
+ * - isFabricSensitive
+ * - dataTypeReference
+ * - discriminatorName
+ * - apiMaturity
  *
  * @param name
  * @param clusterName
@@ -368,6 +462,17 @@ async function zcl_struct_items_by_struct_and_cluster_name(
 
 /**
  * Block helper iterating over all deviceTypes.
+ * From `exports.map.deviceType` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - revision
+ * - code
+ * - profileId
+ * - domain
+ * - label
+ * - name
+ * - caption
+ * - class
+ * - packageRef
  *
  * @param {*} options
  * @returns Promise of content.
@@ -385,6 +490,15 @@ async function zcl_device_types(options) {
 
 /**
  * Block helper for use inside zcl_device_types
+ * From `exports.map.deviceTypeCluster` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - deviceTypeRef
+ * - clusterRef
+ * - clusterName
+ * - includeClient
+ * - includeServer
+ * - lockClient
+ * - lockServer
  *
  * @param {*} options
  * @returns blocks for clusters
@@ -401,6 +515,13 @@ async function zcl_device_type_clusters(options) {
 
 /**
  * Block helper for use inside zcl_device_type_clusters
+ * From `exports.map.deviceTypeCommand` in `src-electron/db/db-mapping.js`:
+ * - deviceTypeClusterRef
+ * - commandRef
+ * - name
+ * - code
+ * - manufacturerCode
+ * - source
  *
  * @param {*} options
  * @returns blocks for commands
@@ -417,6 +538,12 @@ async function zcl_device_type_cluster_commands(options) {
 
 /**
  * Block helper for use inside zcl_device_type_clusters
+ * From `exports.map.deviceTypeAttribute` in `src-electron/db/db-mapping.js`:
+ * - deviceTypeClusterRef
+ * - attributeRef
+ * - name
+ * - code
+ * - manufacturerCode
  *
  * @param {*} options
  * @returns blocks for attributes
@@ -434,6 +561,21 @@ async function zcl_device_type_cluster_attributes(options) {
 
 /**
  * Block helper iterating over all clusters.
+ * From `exports.map.cluster` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - packageRef
+ * - code
+ * - manufacturerCode
+ * - label
+ * - name
+ * - caption
+ * - description
+ * - define
+ * - domainName
+ * - isSingleton
+ * - revision
+ * - isManufacturingSpecific
+ * - apiMaturity
  *
  * @param {*} options
  * @returns Promise of content.
@@ -452,6 +594,43 @@ async function zcl_clusters(options) {
  * There are two modes of this helper:
  *   when used in a global context, it iterates over ALL commands in the database.
  *   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that cluster.
+ * From `exports.map.command` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - clusterRef
+ * - packageRef
+ * - code
+ * - manufacturerCode
+ * - label
+ * - name
+ * - commandName
+ * - description
+ * - source
+ * - isOptional
+ * - conformance
+ * - mustUseTimedInvoke
+ * - isFabricScoped
+ * - clusterCode
+ * - clusterName
+ * - clusterDefineName
+ * - argName
+ * - argType
+ * - argDefaultValue
+ * - argIsArray
+ * - argPresentIf
+ * - argCountArg
+ * - commandArgCount
+ * - requiredCommandArgCount
+ * - hasArguments
+ * - commandHasRequiredField
+ * - argIsNullable
+ * - responseRef
+ * - responseName
+ * - hasSpecificResponse
+ * - isIncoming
+ * - isOutgoing
+ * - isDefaultResponseEnabled
+ * - isLargeMessage
+ * - apiMaturity
  *
  * @param {*} options
  * @returns Promise of content.
@@ -486,6 +665,7 @@ function zcl_commands(options) {
  * the database.
  * - when used inside a `zcl_cluster` block helper, it iterates only over the
  * commands responses for that cluster.
+ * Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
  * @param {*} options
  * @returns all command responses
  */
@@ -510,6 +690,7 @@ async function zcl_command_responses(options) {
 /**
  * Block helper iterating over all commands with cluster information.
  * Note: Similar to zcl_commands but has cluster information as well.
+ * Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
  * @param {*} options
  * @returns Promise of content.
  */
@@ -574,6 +755,7 @@ async function zcl_commands_with_arguments(options) {
  * There are two modes of this helper:
  *   when used in a global context, it iterates over ALL commands in the database based on the source.
  *   when used inside a `zcl_cluster` block helper, it iterates only over the source commands for that cluster.
+ * Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
  *
  * @param {*} options
  * @param {*} source
@@ -609,6 +791,7 @@ function zcl_commands_by_source(options, source) {
  * There are two modes of this helper:
  *   when used in a global context, it iterates over ALL client commands in the database.
  *   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that client cluster.
+ * Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
  *
  * @param {*} options
  * @returns Promise of content.
@@ -622,6 +805,7 @@ function zcl_commands_source_client(options) {
  * There are two modes of this helper:
  *   when used in a global context, it iterates over ALL server commands in the database.
  *   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that server cluster.
+ * Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
  *
  * @param {*} options
  * @returns Promise of content.
@@ -635,6 +819,30 @@ function zcl_commands_source_server(options) {
  * There are two modes of this helper:
  *   when used in a global context, it iterates over ALL events in the database.
  *   when used inside a `zcl_cluster` block helper, it iterates only over the events for that cluster.
+ * From `exports.map.event` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - clusterRef
+ * - clusterCode
+ * - packageRef
+ * - code
+ * - manufacturerCode
+ * - name
+ * - description
+ * - side
+ * - conformance
+ * - isOptional
+ * - isFabricSensitive
+ * - priority
+ * - apiMaturity
+ * The helper adds `items`, an array of `exports.map.eventField` objects:
+ * - fieldIdentifier
+ * - name
+ * - type
+ * - defaultValue
+ * - isArray
+ * - isNullable
+ * - isOptional
+ * - apiMaturity
  *
  * @param {*} options
  * @returns Promise of content.
@@ -667,6 +875,19 @@ async function zcl_events(options) {
 
 /**
  * Block helper iterating over all commands, including their arguments and clusters.
+ * Starts from `exports.map.command` rows (see `zcl_commands` for the per-key list),
+ * then aggregates and adds:
+ * - commandArgs
+ * - argsstring
+ * - clientMacroName
+ * - isGlobal
+ * Each entry in `commandArgs` includes:
+ * - name
+ * - type
+ * - isArray
+ * - hasLength
+ * - nameLength
+ * - formatChar
  *
  * @param {*} options
  * @returns Promise of content.
@@ -758,6 +979,7 @@ function zcl_command_tree(options) {
 
 /**
  * Helper to iterate over all global commands.
+ * Uses the same `exports.map.command` keys as `zcl_commands` (see that helper).
  *
  * @param {*} options
  * @returns Promise of global command iteration.
@@ -776,6 +998,46 @@ function zcl_global_commands(options) {
  * Iterator over the attributes. If it is used at toplevel, if iterates over all the attributes
  * in the database. If used within zcl_cluster context, it iterates over all the attributes
  * that belong to that cluster.
+ * From `exports.map.attribute` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - clusterRef
+ * - packageRef
+ * - code
+ * - clusterCode
+ * - manufacturerCode
+ * - name
+ * - label
+ * - type
+ * - side
+ * - define
+ * - conformance
+ * - min
+ * - max
+ * - minLength
+ * - maxLength
+ * - reportMinInterval
+ * - reportMaxInterval
+ * - reportableChange
+ * - reportableChangeLength
+ * - isWritable
+ * - isWritableAttribute
+ * - isReadable
+ * - isReadableAttribute
+ * - isNullable
+ * - defaultValue
+ * - isOptional
+ * - isReportable
+ * - isReportableAttribute
+ * - reportingPolicy
+ * - storagePolicy
+ * - isSceneRequired
+ * - entryType
+ * - isArray
+ * - mustUseTimedWrite
+ * - apiMaturity
+ * - isChangeOmitted
+ * - persistence
+ * - entryTypeElseType
  *
  * @param {*} options
  * @returns Promise of attribute iteration.
@@ -809,6 +1071,7 @@ async function zcl_attributes(options) {
  * Iterator over the client attributes. If it is used at toplevel, if iterates over all the client attributes
  * in the database. If used within zcl_cluster context, it iterates over all the client attributes
  * that belong to that cluster.
+ * Uses the same `exports.map.attribute` keys as `zcl_attributes` (see that helper).
  *
  * @param {*} options
  * @returns Promise of attribute iteration.
@@ -852,6 +1115,8 @@ async function zcl_attributes_client(options) {
  * - removeKeys: Removes one or more keys from the map(for eg keys in db-mapping.js)
  * for eg: (#zcl_attributes_server removeKeys='isOptional, isNullable') will remove 'isOptional'
  * from the results
+ * Uses the same `exports.map.attribute` keys as `zcl_attributes` (see that helper);
+ * `removeKeys` may delete some of those keys before iteration.
  * @param {*} options
  * @returns Promise of attribute iteration.
  */
@@ -892,6 +1157,20 @@ async function zcl_attributes_server(options) {
 
 /**
  * Block helper iterating over all atomic types.
+ * From `exports.map.atomic` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - atomicId
+ * - name
+ * - description
+ * - size
+ * - isDiscrete
+ * - isString
+ * - isLong
+ * - isChar
+ * - isSigned
+ * - isComposite
+ * - isFloat
+ * - baseType
  *
  * @param {*} options
  * @returns Promise of content.
@@ -1178,6 +1457,31 @@ function command_arguments_total_length(commandId) {
 /**
  * Block helper iterating over command arguments within a command
  * or a command tree.
+ * From `exports.map.commandArgument` in `src-electron/db/db-mapping.js`:
+ * - commandRef
+ * - fieldIdentifier
+ * - label
+ * - name
+ * - type
+ * - typeSize
+ * - typeIsSigned
+ * - min
+ * - max
+ * - minLength
+ * - maxLength
+ * - defaultValue
+ * - code
+ * - isArray
+ * - presentIf
+ * - isNullable
+ * - isOptional
+ * - introducedInRef
+ * - removedInRef
+ * - countArg
+ * - caption
+ * - apiMaturity
+ * When arguments are loaded from the database, this helper refreshes `typeSize`
+ * and `typeIsSigned` from resolved ZCL types.
  *
  * @param {*} options
  * @returns Promise of command argument iteration.
@@ -1230,6 +1534,15 @@ async function zcl_command_arguments(options) {
 
 /**
  * Block helper iterating over the event fields inside an event.
+ * From `exports.map.eventField` in `src-electron/db/db-mapping.js`:
+ * - fieldIdentifier
+ * - name
+ * - type
+ * - defaultValue
+ * - isArray
+ * - isNullable
+ * - isOptional
+ * - apiMaturity
  *
  * @param {*} options
  */
@@ -2800,6 +3113,17 @@ due to no language option specified in the template'
  * structs which are present in more than one cluster
  * eg Usage:
  * {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}}
+ * From `exports.map.struct` in `src-electron/db/db-mapping.js`:
+ * - id
+ * - label
+ * - name
+ * - itemCnt
+ * - isFabricScoped
+ * - caption
+ * - structClusterCount
+ * - structCount
+ * - clusterName
+ * - apiMaturity
  */
 async function structs_with_clusters(options) {
   const packageIds = await templateUtil.ensureZclPackageIds(this)

--- a/src-electron/generator/helper-zcl.js
+++ b/src-electron/generator/helper-zcl.js
@@ -43,17 +43,17 @@ const stringLongTypes = ['LONG_CHAR_STRING', 'LONG_OCTET_STRING']
 /**
  * Block helper iterating over all bitmaps.
  * From `exports.map.bitmap` in `src-electron/db/db-mapping.js`:
+ * - apiMaturity
+ * - bitmapClusterCount
  * - id
  * - label
  * - name
- * - type
- * - bitmapClusterCount
  * - size
- * - apiMaturity
+ * - type
  * Helper-added:
+ * - has_more_than_one_cluster
  * - has_no_clusters
  * - has_one_cluster
- * - has_more_than_one_cluster
  *
  * @param {*} options
  * @returns Promise of content.
@@ -90,13 +90,13 @@ async function zcl_bitmaps(options) {
 /**
  * Iterates over bitmap fields. Valid only inside zcl_bitmaps.
  * From `exports.map.bitmapField` in `src-electron/db/db-mapping.js`:
- * - name
- * - label
- * - mask
- * - type
+ * - apiMaturity
  * - bitmapRef
  * - caption
- * - apiMaturity
+ * - label
+ * - mask
+ * - name
+ * - type
  * @param {*} options
  */
 function zcl_bitmap_items(options) {
@@ -112,17 +112,17 @@ function zcl_bitmap_items(options) {
  * Within a context of a cluster, it iterates only over the
  * enums belonging to a cluster.
  * From `exports.map.enum` in `src-electron/db/db-mapping.js`:
+ * - apiMaturity
+ * - caption
+ * - enumClusterCount
  * - id
  * - label
  * - name
- * - caption
- * - enumClusterCount
  * - size
- * - apiMaturity
  * Helper-added:
+ * - has_more_than_one_cluster
  * - has_no_clusters
  * - has_one_cluster
- * - has_more_than_one_cluster
  *
  * @param {*} options
  * @returns Promise of content.
@@ -241,12 +241,12 @@ async function zcl_structs(options) {
 /**
  * Iterates over enum items. Valid only inside zcl_enums.
  * From `exports.map.enumItem` in `src-electron/db/db-mapping.js`:
- * - name
- * - label
- * - value
- * - enumRef
- * - caption
  * - apiMaturity
+ * - caption
+ * - enumRef
+ * - label
+ * - name
+ * - value
  * @param {*} options
  */
 async function zcl_enum_items(options) {
@@ -321,23 +321,23 @@ async function first_unused_enum_value(options) {
 /**
  * Block helper iterating over all struct items. Valid only inside zcl_structs.
  * From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
- * - name
- * - label
- * - fieldIdentifier
- * - structRef
- * - type
- * - minLength
- * - maxLength
+ * - apiMaturity
+ * - dataTypeReference
  * - defaultValue
+ * - discriminatorName
+ * - fieldIdentifier
  * - isArray
  * - isEnum
- * - isWritable
+ * - isFabricSensitive
  * - isNullable
  * - isOptional
- * - isFabricSensitive
- * - dataTypeReference
- * - discriminatorName
- * - apiMaturity
+ * - isWritable
+ * - label
+ * - maxLength
+ * - minLength
+ * - name
+ * - structRef
+ * - type
  * When `checkForDoubleNestedArray` is true, the helper may also set:
  * - struct_item_contains_nested_array
  * @param {*} options
@@ -371,23 +371,23 @@ async function zcl_struct_items(options) {
 /**
  * Block helper iterating over all struct items given the struct name.
  * From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
- * - name
- * - label
- * - fieldIdentifier
- * - structRef
- * - type
- * - minLength
- * - maxLength
+ * - apiMaturity
+ * - dataTypeReference
  * - defaultValue
+ * - discriminatorName
+ * - fieldIdentifier
  * - isArray
  * - isEnum
- * - isWritable
+ * - isFabricSensitive
  * - isNullable
  * - isOptional
- * - isFabricSensitive
- * - dataTypeReference
- * - discriminatorName
- * - apiMaturity
+ * - isWritable
+ * - label
+ * - maxLength
+ * - minLength
+ * - name
+ * - structRef
+ * - type
  *
  * @param name
  * @param options
@@ -408,23 +408,23 @@ async function zcl_struct_items_by_struct_name(name, options) {
  * must be either a global struct (in which case the cluster name is just
  * ignored), or a struct associated with the given cluster.
  * From `exports.map.structItem` in `src-electron/db/db-mapping.js`:
- * - name
- * - label
- * - fieldIdentifier
- * - structRef
- * - type
- * - minLength
- * - maxLength
+ * - apiMaturity
+ * - dataTypeReference
  * - defaultValue
+ * - discriminatorName
+ * - fieldIdentifier
  * - isArray
  * - isEnum
- * - isWritable
+ * - isFabricSensitive
  * - isNullable
  * - isOptional
- * - isFabricSensitive
- * - dataTypeReference
- * - discriminatorName
- * - apiMaturity
+ * - isWritable
+ * - label
+ * - maxLength
+ * - minLength
+ * - name
+ * - structRef
+ * - type
  *
  * @param name
  * @param clusterName
@@ -463,16 +463,16 @@ async function zcl_struct_items_by_struct_and_cluster_name(
 /**
  * Block helper iterating over all deviceTypes.
  * From `exports.map.deviceType` in `src-electron/db/db-mapping.js`:
- * - id
- * - revision
- * - code
- * - profileId
- * - domain
- * - label
- * - name
  * - caption
  * - class
+ * - code
+ * - domain
+ * - id
+ * - label
+ * - name
  * - packageRef
+ * - profileId
+ * - revision
  *
  * @param {*} options
  * @returns Promise of content.
@@ -491,10 +491,10 @@ async function zcl_device_types(options) {
 /**
  * Block helper for use inside zcl_device_types
  * From `exports.map.deviceTypeCluster` in `src-electron/db/db-mapping.js`:
- * - id
- * - deviceTypeRef
- * - clusterRef
  * - clusterName
+ * - clusterRef
+ * - deviceTypeRef
+ * - id
  * - includeClient
  * - includeServer
  * - lockClient
@@ -516,11 +516,11 @@ async function zcl_device_type_clusters(options) {
 /**
  * Block helper for use inside zcl_device_type_clusters
  * From `exports.map.deviceTypeCommand` in `src-electron/db/db-mapping.js`:
- * - deviceTypeClusterRef
- * - commandRef
- * - name
  * - code
+ * - commandRef
+ * - deviceTypeClusterRef
  * - manufacturerCode
+ * - name
  * - source
  *
  * @param {*} options
@@ -539,11 +539,11 @@ async function zcl_device_type_cluster_commands(options) {
 /**
  * Block helper for use inside zcl_device_type_clusters
  * From `exports.map.deviceTypeAttribute` in `src-electron/db/db-mapping.js`:
- * - deviceTypeClusterRef
  * - attributeRef
- * - name
  * - code
+ * - deviceTypeClusterRef
  * - manufacturerCode
+ * - name
  *
  * @param {*} options
  * @returns blocks for attributes
@@ -562,20 +562,20 @@ async function zcl_device_type_cluster_attributes(options) {
 /**
  * Block helper iterating over all clusters.
  * From `exports.map.cluster` in `src-electron/db/db-mapping.js`:
- * - id
- * - packageRef
- * - code
- * - manufacturerCode
- * - label
- * - name
- * - caption
- * - description
- * - define
- * - domainName
- * - isSingleton
- * - revision
- * - isManufacturingSpecific
  * - apiMaturity
+ * - caption
+ * - code
+ * - define
+ * - description
+ * - domainName
+ * - id
+ * - isManufacturingSpecific
+ * - isSingleton
+ * - label
+ * - manufacturerCode
+ * - name
+ * - packageRef
+ * - revision
  *
  * @param {*} options
  * @returns Promise of content.
@@ -595,42 +595,42 @@ async function zcl_clusters(options) {
  *   when used in a global context, it iterates over ALL commands in the database.
  *   when used inside a `zcl_cluster` block helper, it iterates only over the commands for that cluster.
  * From `exports.map.command` in `src-electron/db/db-mapping.js`:
- * - id
- * - clusterRef
- * - packageRef
- * - code
- * - manufacturerCode
- * - label
- * - name
- * - commandName
- * - description
- * - source
- * - isOptional
- * - conformance
- * - mustUseTimedInvoke
- * - isFabricScoped
- * - clusterCode
- * - clusterName
- * - clusterDefineName
- * - argName
- * - argType
+ * - apiMaturity
+ * - argCountArg
  * - argDefaultValue
  * - argIsArray
- * - argPresentIf
- * - argCountArg
- * - commandArgCount
- * - requiredCommandArgCount
- * - hasArguments
- * - commandHasRequiredField
  * - argIsNullable
- * - responseRef
- * - responseName
+ * - argName
+ * - argPresentIf
+ * - argType
+ * - clusterCode
+ * - clusterDefineName
+ * - clusterName
+ * - clusterRef
+ * - code
+ * - commandArgCount
+ * - commandHasRequiredField
+ * - commandName
+ * - conformance
+ * - description
+ * - hasArguments
  * - hasSpecificResponse
- * - isIncoming
- * - isOutgoing
+ * - id
  * - isDefaultResponseEnabled
+ * - isFabricScoped
+ * - isIncoming
  * - isLargeMessage
- * - apiMaturity
+ * - isOptional
+ * - isOutgoing
+ * - label
+ * - manufacturerCode
+ * - mustUseTimedInvoke
+ * - name
+ * - packageRef
+ * - requiredCommandArgCount
+ * - responseName
+ * - responseRef
+ * - source
  *
  * @param {*} options
  * @returns Promise of content.
@@ -820,29 +820,29 @@ function zcl_commands_source_server(options) {
  *   when used in a global context, it iterates over ALL events in the database.
  *   when used inside a `zcl_cluster` block helper, it iterates only over the events for that cluster.
  * From `exports.map.event` in `src-electron/db/db-mapping.js`:
- * - id
- * - clusterRef
+ * - apiMaturity
  * - clusterCode
- * - packageRef
+ * - clusterRef
  * - code
+ * - conformance
+ * - description
+ * - id
+ * - isFabricSensitive
+ * - isOptional
  * - manufacturerCode
  * - name
- * - description
- * - side
- * - conformance
- * - isOptional
- * - isFabricSensitive
+ * - packageRef
  * - priority
- * - apiMaturity
+ * - side
  * The helper adds `items`, an array of `exports.map.eventField` objects:
- * - fieldIdentifier
- * - name
- * - type
+ * - apiMaturity
  * - defaultValue
+ * - fieldIdentifier
  * - isArray
  * - isNullable
  * - isOptional
- * - apiMaturity
+ * - name
+ * - type
  *
  * @param {*} options
  * @returns Promise of content.
@@ -877,17 +877,17 @@ async function zcl_events(options) {
  * Block helper iterating over all commands, including their arguments and clusters.
  * Starts from `exports.map.command` rows (see `zcl_commands` for the per-key list),
  * then aggregates and adds:
- * - commandArgs
  * - argsstring
  * - clientMacroName
+ * - commandArgs
  * - isGlobal
  * Each entry in `commandArgs` includes:
- * - name
- * - type
- * - isArray
- * - hasLength
- * - nameLength
  * - formatChar
+ * - hasLength
+ * - isArray
+ * - name
+ * - nameLength
+ * - type
  *
  * @param {*} options
  * @returns Promise of content.
@@ -999,45 +999,45 @@ function zcl_global_commands(options) {
  * in the database. If used within zcl_cluster context, it iterates over all the attributes
  * that belong to that cluster.
  * From `exports.map.attribute` in `src-electron/db/db-mapping.js`:
- * - id
- * - clusterRef
- * - packageRef
- * - code
+ * - apiMaturity
  * - clusterCode
- * - manufacturerCode
- * - name
- * - label
- * - type
- * - side
- * - define
+ * - clusterRef
+ * - code
  * - conformance
- * - min
- * - max
- * - minLength
- * - maxLength
- * - reportMinInterval
- * - reportMaxInterval
- * - reportableChange
- * - reportableChangeLength
- * - isWritable
- * - isWritableAttribute
+ * - defaultValue
+ * - define
+ * - entryType
+ * - entryTypeElseType
+ * - id
+ * - isArray
+ * - isChangeOmitted
+ * - isNullable
+ * - isOptional
  * - isReadable
  * - isReadableAttribute
- * - isNullable
- * - defaultValue
- * - isOptional
  * - isReportable
  * - isReportableAttribute
- * - reportingPolicy
- * - storagePolicy
  * - isSceneRequired
- * - entryType
- * - isArray
+ * - isWritable
+ * - isWritableAttribute
+ * - label
+ * - manufacturerCode
+ * - max
+ * - maxLength
+ * - min
+ * - minLength
  * - mustUseTimedWrite
- * - apiMaturity
- * - isChangeOmitted
+ * - name
+ * - packageRef
  * - persistence
- * - entryTypeElseType
+ * - reportableChange
+ * - reportableChangeLength
+ * - reportMaxInterval
+ * - reportMinInterval
+ * - reportingPolicy
+ * - side
+ * - storagePolicy
+ * - type
  *
  * @param {*} options
  * @returns Promise of attribute iteration.
@@ -1158,19 +1158,19 @@ async function zcl_attributes_server(options) {
 /**
  * Block helper iterating over all atomic types.
  * From `exports.map.atomic` in `src-electron/db/db-mapping.js`:
- * - id
  * - atomicId
- * - name
- * - description
- * - size
- * - isDiscrete
- * - isString
- * - isLong
- * - isChar
- * - isSigned
- * - isComposite
- * - isFloat
  * - baseType
+ * - description
+ * - id
+ * - isChar
+ * - isComposite
+ * - isDiscrete
+ * - isFloat
+ * - isLong
+ * - isSigned
+ * - isString
+ * - name
+ * - size
  *
  * @param {*} options
  * @returns Promise of content.
@@ -1458,28 +1458,28 @@ function command_arguments_total_length(commandId) {
  * Block helper iterating over command arguments within a command
  * or a command tree.
  * From `exports.map.commandArgument` in `src-electron/db/db-mapping.js`:
- * - commandRef
- * - fieldIdentifier
- * - label
- * - name
- * - type
- * - typeSize
- * - typeIsSigned
- * - min
- * - max
- * - minLength
- * - maxLength
- * - defaultValue
+ * - apiMaturity
+ * - caption
  * - code
+ * - commandRef
+ * - countArg
+ * - defaultValue
+ * - fieldIdentifier
+ * - introducedInRef
  * - isArray
- * - presentIf
  * - isNullable
  * - isOptional
- * - introducedInRef
+ * - label
+ * - max
+ * - maxLength
+ * - min
+ * - minLength
+ * - name
+ * - presentIf
  * - removedInRef
- * - countArg
- * - caption
- * - apiMaturity
+ * - type
+ * - typeIsSigned
+ * - typeSize
  * When arguments are loaded from the database, this helper refreshes `typeSize`
  * and `typeIsSigned` from resolved ZCL types.
  *
@@ -1535,14 +1535,14 @@ async function zcl_command_arguments(options) {
 /**
  * Block helper iterating over the event fields inside an event.
  * From `exports.map.eventField` in `src-electron/db/db-mapping.js`:
- * - fieldIdentifier
- * - name
- * - type
+ * - apiMaturity
  * - defaultValue
+ * - fieldIdentifier
  * - isArray
  * - isNullable
  * - isOptional
- * - apiMaturity
+ * - name
+ * - type
  *
  * @param {*} options
  */
@@ -3114,16 +3114,16 @@ due to no language option specified in the template'
  * eg Usage:
  * {{#structs_with_clusters groupByStructName=1}}{{/structs_with_clusters}}
  * From `exports.map.struct` in `src-electron/db/db-mapping.js`:
+ * - apiMaturity
+ * - caption
+ * - clusterName
  * - id
+ * - isFabricScoped
+ * - itemCnt
  * - label
  * - name
- * - itemCnt
- * - isFabricScoped
- * - caption
  * - structClusterCount
  * - structCount
- * - clusterName
- * - apiMaturity
  */
 async function structs_with_clusters(options) {
   const packageIds = await templateUtil.ensureZclPackageIds(this)


### PR DESCRIPTION
- Attribute keys available for each block helper added to the the block helper function definition

- Github: ZAP #915