### PR TITLE
refactor watchdog: use per-instance timers; add idle + hard template timeouts

### DIFF
--- a/src-electron/generator/template-engine.js
+++ b/src-electron/generator/template-engine.js
@@ -28,6 +28,7 @@ const notification = require('../db/query-session-notification.js')
 const util = require('../util/util')
 const helper = require('../util/external-helper')
 const templateIterators = require('./template-iterators')
+const watchdog = require('../main-process/watchdog')
 
 const includedHelpers = [
   require('./helper-zcl'),
@@ -70,7 +71,12 @@ const precompiledTemplates = {}
 
 const handlebarsInstance = {}
 
-const TEMPLATE_RENDER_TIMEOUT = 540000 // 9 minutes
+// Per-render idle watchdog: a render is killed if it makes no progress
+// (no helper invocation, no deferred block) for this long. Reset on activity
+// so long-but-healthy generations keep running.
+const TEMPLATE_RENDER_IDLE_TIMEOUT = 60000 // 1 minute of no progress
+// Absolute safety net; a render cannot exceed this even if it keeps kicking.
+const TEMPLATE_RENDER_HARD_TIMEOUT = 540000 // 9 minutes
 
 /**
  * Resolves into a precompiled template, either from previous precompile or freshly compiled.
@@ -243,25 +249,49 @@ async function produceContent(
     Object.assign(context, options.initialContext)
   }
   let content
-  // Render the template but if it does not render within
-  // TEMPLATE_RENDER_TIMEOUT then throw an error instead of just hanging
-  // forever.
-  try {
-    // Attempt to render the template
-    content = await Promise.race([
-      template(context),
-      new Promise((_, reject) =>
-        setTimeout(
-          () => reject(new Error('Template rendering timed out')),
-          TEMPLATE_RENDER_TIMEOUT
+  // Render the template (main pass + deferred blocks) under two timers:
+  //  - An idle watchdog that trips only if the render makes no progress
+  //    for TEMPLATE_RENDER_IDLE_TIMEOUT ms (reset on every helper call and
+  //    on each deferred block). This catches true hangs quickly without
+  //    penalizing large, healthy generations.
+  //  - A hard deadline (TEMPLATE_RENDER_HARD_TIMEOUT) as a final safety net.
+  //  Both timers apply to the whole pipeline via a single Promise.race.
+  let idleWatchdog = null
+  let hardTimer = null
+  const timeoutPromise = new Promise((_, reject) => {
+    idleWatchdog = watchdog.createWatchdog(TEMPLATE_RENDER_IDLE_TIMEOUT, () =>
+      reject(
+        new Error(
+          `Template rendering stalled: no progress for ${TEMPLATE_RENDER_IDLE_TIMEOUT}ms in ${singleTemplatePkg.path}`
         )
       )
-    ])
-    // Render deferred blocks (parallel; order preserved by Promise.all)
-    const deferredParts = await Promise.all(
-      context.global.deferredBlocks.map((block) => block(context))
     )
-    content += deferredParts.join('')
+    hardTimer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `Template rendering exceeded hard timeout of ${TEMPLATE_RENDER_HARD_TIMEOUT}ms in ${singleTemplatePkg.path}`
+          )
+        ),
+      TEMPLATE_RENDER_HARD_TIMEOUT
+    )
+    if (typeof hardTimer.unref === 'function') hardTimer.unref()
+  })
+  context.global.watchdog = idleWatchdog
+  try {
+    content = await Promise.race([
+      (async () => {
+        const mainContent = await template(context)
+        const deferredParts = await Promise.all(
+          context.global.deferredBlocks.map((block) => {
+            idleWatchdog.reset()
+            return block(context)
+          })
+        )
+        return mainContent + deferredParts.join('')
+      })(),
+      timeoutPromise
+    ])
   } catch (error) {
     // Log the error and throw it
     notification.setNotification(
@@ -277,6 +307,10 @@ async function produceContent(
       error
     )
     throw error
+  } finally {
+    idleWatchdog?.stop()
+    if (hardTimer != null) clearTimeout(hardTimer)
+    context.global.watchdog = null
   }
   return [
     {
@@ -352,6 +386,9 @@ function loadPartial(hb, name, data) {
  */
 function helperWrapper(wrappedHelper) {
   return function w(...args) {
+    // Kick the per-render watchdog: a helper call is a sign of progress,
+    // so the idle timer should not expire.
+    this.global?.watchdog?.reset()
     let helperName = wrappedHelper.name
     if (wrappedHelper.originalHelper != null) {
       helperName = wrappedHelper.originalHelper

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -63,7 +63,7 @@ async function startNormal(quitFunction, argv) {
     env.zapVersion()
   )
 
-  watchdog.start(argv.watchdogTimer, () => {
+  const serverWatchdog = watchdog.createWatchdog(argv.watchdogTimer, () => {
     if (quitFunction != null) {
       quitFunction()
     } else {
@@ -88,9 +88,10 @@ async function startNormal(quitFunction, argv) {
       await httpServer.initHttpServer(db, argv.httpPort, argv.studioHttpPort, {
         zcl: argv.zclProperties,
         template: argv.generationTemplate,
-        allowCors: argv.allowCors
+        allowCors: argv.allowCors,
+        watchdog: serverWatchdog
       })
-      await ipcServer.initServer(db, argv.httpPort)
+      await ipcServer.initServer(db, argv.httpPort, serverWatchdog)
     }
     let port = httpServer.httpServerPort()
 
@@ -641,7 +642,7 @@ async function startServer(argv, quitFunction) {
     env.zapVersion()
   )
 
-  watchdog.start(argv.watchdogTimer, () => {
+  const serverWatchdog = watchdog.createWatchdog(argv.watchdogTimer, () => {
     if (quitFunction != null) {
       quitFunction()
     } else {
@@ -662,9 +663,10 @@ async function startServer(argv, quitFunction) {
     await httpServer.initHttpServer(db, argv.httpPort, argv.studioHttpPort, {
       zcl: argv.zclProperties,
       template: argv.generationTemplate,
-      allowCors: argv.allowCors
+      allowCors: argv.allowCors,
+      watchdog: serverWatchdog
     })
-    await ipcServer.initServer(db, argv.httpPort)
+    await ipcServer.initServer(db, argv.httpPort, serverWatchdog)
     logRemoteData(httpServer.httpServerStartupMessage())
   } catch (err) {
     env.logError(err)

--- a/src-electron/main-process/watchdog.js
+++ b/src-electron/main-process/watchdog.js
@@ -21,25 +21,36 @@
  * @module watchdog API: initializes times.
  */
 
-let watchDogId = null
-
 /**
- * Starts a zap watchdog.
+ * Creates an independent watchdog instance.
  *
- * @param {*} expirationInterval
- * @param {*} triggerFunction
+ * A watchdog is a refreshable timer: if `reset()` is not called within
+ * `expirationInterval` ms, `triggerFunction` fires once. Call `stop()` to
+ * cancel it entirely. Multiple watchdogs can coexist (e.g. one per
+ * template render and one for overall server inactivity).
+ *
+ * @param {number} expirationInterval - ms of inactivity before triggering.
+ * @param {Function} triggerFunction - invoked when the watchdog expires.
+ * @returns {{ reset: Function, stop: Function }}
  */
-function start(expirationInterval, triggerFunction) {
-  watchDogId = setTimeout(triggerFunction, expirationInterval)
-  watchDogId.unref()
+function createWatchdog(expirationInterval, triggerFunction) {
+  let id = setTimeout(triggerFunction, expirationInterval)
+  // Do not keep the event loop alive just because of this timer.
+  if (typeof id.unref === 'function') id.unref()
+  let stopped = false
+  return {
+    reset() {
+      if (stopped) return
+      if (id != null && typeof id.refresh === 'function') id.refresh()
+    },
+    stop() {
+      stopped = true
+      if (id != null) {
+        clearTimeout(id)
+        id = null
+      }
+    }
+  }
 }
 
-/**
- * Resets a zap watchdog.
- */
-function reset() {
-  if (watchDogId != null) watchDogId.refresh()
-}
-
-exports.start = start
-exports.reset = reset
+exports.createWatchdog = createWatchdog

--- a/src-electron/server/http-server.js
+++ b/src-electron/server/http-server.js
@@ -30,7 +30,6 @@ const webSocket = require('./ws-server.js')
 const studio = require('../ide-integration/studio-rest-api')
 const restApi = require('../../src-shared/rest-api.js')
 const dbEnum = require('../../src-shared/db-enum.js')
-const watchdog = require('../main-process/watchdog')
 const initialize = require('../rest/initialize')
 const dirtyFlag = require('../util/async-reporting')
 const notification = require('../db/query-session-notification.js')
@@ -118,9 +117,11 @@ async function initHttpServer(
   options = {
     allowCors: false,
     zcl: env.builtinSilabsZclMetafile(),
-    template: env.builtinTemplateMetafile()
+    template: env.builtinTemplateMetafile(),
+    watchdog: null
   }
 ) {
+  const serverWatchdog = options.watchdog
   return new Promise((resolve, reject) => {
     const app = express()
 
@@ -174,7 +175,7 @@ async function initHttpServer(
 
     webSocket.initializeWebSocket(httpServer)
     webSocket.onWebSocket(dbEnum.wsCategory.tick, () => {
-      watchdog.reset()
+      serverWatchdog?.reset()
     })
     studio.initIdeIntegration(db, studioPort)
     dirtyFlag.startAsyncReporting(db)

--- a/src-electron/server/ipc-server.js
+++ b/src-electron/server/ipc-server.js
@@ -26,7 +26,6 @@ const env = require('../util/env')
 const path = require('path')
 const os = require('os')
 const util = require('../util/util.js')
-const watchdog = require('../main-process/watchdog')
 const httpServer = require('./http-server.js')
 const startup = require('../main-process/startup.js')
 const queryPackage = require('../db/query-package.js')
@@ -189,8 +188,8 @@ const handlers = [
 /**
  * Runs just before every time IPC request is processed.
  */
-function preHandler() {
-  watchdog.reset()
+function preHandler(serverWatchdog) {
+  serverWatchdog?.reset()
 }
 
 /**
@@ -199,7 +198,7 @@ function preHandler() {
  * @parem {*} isServer 'true' if this is a server, 'false' for client.
  * @param {*} options
  */
-async function initServer(db = null, httpPort = 0) {
+async function initServer(db = null, httpPort = 0, serverWatchdog = null) {
   return new Promise((resolve, reject) => {
     server.ipc.config.logger = log
     server.ipc.config.id = 'main'
@@ -214,7 +213,7 @@ async function initServer(db = null, httpPort = 0) {
       })
       server.ipc.server.on('connect', () => {
         env.logIpc('New connection.')
-        watchdog.reset()
+        serverWatchdog?.reset()
       })
       server.ipc.server.on('destroy', () => {
         env.logIpc('IPC server destroyed.')
@@ -223,7 +222,7 @@ async function initServer(db = null, httpPort = 0) {
       // Register individual type handlers
       handlers.forEach((handlerRecord) => {
         server.ipc.server.on(handlerRecord.eventType, (data, socket) => {
-          preHandler()
+          preHandler(serverWatchdog)
           handlerRecord.handler(
             {
               db: db,


### PR DESCRIPTION
- Replace the global watchdog singleton with createWatchdog() so the server inactivity timer and per-render template guards do not share one timer.
- Inject the server watchdog from startup into the HTTP and IPC servers;
- reset it on ticks, IPC activity, and connections as before.
- Template rendering now uses an idle watchdog (no helper/deferred progress) plus a longer hard cap, instead of a single fixed render race.
- Github: ZAP #1567