### PR TITLE
Add headless .zap validation, UI panel, and CLI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This software is licensed under [Apache 2.0 license](LICENSE.txt).
 
 ## Detailed Developer Documentation
 
+- [Validating `.zap` files](docs/validating-zap-files.md)
 - [ZAP Template Helpers](docs/helpers.md)
 - [ZAP External Template Helpers](docs/external-helpers.md)
 - [ZAP file Extensions](docs/zap-file-extensions.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -323,6 +323,10 @@ and generate warnings for non-conformance.</p>
 <dt><a href="#module_Validation API_ Parse conformance data from XML">Validation API: Parse conformance data from XML</a></dt>
 <dd><p>This module provides utilities for parsing conformance data from XML into expressions.</p>
 </dd>
+<dt><a href="#module_Validation API_ validate all session elements">Validation API: validate all session elements</a></dt>
+<dd><p>Runs existing ZCL / data-model validators across an entire session (all endpoints,
+endpoint types, included attributes, and per-cluster conformance).</p>
+</dd>
 <dt><a href="#module_Validation API_ Validation APIs">Validation API: Validation APIs</a></dt>
 <dd><p>This module provides the APIs for validating inputs to the database, and returning flags indicating if
 things were successful or not.</p>
@@ -15750,6 +15754,7 @@ This module provides the API to access zcl specific information.
     * [~httpPostDuplicateEndpointType(db)](#module_REST API_ user data..httpPostDuplicateEndpointType) ⇒
     * [~httpPatchUpdateBitOfFeatureMapAttribute(db)](#module_REST API_ user data..httpPatchUpdateBitOfFeatureMapAttribute) ⇒
     * [~httpGetConformDataExists(db)](#module_REST API_ user data..httpGetConformDataExists) ⇒
+    * [~httpGetValidateAll(db)](#module_REST API_ user data..httpGetValidateAll) ⇒
     * [~httpPostRequiredElementWarning(db)](#module_REST API_ user data..httpPostRequiredElementWarning) ⇒
     * [~duplicateEndpointTypeClusters(db, oldEndpointTypeId, newEndpointTypeId)](#module_REST API_ user data..duplicateEndpointTypeClusters)
 
@@ -16206,6 +16211,18 @@ Check if conformance data exists in the database
 
 **Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
 **Returns**: boolean value of data exist or not  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+
+<a name="module_REST API_ user data..httpGetValidateAll"></a>
+
+### REST API: user data~httpGetValidateAll(db) ⇒
+HTTP GET: validate entire session (all endpoints, attribute defaults, conformance).
+
+**Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
+**Returns**: callback for the express uri registration  
 
 | Param | Type |
 | --- | --- |
@@ -17102,6 +17119,7 @@ This module provides the REST API to the user specific data.
     * [~httpPostDuplicateEndpointType(db)](#module_REST API_ user data..httpPostDuplicateEndpointType) ⇒
     * [~httpPatchUpdateBitOfFeatureMapAttribute(db)](#module_REST API_ user data..httpPatchUpdateBitOfFeatureMapAttribute) ⇒
     * [~httpGetConformDataExists(db)](#module_REST API_ user data..httpGetConformDataExists) ⇒
+    * [~httpGetValidateAll(db)](#module_REST API_ user data..httpGetValidateAll) ⇒
     * [~httpPostRequiredElementWarning(db)](#module_REST API_ user data..httpPostRequiredElementWarning) ⇒
     * [~duplicateEndpointTypeClusters(db, oldEndpointTypeId, newEndpointTypeId)](#module_REST API_ user data..duplicateEndpointTypeClusters)
 
@@ -17558,6 +17576,18 @@ Check if conformance data exists in the database
 
 **Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
 **Returns**: boolean value of data exist or not  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+
+<a name="module_REST API_ user data..httpGetValidateAll"></a>
+
+### REST API: user data~httpGetValidateAll(db) ⇒
+HTTP GET: validate entire session (all endpoints, attribute defaults, conformance).
+
+**Kind**: inner method of [<code>REST API: user data</code>](#module_REST API_ user data)  
+**Returns**: callback for the express uri registration  
 
 | Param | Type |
 | --- | --- |
@@ -18453,6 +18483,7 @@ Arguments for ZAP
         * [.processCommandLineArguments(argv)](#module_JS API_ Arguments for ZAP.processCommandLineArguments) ⇒
     * _inner_
         * [~environmentVariablesDescription()](#module_JS API_ Arguments for ZAP..environmentVariablesDescription) ⇒
+        * [~expandCommaSeparatedZapPaths(tokens)](#module_JS API_ Arguments for ZAP..expandCommaSeparatedZapPaths) ⇒ <code>Array.&lt;string&gt;</code>
 
 <a name="module_JS API_ Arguments for ZAP.processCommandLineArguments"></a>
 
@@ -18474,6 +18505,19 @@ Get environment variable details.
 
 **Kind**: inner method of [<code>JS API: Arguments for ZAP</code>](#module_JS API_ Arguments for ZAP)  
 **Returns**: environment varibale details  
+<a name="module_JS API_ Arguments for ZAP..expandCommaSeparatedZapPaths"></a>
+
+### JS API: Arguments for ZAP~expandCommaSeparatedZapPaths(tokens) ⇒ <code>Array.&lt;string&gt;</code>
+Split comma-separated path lists (for `validate` only). Shells already pass
+space-separated paths as separate argv tokens; this lets you use a single
+`-i a.zap,b.zap` as well.
+
+**Kind**: inner method of [<code>JS API: Arguments for ZAP</code>](#module_JS API_ Arguments for ZAP)  
+
+| Param | Type |
+| --- | --- |
+| tokens | <code>Array.&lt;string&gt;</code> | 
+
 <a name="module_JS API_ async reporting"></a>
 
 ## JS API: async reporting
@@ -20613,14 +20657,17 @@ things were successful or not.
         * [~validateAttribute(db, endpointTypeId, attributeRef, clusterRef, zapSessionId)](#module_Validation API_ Validation APIs..validateAttribute) ⇒
         * [~validateEndpoint(db, endpointId)](#module_Validation API_ Validation APIs..validateEndpoint) ⇒
         * [~validateNoDuplicateEndpoints(db, endpointIdentifier, sessionRef)](#module_Validation API_ Validation APIs..validateNoDuplicateEndpoints) ⇒
+        * [~isMatterSession(db, sessionId)](#module_Validation API_ Validation APIs..isMatterSession) ⇒
         * [~validateXmlAttributeDefault(db, attribute, packageId)](#module_Validation API_ Validation APIs..validateXmlAttributeDefault) ⇒ <code>Promise.&lt;void&gt;</code>
         * [~validateSpecificAttribute(endpointAttribute, attribute, db, zapSessionId)](#module_Validation API_ Validation APIs..validateSpecificAttribute) ⇒
         * [~validateSpecificEndpoint(endpoint)](#module_Validation API_ Validation APIs..validateSpecificEndpoint) ⇒
         * [~isValidNumberString(value)](#module_Validation API_ Validation APIs..isValidNumberString) ⇒
         * [~isValidHexString(value)](#module_Validation API_ Validation APIs..isValidHexString) ⇒
         * [~isValidDecimalString(value)](#module_Validation API_ Validation APIs..isValidDecimalString) ⇒
-        * [~isValidFloat(value)](#module_Validation API_ Validation APIs..isValidFloat) ⇒
+        * [~isValidFloat(value, typeSize)](#module_Validation API_ Validation APIs..isValidFloat) ⇒
         * [~extractFloatValue(value)](#module_Validation API_ Validation APIs..extractFloatValue) ⇒
+        * [~decodeFloat16(bits)](#module_Validation API_ Validation APIs..decodeFloat16) ⇒
+        * [~getFloatFromAttribute(attribute, typeSize)](#module_Validation API_ Validation APIs..getFloatFromAttribute) ⇒
         * [~extractIntegerValue(value)](#module_Validation API_ Validation APIs..extractIntegerValue) ⇒
         * [~extractBigIntegerValue(value)](#module_Validation API_ Validation APIs..extractBigIntegerValue) ⇒
         * [~isBigInteger(bits)](#module_Validation API_ Validation APIs..isBigInteger) ⇒
@@ -20631,8 +20678,10 @@ things were successful or not.
         * [~getIntegerAttributeSize(db, zapSessionId, attribType, clusterRef)](#module_Validation API_ Validation APIs..getIntegerAttributeSize) ⇒ <code>\*</code>
         * [~checkAttributeBoundsInteger(attribute, endpointAttribute, db, zapSessionId)](#module_Validation API_ Validation APIs..checkAttributeBoundsInteger) ⇒
         * [~checkBoundsInteger(defaultValue, min, max)](#module_Validation API_ Validation APIs..checkBoundsInteger) ⇒
-        * [~checkAttributeBoundsFloat(attribute, endpointAttribute)](#module_Validation API_ Validation APIs..checkAttributeBoundsFloat) ⇒
-        * [~getBoundsFloat(attribute)](#module_Validation API_ Validation APIs..getBoundsFloat) ⇒
+        * [~getFloatAttributeSize(db, zapSessionId, attribType, clusterRef)](#module_Validation API_ Validation APIs..getFloatAttributeSize) ⇒ <code>\*</code>
+        * [~getFloatTypeRange(typeSize, isMin)](#module_Validation API_ Validation APIs..getFloatTypeRange) ⇒
+        * [~checkAttributeBoundsFloat(attribute, endpointAttribute, db, zapSessionId)](#module_Validation API_ Validation APIs..checkAttributeBoundsFloat) ⇒
+        * [~getBoundsFloat(attribute, typeSize)](#module_Validation API_ Validation APIs..getBoundsFloat) ⇒
         * [~checkBoundsFloat(defaultValue, min, max)](#module_Validation API_ Validation APIs..checkBoundsFloat) ⇒
 
 <a name="module_Validation API_ Validation APIs.initAsyncValidation"></a>
@@ -20698,7 +20747,12 @@ Get issues in an endpoint.
 <a name="module_Validation API_ Validation APIs..validateNoDuplicateEndpoints"></a>
 
 ### Validation API: Validation APIs~validateNoDuplicateEndpoints(db, endpointIdentifier, sessionRef) ⇒
-Check if there are no duplicate endpoints.
+Returns true when this endpoint identifier is unique within the session.
+
+The schema enforces UNIQUE(ENDPOINT_TYPE_REF, ENDPOINT_IDENTIFIER), but for the
+user-visible "duplicate endpoint" check we want session-wide uniqueness: two
+endpoints with the same identifier are wrong on a real device regardless of
+which endpoint type they belong to.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
 **Returns**: boolean  
@@ -20708,6 +20762,21 @@ Check if there are no duplicate endpoints.
 | db | <code>\*</code> | 
 | endpointIdentifier | <code>\*</code> | 
 | sessionRef | <code>\*</code> | 
+
+<a name="module_Validation API_ Validation APIs..isMatterSession"></a>
+
+### Validation API: Validation APIs~isMatterSession(db, sessionId) ⇒
+True when the session uses Matter ZCL packages (CATEGORY = 'matter').
+Used to relax Zigbee-only rules (e.g. endpoint 0 is reserved in Zigbee but is
+the root node in Matter).
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: Promise<boolean>  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| sessionId | <code>\*</code> | 
 
 <a name="module_Validation API_ Validation APIs..validateXmlAttributeDefault"></a>
 
@@ -20789,27 +20858,73 @@ Check if value is a valid decimal string.
 
 <a name="module_Validation API_ Validation APIs..isValidFloat"></a>
 
-### Validation API: Validation APIs~isValidFloat(value) ⇒
+### Validation API: Validation APIs~isValidFloat(value, typeSize) ⇒
 Check if value is a valid float value.
+
+Decimal literals (e.g. "1.5", "-0.25", "1e40") are always accepted.
+When a typeSize is supplied, hex IEEE 754 bit-pattern literals are
+also accepted as long as they fit within the type's nibble width
+(e.g. "0x3F800000" for `float_single` decodes to 1.0). This mirrors
+the ZCL/Matter XML convention used for float min/max bounds.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
 **Returns**: boolean  
 
-| Param | Type |
-| --- | --- |
-| value | <code>\*</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| value | <code>\*</code> |  |
+| typeSize | <code>\*</code> | Optional bit width of the float type (16, 32, or 64). When omitted, hex strings are rejected (legacy decimal-only behavior). |
 
 <a name="module_Validation API_ Validation APIs..extractFloatValue"></a>
 
 ### Validation API: Validation APIs~extractFloatValue(value) ⇒
 Get float value from the given value.
+Hex strings (e.g. "0x42C80000") cannot be reliably decoded without knowing
+the bit-width, so they are returned as NaN and treated as unconstrained.
+Use [getFloatFromAttribute](getFloatFromAttribute) when the float type's bit width is known
+and IEEE 754 hex bit patterns should be decoded.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
-**Returns**: float value  
+**Returns**: float value, or NaN if value is null/undefined/hex  
 
 | Param | Type |
 | --- | --- |
 | value | <code>\*</code> | 
+
+<a name="module_Validation API_ Validation APIs..decodeFloat16"></a>
+
+### Validation API: Validation APIs~decodeFloat16(bits) ⇒
+Decodes a 16-bit IEEE 754 half-precision bit pattern into a Number.
+Implemented manually because Float16Array is not yet available across
+all supported Node versions. Counterpart of `convertFloatToBigEndian`
+for sizes the 32/64-bit DataView path cannot handle.
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: Number  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bits | <code>\*</code> | Unsigned 16-bit integer (0..0xFFFF) |
+
+<a name="module_Validation API_ Validation APIs..getFloatFromAttribute"></a>
+
+### Validation API: Validation APIs~getFloatFromAttribute(attribute, typeSize) ⇒
+Converts a float attribute string into a Number, honoring the IEEE 754
+bit-pattern hex convention used by ZCL/Matter XML for float min/max
+bounds and defaults (e.g. "0x3F800000" => 1.0 for `float_single`).
+
+Mirrors `getIntegerFromAttribute` on the integer side: the type's bit
+width drives how the string is decoded. Decimal literals fall through
+to `parseFloat`. Hex literals wider than the type can encode (more
+than `typeSize / 4` nibbles) return NaN so the caller can flag them.
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: Number, or NaN if the value cannot be decoded for typeSize  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| attribute | <code>\*</code> | string representation of a float |
+| typeSize | <code>\*</code> | bit width of the float type (16, 32, or 64) |
 
 <a name="module_Validation API_ Validation APIs..extractIntegerValue"></a>
 
@@ -20951,10 +21066,49 @@ Check if an integer value is within the bounds.
 | min | <code>\*</code> | 
 | max | <code>\*</code> | 
 
+<a name="module_Validation API_ Validation APIs..getFloatAttributeSize"></a>
+
+### Validation API: Validation APIs~getFloatAttributeSize(db, zapSessionId, attribType, clusterRef) ⇒ <code>\*</code>
+Returns information about a float type by querying the data type
+metadata stored in the database. Mirrors getIntegerAttributeSize so
+the size lookup uses the same source of truth for both integer and
+float types and works for any float type defined in the loaded ZCL
+(e.g. silabs `float_semi`/`float_single`/`float_double` and Matter
+`single`/`double`).
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: <code>\*</code> - { size: bit representation }  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| zapSessionId | <code>\*</code> | 
+| attribType | <code>\*</code> | 
+| clusterRef | <code>\*</code> | 
+
+<a name="module_Validation API_ Validation APIs..getFloatTypeRange"></a>
+
+### Validation API: Validation APIs~getFloatTypeRange(typeSize, isMin) ⇒
+Gets the representable range of a float type. Mirrors getTypeRange for
+integer types and is used as the fallback when an attribute does not
+explicitly declare min/max.
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: float  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| typeSize | <code>\*</code> | bit width of the float type |
+| isMin | <code>\*</code> | true to return the minimum, false for the maximum |
+
 <a name="module_Validation API_ Validation APIs..checkAttributeBoundsFloat"></a>
 
-### Validation API: Validation APIs~checkAttributeBoundsFloat(attribute, endpointAttribute) ⇒
-Check if float attribute's value is within the bounds.
+### Validation API: Validation APIs~checkAttributeBoundsFloat(attribute, endpointAttribute, db, zapSessionId) ⇒
+Checks if the incoming float is within its attribute's bounds while
+honoring the representable range of the float type. Mirrors
+checkAttributeBoundsInteger: it first resolves the type metadata
+from the database, bails out if the type is unknown, and then
+compares against the (possibly type-defaulted) min/max bounds.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
 **Returns**: boolean  
@@ -20963,18 +21117,23 @@ Check if float attribute's value is within the bounds.
 | --- | --- |
 | attribute | <code>\*</code> | 
 | endpointAttribute | <code>\*</code> | 
+| db | <code>\*</code> | 
+| zapSessionId | <code>\*</code> | 
 
 <a name="module_Validation API_ Validation APIs..getBoundsFloat"></a>
 
-### Validation API: Validation APIs~getBoundsFloat(attribute) ⇒
-Get the bounds on a float attribute's value.
+### Validation API: Validation APIs~getBoundsFloat(attribute, typeSize) ⇒
+Get the bounds on a float attribute's value. When the attribute does
+not declare an explicit min/max, the type's representable range is
+used as the fallback (mirroring getBoundsInteger).
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
 **Returns**: object  
 
-| Param | Type |
-| --- | --- |
-| attribute | <code>\*</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| attribute | <code>\*</code> |  |
+| typeSize | <code>\*</code> | bit width of the float type. When omitted the 64-bit IEEE 754 range is assumed, which keeps legacy single-argument callers (e.g. XML pre-validation, which has no session) working. |
 
 <a name="module_Validation API_ Validation APIs..checkBoundsFloat"></a>
 
@@ -21006,7 +21165,7 @@ and generate warnings for non-conformance.
         * [~processElements(elementType)](#module_Validation API_ check element conformance..getOutdatedElementWarning..processElements)
     * [~filterRequiredElements(elements, elementMap, featureMap)](#module_Validation API_ check element conformance..filterRequiredElements) ⇒
     * [~getStateOfOperands(expression, elementMap, featureMap)](#module_Validation API_ check element conformance..getStateOfOperands) ⇒
-    * [~setConformanceWarnings(db, endpointId, endpointTypeId, endpointClusterId, deviceTypeRefs, cluster, sessionId)](#module_Validation API_ check element conformance..setConformanceWarnings) ⇒
+    * [~setConformanceWarnings(db, endpointId, endpointTypeId, endpointClusterId, deviceTypeRefs, cluster, sessionId, options)](#module_Validation API_ check element conformance..setConformanceWarnings) ⇒
     * [~getEndpointTypeClusterIdFromFeatureData(db, featureData, endpointTypeId, clusterRef)](#module_Validation API_ check element conformance..getEndpointTypeClusterIdFromFeatureData) ⇒
 
 <a name="module_Validation API_ check element conformance..generateWarningMessage"></a>
@@ -21135,7 +21294,7 @@ empty string if no operands conform to any element
 
 <a name="module_Validation API_ check element conformance..setConformanceWarnings"></a>
 
-### Validation API: check element conformance~setConformanceWarnings(db, endpointId, endpointTypeId, endpointClusterId, deviceTypeRefs, cluster, sessionId) ⇒
+### Validation API: check element conformance~setConformanceWarnings(db, endpointId, endpointTypeId, endpointClusterId, deviceTypeRefs, cluster, sessionId, options) ⇒
 Adds warnings to the session notification table during ZAP file imports
 for features, attributes, commands, and events that do not correctly conform
 within a cluster.
@@ -21143,15 +21302,16 @@ within a cluster.
 **Kind**: inner method of [<code>Validation API: check element conformance</code>](#module_Validation API_ check element conformance)  
 **Returns**: list of warning messages if any, otherwise false  
 
-| Param | Type |
-| --- | --- |
-| db | <code>\*</code> | 
-| endpointId | <code>\*</code> | 
-| endpointTypeId | <code>\*</code> | 
-| endpointClusterId | <code>\*</code> | 
-| deviceTypeRefs | <code>\*</code> | 
-| cluster | <code>\*</code> | 
-| sessionId | <code>\*</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| db | <code>\*</code> |  |
+| endpointId | <code>\*</code> |  |
+| endpointTypeId | <code>\*</code> |  |
+| endpointClusterId | <code>\*</code> |  |
+| deviceTypeRefs | <code>\*</code> |  |
+| cluster | <code>\*</code> |  |
+| sessionId | <code>\*</code> |  |
+| options | <code>\*</code> | Optional. Set `{ persistNotifications: false }` to skip writing SESSION_NOTICE (e.g. bulk validate). |
 
 <a name="module_Validation API_ check element conformance..getEndpointTypeClusterIdFromFeatureData"></a>
 
@@ -21441,6 +21601,91 @@ Return null when neither source specifies maturity.
 | --- | --- | --- |
 | element | <code>\*</code> | XML element from xml2js |
 
+<a name="module_Validation API_ validate all session elements"></a>
+
+## Validation API: validate all session elements
+Runs existing ZCL / data-model validators across an entire session (all endpoints,
+endpoint types, included attributes, and per-cluster conformance).
+
+
+* [Validation API: validate all session elements](#module_Validation API_ validate all session elements)
+    * [~validateAll(db, sessionId, options)](#module_Validation API_ validate all session elements..validateAll) ⇒ <code>Promise.&lt;object&gt;</code>
+        * [~endpointIdentifiersByEndpointTypeId](#module_Validation API_ validate all session elements..validateAll..endpointIdentifiersByEndpointTypeId) : <code>Map.&lt;number, Array.&lt;number&gt;&gt;</code>
+        * [~conformanceByCluster](#module_Validation API_ validate all session elements..validateAll..conformanceByCluster)
+        * [~endpointTypeMandatoryCache](#module_Validation API_ validate all session elements..validateAll..endpointTypeMandatoryCache)
+    * [~collectMandatoryClusterElements(db, endpointTypeId, packageIds)](#module_Validation API_ validate all session elements..collectMandatoryClusterElements) ⇒ <code>Promise.&lt;{attributes: Array.&lt;object&gt;, commands: Array.&lt;object&gt;}&gt;</code>
+    * [~collectDeviceTypeRequirements(db, endpointTypeId)](#module_Validation API_ validate all session elements..collectDeviceTypeRequirements) ⇒ <code>Promise.&lt;{clusters: Array.&lt;object&gt;, attributes: Array.&lt;object&gt;, commands: Array.&lt;object&gt;}&gt;</code>
+
+<a name="module_Validation API_ validate all session elements..validateAll"></a>
+
+### Validation API: validate all session elements~validateAll(db, sessionId, options) ⇒ <code>Promise.&lt;object&gt;</code>
+**Kind**: inner method of [<code>Validation API: validate all session elements</code>](#module_Validation API_ validate all session elements)  
+**Returns**: <code>Promise.&lt;object&gt;</code> - Aggregated validation report  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| db | <code>\*</code> |  |  |
+| sessionId | <code>\*</code> |  |  |
+| options | <code>\*</code> |  |  |
+| [options.conformance] | <code>boolean</code> | <code>true</code> | Run conformance checks (feature map / mandatory elements). |
+| [options.persistConformanceNotifications] | <code>boolean</code> | <code>false</code> | If true, conformance issues are also written to SESSION_NOTICE. |
+
+
+* [~validateAll(db, sessionId, options)](#module_Validation API_ validate all session elements..validateAll) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [~endpointIdentifiersByEndpointTypeId](#module_Validation API_ validate all session elements..validateAll..endpointIdentifiersByEndpointTypeId) : <code>Map.&lt;number, Array.&lt;number&gt;&gt;</code>
+    * [~conformanceByCluster](#module_Validation API_ validate all session elements..validateAll..conformanceByCluster)
+    * [~endpointTypeMandatoryCache](#module_Validation API_ validate all session elements..validateAll..endpointTypeMandatoryCache)
+
+<a name="module_Validation API_ validate all session elements..validateAll..endpointIdentifiersByEndpointTypeId"></a>
+
+#### validateAll~endpointIdentifiersByEndpointTypeId : <code>Map.&lt;number, Array.&lt;number&gt;&gt;</code>
+endpoint type id -> sorted endpoint identifier numbers
+
+**Kind**: inner constant of [<code>validateAll</code>](#module_Validation API_ validate all session elements..validateAll)  
+<a name="module_Validation API_ validate all session elements..validateAll..conformanceByCluster"></a>
+
+#### validateAll~conformanceByCluster
+Per-endpoint warning bucket: key = `${endpointDbId}:${clusterRef}`.
+
+**Kind**: inner constant of [<code>validateAll</code>](#module_Validation API_ validate all session elements..validateAll)  
+<a name="module_Validation API_ validate all session elements..validateAll..endpointTypeMandatoryCache"></a>
+
+#### validateAll~endpointTypeMandatoryCache
+endpoint type id -> mandatory attribute / command lists across enabled clusters
+
+**Kind**: inner constant of [<code>validateAll</code>](#module_Validation API_ validate all session elements..validateAll)  
+<a name="module_Validation API_ validate all session elements..collectMandatoryClusterElements"></a>
+
+### Validation API: validate all session elements~collectMandatoryClusterElements(db, endpointTypeId, packageIds) ⇒ <code>Promise.&lt;{attributes: Array.&lt;object&gt;, commands: Array.&lt;object&gt;}&gt;</code>
+Collect mandatory (non-optional, non-global) attributes and mandatory commands
+across every enabled cluster on an endpoint type.
+
+Mirrors getMandatoryClusterAttributes / getMandatoryClusterCommands in
+import-json.js, returning a flat list with cluster context attached.
+
+**Kind**: inner method of [<code>Validation API: validate all session elements</code>](#module_Validation API_ validate all session elements)  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| endpointTypeId | <code>\*</code> | 
+| packageIds | <code>Array.&lt;number&gt;</code> | 
+
+<a name="module_Validation API_ validate all session elements..collectDeviceTypeRequirements"></a>
+
+### Validation API: validate all session elements~collectDeviceTypeRequirements(db, endpointTypeId) ⇒ <code>Promise.&lt;{clusters: Array.&lt;object&gt;, attributes: Array.&lt;object&gt;, commands: Array.&lt;object&gt;}&gt;</code>
+Collect device-type required clusters / attributes / commands for an endpoint type.
+
+Mirrors deviceTypeClustersAttributesAndCommands in import-json.js and joins in
+names + side flags so the validator can report compliance gaps without re-querying.
+
+**Kind**: inner method of [<code>Validation API: validate all session elements</code>](#module_Validation API_ validate all session elements)  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| endpointTypeId | <code>\*</code> | 
+
 <a name="module_Validation API_ Validation APIs"></a>
 
 ## Validation API: Validation APIs
@@ -21457,14 +21702,17 @@ things were successful or not.
         * [~validateAttribute(db, endpointTypeId, attributeRef, clusterRef, zapSessionId)](#module_Validation API_ Validation APIs..validateAttribute) ⇒
         * [~validateEndpoint(db, endpointId)](#module_Validation API_ Validation APIs..validateEndpoint) ⇒
         * [~validateNoDuplicateEndpoints(db, endpointIdentifier, sessionRef)](#module_Validation API_ Validation APIs..validateNoDuplicateEndpoints) ⇒
+        * [~isMatterSession(db, sessionId)](#module_Validation API_ Validation APIs..isMatterSession) ⇒
         * [~validateXmlAttributeDefault(db, attribute, packageId)](#module_Validation API_ Validation APIs..validateXmlAttributeDefault) ⇒ <code>Promise.&lt;void&gt;</code>
         * [~validateSpecificAttribute(endpointAttribute, attribute, db, zapSessionId)](#module_Validation API_ Validation APIs..validateSpecificAttribute) ⇒
         * [~validateSpecificEndpoint(endpoint)](#module_Validation API_ Validation APIs..validateSpecificEndpoint) ⇒
         * [~isValidNumberString(value)](#module_Validation API_ Validation APIs..isValidNumberString) ⇒
         * [~isValidHexString(value)](#module_Validation API_ Validation APIs..isValidHexString) ⇒
         * [~isValidDecimalString(value)](#module_Validation API_ Validation APIs..isValidDecimalString) ⇒
-        * [~isValidFloat(value)](#module_Validation API_ Validation APIs..isValidFloat) ⇒
+        * [~isValidFloat(value, typeSize)](#module_Validation API_ Validation APIs..isValidFloat) ⇒
         * [~extractFloatValue(value)](#module_Validation API_ Validation APIs..extractFloatValue) ⇒
+        * [~decodeFloat16(bits)](#module_Validation API_ Validation APIs..decodeFloat16) ⇒
+        * [~getFloatFromAttribute(attribute, typeSize)](#module_Validation API_ Validation APIs..getFloatFromAttribute) ⇒
         * [~extractIntegerValue(value)](#module_Validation API_ Validation APIs..extractIntegerValue) ⇒
         * [~extractBigIntegerValue(value)](#module_Validation API_ Validation APIs..extractBigIntegerValue) ⇒
         * [~isBigInteger(bits)](#module_Validation API_ Validation APIs..isBigInteger) ⇒
@@ -21475,8 +21723,10 @@ things were successful or not.
         * [~getIntegerAttributeSize(db, zapSessionId, attribType, clusterRef)](#module_Validation API_ Validation APIs..getIntegerAttributeSize) ⇒ <code>\*</code>
         * [~checkAttributeBoundsInteger(attribute, endpointAttribute, db, zapSessionId)](#module_Validation API_ Validation APIs..checkAttributeBoundsInteger) ⇒
         * [~checkBoundsInteger(defaultValue, min, max)](#module_Validation API_ Validation APIs..checkBoundsInteger) ⇒
-        * [~checkAttributeBoundsFloat(attribute, endpointAttribute)](#module_Validation API_ Validation APIs..checkAttributeBoundsFloat) ⇒
-        * [~getBoundsFloat(attribute)](#module_Validation API_ Validation APIs..getBoundsFloat) ⇒
+        * [~getFloatAttributeSize(db, zapSessionId, attribType, clusterRef)](#module_Validation API_ Validation APIs..getFloatAttributeSize) ⇒ <code>\*</code>
+        * [~getFloatTypeRange(typeSize, isMin)](#module_Validation API_ Validation APIs..getFloatTypeRange) ⇒
+        * [~checkAttributeBoundsFloat(attribute, endpointAttribute, db, zapSessionId)](#module_Validation API_ Validation APIs..checkAttributeBoundsFloat) ⇒
+        * [~getBoundsFloat(attribute, typeSize)](#module_Validation API_ Validation APIs..getBoundsFloat) ⇒
         * [~checkBoundsFloat(defaultValue, min, max)](#module_Validation API_ Validation APIs..checkBoundsFloat) ⇒
 
 <a name="module_Validation API_ Validation APIs.initAsyncValidation"></a>
@@ -21542,7 +21792,12 @@ Get issues in an endpoint.
 <a name="module_Validation API_ Validation APIs..validateNoDuplicateEndpoints"></a>
 
 ### Validation API: Validation APIs~validateNoDuplicateEndpoints(db, endpointIdentifier, sessionRef) ⇒
-Check if there are no duplicate endpoints.
+Returns true when this endpoint identifier is unique within the session.
+
+The schema enforces UNIQUE(ENDPOINT_TYPE_REF, ENDPOINT_IDENTIFIER), but for the
+user-visible "duplicate endpoint" check we want session-wide uniqueness: two
+endpoints with the same identifier are wrong on a real device regardless of
+which endpoint type they belong to.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
 **Returns**: boolean  
@@ -21552,6 +21807,21 @@ Check if there are no duplicate endpoints.
 | db | <code>\*</code> | 
 | endpointIdentifier | <code>\*</code> | 
 | sessionRef | <code>\*</code> | 
+
+<a name="module_Validation API_ Validation APIs..isMatterSession"></a>
+
+### Validation API: Validation APIs~isMatterSession(db, sessionId) ⇒
+True when the session uses Matter ZCL packages (CATEGORY = 'matter').
+Used to relax Zigbee-only rules (e.g. endpoint 0 is reserved in Zigbee but is
+the root node in Matter).
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: Promise<boolean>  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| sessionId | <code>\*</code> | 
 
 <a name="module_Validation API_ Validation APIs..validateXmlAttributeDefault"></a>
 
@@ -21633,27 +21903,73 @@ Check if value is a valid decimal string.
 
 <a name="module_Validation API_ Validation APIs..isValidFloat"></a>
 
-### Validation API: Validation APIs~isValidFloat(value) ⇒
+### Validation API: Validation APIs~isValidFloat(value, typeSize) ⇒
 Check if value is a valid float value.
+
+Decimal literals (e.g. "1.5", "-0.25", "1e40") are always accepted.
+When a typeSize is supplied, hex IEEE 754 bit-pattern literals are
+also accepted as long as they fit within the type's nibble width
+(e.g. "0x3F800000" for `float_single` decodes to 1.0). This mirrors
+the ZCL/Matter XML convention used for float min/max bounds.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
 **Returns**: boolean  
 
-| Param | Type |
-| --- | --- |
-| value | <code>\*</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| value | <code>\*</code> |  |
+| typeSize | <code>\*</code> | Optional bit width of the float type (16, 32, or 64). When omitted, hex strings are rejected (legacy decimal-only behavior). |
 
 <a name="module_Validation API_ Validation APIs..extractFloatValue"></a>
 
 ### Validation API: Validation APIs~extractFloatValue(value) ⇒
 Get float value from the given value.
+Hex strings (e.g. "0x42C80000") cannot be reliably decoded without knowing
+the bit-width, so they are returned as NaN and treated as unconstrained.
+Use [getFloatFromAttribute](getFloatFromAttribute) when the float type's bit width is known
+and IEEE 754 hex bit patterns should be decoded.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
-**Returns**: float value  
+**Returns**: float value, or NaN if value is null/undefined/hex  
 
 | Param | Type |
 | --- | --- |
 | value | <code>\*</code> | 
+
+<a name="module_Validation API_ Validation APIs..decodeFloat16"></a>
+
+### Validation API: Validation APIs~decodeFloat16(bits) ⇒
+Decodes a 16-bit IEEE 754 half-precision bit pattern into a Number.
+Implemented manually because Float16Array is not yet available across
+all supported Node versions. Counterpart of `convertFloatToBigEndian`
+for sizes the 32/64-bit DataView path cannot handle.
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: Number  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bits | <code>\*</code> | Unsigned 16-bit integer (0..0xFFFF) |
+
+<a name="module_Validation API_ Validation APIs..getFloatFromAttribute"></a>
+
+### Validation API: Validation APIs~getFloatFromAttribute(attribute, typeSize) ⇒
+Converts a float attribute string into a Number, honoring the IEEE 754
+bit-pattern hex convention used by ZCL/Matter XML for float min/max
+bounds and defaults (e.g. "0x3F800000" => 1.0 for `float_single`).
+
+Mirrors `getIntegerFromAttribute` on the integer side: the type's bit
+width drives how the string is decoded. Decimal literals fall through
+to `parseFloat`. Hex literals wider than the type can encode (more
+than `typeSize / 4` nibbles) return NaN so the caller can flag them.
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: Number, or NaN if the value cannot be decoded for typeSize  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| attribute | <code>\*</code> | string representation of a float |
+| typeSize | <code>\*</code> | bit width of the float type (16, 32, or 64) |
 
 <a name="module_Validation API_ Validation APIs..extractIntegerValue"></a>
 
@@ -21795,10 +22111,49 @@ Check if an integer value is within the bounds.
 | min | <code>\*</code> | 
 | max | <code>\*</code> | 
 
+<a name="module_Validation API_ Validation APIs..getFloatAttributeSize"></a>
+
+### Validation API: Validation APIs~getFloatAttributeSize(db, zapSessionId, attribType, clusterRef) ⇒ <code>\*</code>
+Returns information about a float type by querying the data type
+metadata stored in the database. Mirrors getIntegerAttributeSize so
+the size lookup uses the same source of truth for both integer and
+float types and works for any float type defined in the loaded ZCL
+(e.g. silabs `float_semi`/`float_single`/`float_double` and Matter
+`single`/`double`).
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: <code>\*</code> - { size: bit representation }  
+
+| Param | Type |
+| --- | --- |
+| db | <code>\*</code> | 
+| zapSessionId | <code>\*</code> | 
+| attribType | <code>\*</code> | 
+| clusterRef | <code>\*</code> | 
+
+<a name="module_Validation API_ Validation APIs..getFloatTypeRange"></a>
+
+### Validation API: Validation APIs~getFloatTypeRange(typeSize, isMin) ⇒
+Gets the representable range of a float type. Mirrors getTypeRange for
+integer types and is used as the fallback when an attribute does not
+explicitly declare min/max.
+
+**Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
+**Returns**: float  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| typeSize | <code>\*</code> | bit width of the float type |
+| isMin | <code>\*</code> | true to return the minimum, false for the maximum |
+
 <a name="module_Validation API_ Validation APIs..checkAttributeBoundsFloat"></a>
 
-### Validation API: Validation APIs~checkAttributeBoundsFloat(attribute, endpointAttribute) ⇒
-Check if float attribute's value is within the bounds.
+### Validation API: Validation APIs~checkAttributeBoundsFloat(attribute, endpointAttribute, db, zapSessionId) ⇒
+Checks if the incoming float is within its attribute's bounds while
+honoring the representable range of the float type. Mirrors
+checkAttributeBoundsInteger: it first resolves the type metadata
+from the database, bails out if the type is unknown, and then
+compares against the (possibly type-defaulted) min/max bounds.
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
 **Returns**: boolean  
@@ -21807,18 +22162,23 @@ Check if float attribute's value is within the bounds.
 | --- | --- |
 | attribute | <code>\*</code> | 
 | endpointAttribute | <code>\*</code> | 
+| db | <code>\*</code> | 
+| zapSessionId | <code>\*</code> | 
 
 <a name="module_Validation API_ Validation APIs..getBoundsFloat"></a>
 
-### Validation API: Validation APIs~getBoundsFloat(attribute) ⇒
-Get the bounds on a float attribute's value.
+### Validation API: Validation APIs~getBoundsFloat(attribute, typeSize) ⇒
+Get the bounds on a float attribute's value. When the attribute does
+not declare an explicit min/max, the type's representable range is
+used as the fallback (mirroring getBoundsInteger).
 
 **Kind**: inner method of [<code>Validation API: Validation APIs</code>](#module_Validation API_ Validation APIs)  
 **Returns**: object  
 
-| Param | Type |
-| --- | --- |
-| attribute | <code>\*</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| attribute | <code>\*</code> |  |
+| typeSize | <code>\*</code> | bit width of the float type. When omitted the 64-bit IEEE 754 range is assumed, which keeps legacy single-argument callers (e.g. XML pre-validation, which has no session) working. |
 
 <a name="module_Validation API_ Validation APIs..checkBoundsFloat"></a>
 

--- a/docs/validating-zap-files.md
+++ b/docs/validating-zap-files.md
@@ -1,0 +1,80 @@
+# Validating `.zap` files
+
+You can validate ZCL and data-model configuration in one or more `.zap` files without opening the UI. The same checks are available from the ZAP UI toolbar (**Validate**), which opens results in the side panel.
+
+## CLI
+
+### Synopsis
+
+```bash
+zap validate -i path/to/config.zap [-z zcl.json] [-g gen-templates.json] [-o report.json]
+```
+
+You can pass **more than one** `.zap` file in three ways:
+
+- **Space-separated** after `validate` (no `-i` per file): `validate first.zap second.zap`
+- **Comma-separated** in one argument: `validate -i first.zap,second.zap` (also works for a single `-i` value)
+- **Repeat** `-i` / `--in` / `--zap` for each file: `validate -i first.zap -i second.zap`
+
+One merged JSON (or YAML) report is written; it has a `zapFiles` array and one `results[]` entry per file.
+
+```bash
+node src-script/zap-start.js validate first.zap second.zap -o report.json
+# or
+node src-script/zap-start.js validate -i first.zap,second.zap -o report.json
+# or
+node src-script/zap-start.js validate -i first.zap -i second.zap -o report.json
+```
+
+### Options
+
+| Flag                                  | Meaning                                                                                                                                                                                                                                                                            |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-i`, `--in`, `--zap`                 | Input `.zap` file. For `validate`, you may pass several paths: space-separated after the command, comma-separated in one `-i` value (e.g. `-i a.zap,b.zap`), or repeat this flag.                                                                                                  |
+| `-z`, `--zcl`, `--zclProperties`      | ZCL metafile(s), for example `./zcl-builtin/matter/zcl.json` or `./zcl-builtin/silabs/zcl.json`. Use these to validate against a specific ZCL definition instead of only the built-in default or whatever `zcl.properties` paths are embedded in the `.zap` file. May be repeated. |
+| `-g`, `--gen`, `--generationTemplate` | Generation template metafile(s), for example `./test/gen-template/matter/gen-test.json`. Overrides the built-in default and template references inside the `.zap` file for validation context. May be repeated.                                                                    |
+| `-o`, `--output`, `--validateOutput`  | Write the structured validation report to a file. Use a `.yaml` or `.yml` extension for YAML output. For the `validate` command, `-o` / `--output` is treated as the report path (not the generation output directory).                                                            |
+
+When **no** output path is given, the JSON report is printed to **stdout**. Progress and status messages go to **stderr** so you can redirect stdout to a file safely:
+
+```bash
+node src-script/zap-start.js validate -i path/to/config.zap > report.json
+```
+
+Exit code is **non-zero** when the report contains validation errors.
+
+### Running from this repository
+
+Use the start script so flags are passed straight through (avoiding `npm run` swallowing leading `-` flags):
+
+```bash
+node src-script/zap-start.js validate \
+  -i path/to/config.zap \
+  -z ./zcl-builtin/matter/zcl.json \
+  -g ./test/gen-template/matter/gen-test.json \
+  -o report.json
+```
+
+If you use `npm run zap-validate`, put **`--`** before script arguments so npm forwards `-i`, `-z`, `-g`, and `-o`:
+
+```bash
+npm run zap-validate -- -i path/to/config.zap -z path/to/zcl.json -g path/to/templates.json -o ./report.json
+```
+
+### Example: Matter / connectedhomeip
+
+When validating an app from [connectedhomeip](https://github.com/project-chip/connectedhomeip), point `-z` and `-g` at that tree’s ZCL and template metafiles so validation matches the SDK your app targets:
+
+```bash
+node src-script/zap-start.js validate \
+  -i examples/your-app/your-app.zap \
+  -z src/app/zap-templates/zcl/zcl.json \
+  -g src/app/zap-templates/app-templates.json \
+  -o ./report.json
+```
+
+Paths above are relative to the connectedhomeip repository root; adjust for your checkout.
+
+## Report format
+
+The report is JSON (or YAML if the output path ends in `.yaml` / `.yml`). It aggregates per-file results, summaries (error counts, endpoint/cluster/attribute counts), and detailed findings for endpoints, attributes, and conformance.

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "zapmatter": "node src-script/zap-start.js --logToStdout --zcl ./zcl-builtin/matter/zcl.json --gen ./test/gen-template/matter/gen-test.json",
     "zapmeta": "node src-script/zap-start.js --logToStdout --zcl ./test/resource/meta/zcl.json --gen ./test/resource/meta/gen-test.json --in ./test/resource/test-meta.zap",
     "zaphelp": "node src-script/zap-start.js --help",
+    "zap-validate": "node src-script/zap-start.js validate",
     "zap-dotdot": "node src-script/zap-start.js --logToStdout --zcl ./zcl-builtin/dotdot/library.xml -g ./test/gen-template/dotdot/dotdot-templates.json",
     "zap-devserver": "node src-script/zap-start.js server --stateDirectory ~/.zap/zigbee-server/ --allowCors --logToStdout --gen ./test/gen-template/zigbee/gen-templates.json --reuseZapInstance",
     "zigbeezap-devserver": "node src-script/zap-start.js server --stateDirectory ~/.zap/zigbee-server/ --allowCors --logToStdout --gen ./test/gen-template/zigbee/gen-templates.json --reuseZapInstance",

--- a/src-electron/main-process/startup.js
+++ b/src-electron/main-process/startup.js
@@ -42,6 +42,7 @@ const queryPackage = require('../db/query-package.js')
 const util = require('../util/util.js')
 const importJs = require('../importexport/import.js')
 const exportJs = require('../importexport/export.js')
+const validateAll = require('../validation/validate-all.js')
 const watchdog = require('./watchdog')
 const sdkUtil = require('../util/sdk-util')
 
@@ -630,6 +631,141 @@ async function startAnalyze(argv, options) {
 }
 
 /**
+ * Validate ZCL / data-model elements for one or more .zap files (headless).
+ *
+ * @param {*} argv
+ * @param {*} options
+ * @returns exit code 0 or 1 (1 if any attribute/endpoint validation errors)
+ */
+async function startValidate(argv, options) {
+  let paths = argv.zapFiles
+  options.logger(env.formatEmojiMessage('🤖', `Starting validation: ${paths}`))
+  let dbFile = env.sqliteFile('validate')
+  if (options.cleanDb && fs.existsSync(dbFile)) {
+    options.logger(env.formatEmojiMessage('🔧', 'remove old database file'))
+    fs.unlinkSync(dbFile)
+  }
+  let db = await dbApi.initDatabaseAndLoadSchema(
+    dbFile,
+    env.schemaFile(),
+    env.zapVersion()
+  )
+  options.logger(
+    env.formatEmojiMessage('🐝', 'database and schema initialized')
+  )
+  await zclLoader.loadZclMetafiles(db, argv.zclProperties, {
+    failOnLoadingError: !argv.noLoadingFailure
+  })
+  if (argv.generationTemplate != null) {
+    let ctx = await generatorEngine.loadTemplates(db, argv.generationTemplate, {
+      failOnLoadingError: !argv.noLoadingFailure
+    })
+    if (ctx.error) {
+      throw ctx.error
+    }
+  }
+
+  let exitCode = 0
+  const mergedReport = {
+    zapFiles: paths,
+    results: [],
+    summary: {
+      errors: 0,
+      warnings: 0,
+      attributes: 0,
+      endpoints: 0,
+      clusters: 0
+    }
+  }
+
+  await util.executePromisesSequentially(paths, async (singlePath) => {
+    let importResult = await importJs.importDataFromFile(db, singlePath, {
+      defaultZclMetafile: argv.zclProperties,
+      postImportScript: argv.postImportScript,
+      packageMatch: argv.packageMatch
+    })
+    let sessionId = importResult.sessionId
+    await util.ensurePackagesAndPopulateSessionOptions(db, sessionId, {
+      zcl: argv.zclProperties,
+      template: argv.generationTemplate
+    })
+    if (argv.postImportScript) {
+      await importJs.executePostImportScript(
+        db,
+        sessionId,
+        argv.postImportScript
+      )
+    }
+    const report = await validateAll.validateAll(db, sessionId, {
+      persistConformanceNotifications: false
+    })
+    const tagged = {
+      ...report,
+      zapFile: singlePath,
+      endpoints: report.endpoints.map((row) => ({
+        ...row,
+        zapFile: singlePath
+      })),
+      attributes: report.attributes.map((row) => ({
+        ...row,
+        zapFile: singlePath
+      })),
+      conformance: report.conformance.map((row) => ({
+        ...row,
+        zapFile: singlePath
+      }))
+    }
+    mergedReport.results.push(tagged)
+    mergedReport.summary.errors += report.summary.errors
+    mergedReport.summary.warnings += report.summary.warnings
+    mergedReport.summary.attributes += report.summary.attributes
+    mergedReport.summary.endpoints += report.summary.endpoints
+    mergedReport.summary.clusters += report.summary.clusters
+    if (report.summary.errors > 0) {
+      exitCode = 1
+    }
+
+    options.logger(
+      env.formatEmojiMessage(
+        '🔍',
+        `${singlePath}: errors=${report.summary.errors} warnings=${report.summary.warnings}`
+      )
+    )
+  })
+
+  options.logger(
+    env.formatEmojiMessage(
+      '🔧',
+      `Validation totals: errors=${mergedReport.summary.errors} warnings=${mergedReport.summary.warnings}`
+    )
+  )
+
+  if (argv.validateOutput != null) {
+    let outPath = argv.validateOutput
+    let ext = path.extname(outPath).toLowerCase()
+    let body =
+      ext === '.yaml' || ext === '.yml'
+        ? YAML.stringify(mergedReport)
+        : JSON.stringify(mergedReport, null, 2)
+    let parent = path.dirname(outPath)
+    if (!fs.existsSync(parent)) {
+      fs.mkdirSync(parent, { recursive: true })
+    }
+    await fsp.writeFile(outPath, body)
+    options.logger(
+      env.formatEmojiMessage('👉', `Wrote validation report: ${outPath}`)
+    )
+  } else {
+    process.stdout.write(JSON.stringify(mergedReport, null, 2) + '\n')
+  }
+
+  await dbApi.closeDatabase(db)
+  options.logger(env.formatEmojiMessage('🔧', 'Validation done!'))
+  if (options.quitFunction != null) options.quitFunction()
+  return exitCode
+}
+
+/**
  * Starts zap in a server mode.
  *
  * @param {*} options
@@ -1197,13 +1333,62 @@ async function startUpMainInstance(argv, callbacks) {
     }
     return startSelfCheck(argv, options)
   } else if (argv._.includes('analyze')) {
-    if (argv.zapFiles.length < 1)
-      throw 'You need to specify at least one zap file.'
+    if (argv.zapFiles.length < 1) {
+      console.error(
+        'Error: You need to specify at least one zap file.\n\n' +
+          'Usage:\n' +
+          '  npm run zap-analyze -- [options] <file.zap> [<file.zap> ...]\n\n' +
+          'Options:\n' +
+          '  -i, --in, --zap          Input .zap file(s). May be repeated or comma-separated.\n' +
+          '  -z, --zcl                ZCL metafile (e.g. zcl-builtin/silabs/zcl.json). May be repeated.\n' +
+          '  -g, --gen                Generation template metafile (e.g. gen-templates.json). May be repeated.\n'
+      )
+      cleanExit(argv.cleanupDelay, 1)
+      return
+    }
     let options = {
       quitFunction: quitFunction,
       logger: console.log
     }
     return startAnalyze(argv, options)
+  } else if (argv._.includes('validate')) {
+    if (argv.zapFiles.length < 1) {
+      console.error(
+        'Error: You need to specify at least one zap file.\n\n' +
+          'Usage:\n' +
+          '  npm run zap-validate -- [options] <file.zap> [<file.zap> ...]\n\n' +
+          'Options:\n' +
+          '  -i, --in, --zap          Input .zap file(s). May be repeated or comma-separated.\n' +
+          '  -z, --zcl                ZCL metafile (e.g. zcl-builtin/silabs/zcl.json). May be repeated.\n' +
+          '  -g, --gen                Generation template metafile (e.g. gen-templates.json). May be repeated.\n' +
+          '  -o, --validateOutput     Write validation report to a file (.json or .yaml). Defaults to stdout.\n'
+      )
+      cleanExit(argv.cleanupDelay, 1)
+      return
+    }
+    // When no report file is given, the JSON report goes to stdout, so route
+    // status messages to stderr to keep stdout clean and pipe-friendly.
+    // quitFunction is intentionally omitted here so that startValidate returns
+    // the numeric exit code rather than calling process.exit(0) prematurely.
+    // cleanExit below propagates the code to CI callers.
+    let options = {
+      quitFunction: null,
+      logger: argv.validateOutput == null ? console.error : console.log
+    }
+    return startValidate(argv, options)
+      .then((code) => {
+        if (code !== 0) {
+          env.printToStderr(
+            `Validation completed with errors (exit code ${code}). Check the report for details.`
+          )
+        }
+        cleanExit(argv.cleanupDelay, code)
+      })
+      .catch((err) => {
+        console.log(err)
+        env.printToStderr(`Zap validation error: ${err}`)
+        cleanExit(argv.cleanupDelay, 1)
+      })
   } else if (argv._.includes('server')) {
     return startServer(argv, quitFunction)
   } else if (argv._.includes('convert')) {
@@ -1289,6 +1474,7 @@ exports.startSelfCheck = startSelfCheck
 exports.clearDatabaseFile = clearDatabaseFile
 exports.startConvert = startConvert
 exports.startAnalyze = startAnalyze
+exports.startValidate = startValidate
 exports.startUpMainInstance = startUpMainInstance
 exports.startUpSecondaryInstance = startUpSecondaryInstance
 exports.shutdown = shutdown

--- a/src-electron/rest/user-data.js
+++ b/src-electron/rest/user-data.js
@@ -37,6 +37,7 @@ const querySession = require('../db/query-session.js')
 const queryPackage = require('../db/query-package.js')
 const asyncValidation = require('../validation/async-validation.js')
 const validation = require('../validation/validation.js')
+const validateAll = require('../validation/validate-all.js')
 const restApi = require('../../src-shared/rest-api.js')
 const zclLoader = require('../zcl/zcl-loader.js')
 const dbEnum = require('../../src-shared/db-enum.js')
@@ -1137,6 +1138,28 @@ function httpGetConformDataExists(db) {
 }
 
 /**
+ * HTTP GET: validate entire session (all endpoints, attribute defaults, conformance).
+ *
+ * @param {*} db
+ * @returns callback for the express uri registration
+ */
+function httpGetValidateAll(db) {
+  return async (request, response) => {
+    try {
+      const report = await validateAll.validateAll(db, request.zapSessionId, {
+        persistConformanceNotifications: false
+      })
+      response.status(StatusCodes.OK).json(report)
+    } catch (err) {
+      env.logError(err)
+      response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        error: err.message || String(err)
+      })
+    }
+  }
+}
+
+/**
  * Set warning for the required element, and delete its existing warning if any.
  *
  * @param {*} db
@@ -1331,6 +1354,10 @@ exports.get = [
   {
     uri: restApi.uri.conformDataExists,
     callback: httpGetConformDataExists
+  },
+  {
+    uri: restApi.uri.validate,
+    callback: httpGetValidateAll
   },
   {
     uri: restApi.uri.featureMapAttribute,

--- a/src-electron/util/args.js
+++ b/src-electron/util/args.js
@@ -44,6 +44,26 @@ function environmentVariablesDescription() {
 }
 
 /**
+ * Split comma-separated path lists (for `validate` only). Shells already pass
+ * space-separated paths as separate argv tokens; this lets you use a single
+ * `-i a.zap,b.zap` as well.
+ *
+ * @param {string[]} tokens
+ * @returns {string[]}
+ */
+function expandCommaSeparatedZapPaths(tokens) {
+  const out = []
+  for (const t of tokens) {
+    if (typeof t !== 'string') continue
+    for (const part of t.split(',')) {
+      const s = part.trim()
+      if (s) out.push(s)
+    }
+  }
+  return out
+}
+
+/**
  * Process the command line arguments and resets the state in this file
  * to the specified values.
  *
@@ -62,7 +82,8 @@ export function processCommandLineArguments(argv) {
     ['server', 'Run zap in a server mode.'],
     ['stop', 'Stop zap server if one is running.'],
     ['new', 'If in client mode, start a new window on a main instance.'],
-    ['regenerateSdk', 'Perform full SDK regeneration.']
+    ['regenerateSdk', 'Perform full SDK regeneration.'],
+    ['validate', 'Validate ZCL/Data-Model elements in one or more .zap files.']
   ])
   let y = yargs
   for (let cmd of commands.entries()) {
@@ -170,6 +191,11 @@ export function processCommandLineArguments(argv) {
       type: 'boolean',
       default: false
     })
+    .option('logToStdout', {
+      desc: 'Write log output to stdout instead of the log file.',
+      type: 'boolean',
+      default: false
+    })
     .option('cleanupDelay', {
       desc: 'When shutting down zap, this provides a number of millisecons to wait for SQLite to perform cleanup. Default is: 1500',
       type: 'number',
@@ -226,6 +252,11 @@ export function processCommandLineArguments(argv) {
     .option('results', {
       desc: 'Specifying the output YAML file to capture convert results.',
       type: 'string'
+    })
+    .option('validateOutput', {
+      desc: 'Optional file path to write the validation report (.json or .yaml). For the validate command, -o/--output is accepted as an alias when this option is omitted.',
+      type: 'string',
+      default: null
     })
     .option('disableDbCaching', {
       desc: 'Disable query caching when accessing database',
@@ -297,8 +328,26 @@ For more information, see ${commonUrl.projectUrl}`
   let allZapFileExtensions = ret._.filter((arg) => {
     return arg.endsWith('.zapExtension')
   })
-  if (ret.zapFile != null) allFiles.push(ret.zapFile)
-  ret.zapFiles = allFiles
+  if (ret.zapFile != null) {
+    if (Array.isArray(ret.zapFile)) {
+      allFiles.push(...ret.zapFile)
+    } else {
+      allFiles.push(ret.zapFile)
+    }
+  }
+  ret.zapFiles = ret._.includes('validate')
+    ? expandCommaSeparatedZapPaths(allFiles)
+    : allFiles
+
+  // validate: -o/--output normally maps to generation output; reuse as report path
+  if (ret._.includes('validate')) {
+    if (ret.validateOutput == null && ret.output != null) {
+      ret.validateOutput = ret.output
+    }
+    if (ret.validateOutput != null) {
+      ret.output = null
+    }
+  }
 
   if (allZapFileExtensions && allZapFileExtensions.length > 0) {
     ret.zapFileExtensions = allZapFileExtensions

--- a/src-electron/validation/conformance-checker.js
+++ b/src-electron/validation/conformance-checker.js
@@ -518,6 +518,7 @@ function getStateOfOperands(expression, elementMap, featureMap) {
  * @param {*} deviceTypeRefs
  * @param {*} cluster
  * @param {*} sessionId
+ * @param {*} options Optional. Set `{ persistNotifications: false }` to skip writing SESSION_NOTICE (e.g. bulk validate).
  * @returns list of warning messages if any, otherwise false
  */
 async function setConformanceWarnings(
@@ -527,8 +528,10 @@ async function setConformanceWarnings(
   endpointClusterId,
   deviceTypeRefs,
   cluster,
-  sessionId
+  sessionId,
+  options = {}
 ) {
+  const persistNotifications = options.persistNotifications !== false
   let deviceTypeFeatures = await queryFeature.getFeaturesByDeviceTypeRefs(
     db,
     deviceTypeRefs,
@@ -624,15 +627,17 @@ async function setConformanceWarnings(
 
     // set warnings in the session notification table
     if (warnings.length > 0) {
-      for (const warning of warnings) {
-        await querySessionNotice.setNotification(
-          db,
-          'WARNING',
-          warning,
-          sessionId,
-          1,
-          0
-        )
+      if (persistNotifications) {
+        for (const warning of warnings) {
+          await querySessionNotice.setNotification(
+            db,
+            'WARNING',
+            warning,
+            sessionId,
+            1,
+            0
+          )
+        }
       }
       return warnings
     }

--- a/src-electron/validation/validate-all.js
+++ b/src-electron/validation/validate-all.js
@@ -1,0 +1,595 @@
+/**
+ *
+ *    Copyright (c) 2025 Silicon Labs
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Runs existing ZCL / data-model validators across an entire session (all endpoints,
+ * endpoint types, included attributes, and per-cluster conformance).
+ *
+ * @module Validation API: validate all session elements
+ */
+
+const validation = require('./validation.js')
+const conformChecker = require('./conformance-checker.js')
+const queryEndpoint = require('../db/query-endpoint.js')
+const queryEndpointType = require('../db/query-endpoint-type.js')
+const queryZcl = require('../db/query-zcl.js')
+const queryCommand = require('../db/query-command.js')
+const queryDeviceType = require('../db/query-device-type.js')
+const queryPackage = require('../db/query-package.js')
+const dbEnum = require('../../src-shared/db-enum.js')
+
+/**
+ * @param {*} db
+ * @param {*} sessionId
+ * @param {*} options
+ * @param {boolean} [options.conformance=true] Run conformance checks (feature map / mandatory elements).
+ * @param {boolean} [options.persistConformanceNotifications=false] If true, conformance issues are also written to SESSION_NOTICE.
+ * @returns {Promise<object>} Aggregated validation report
+ */
+async function validateAll(db, sessionId, options = {}) {
+  const conformanceEnabled = options.conformance !== false
+  const persistConformanceNotifications =
+    options.persistConformanceNotifications === true
+
+  const endpointRows = []
+  const attributeRows = []
+  const conformanceRows = []
+
+  let errorCount = 0
+  let attributesChecked = 0
+  let clustersChecked = 0
+
+  const endpoints = await queryEndpoint.selectAllEndpoints(db, sessionId)
+
+  /** @type {Map<number, number[]>} endpoint type id -> sorted endpoint identifier numbers */
+  const endpointIdentifiersByEndpointTypeId = new Map()
+  for (const ep of endpoints) {
+    const tid = ep.endpointTypeRef
+    if (!endpointIdentifiersByEndpointTypeId.has(tid)) {
+      endpointIdentifiersByEndpointTypeId.set(tid, [])
+    }
+    endpointIdentifiersByEndpointTypeId.get(tid).push(ep.endpointIdentifier)
+  }
+  for (const list of endpointIdentifiersByEndpointTypeId.values()) {
+    list.sort((a, b) => a - b)
+  }
+
+  for (const ep of endpoints) {
+    const issues = await validation.validateEndpoint(db, ep.id)
+    const epIssues = {
+      endpointId: issues.endpointId || [],
+      networkId: issues.networkId || []
+    }
+    // The shared validation helpers (isValidNumberString / extractIntegerValue)
+    // treat null/undefined as 0 because Number(null) === 0. That's fine for the
+    // UI's runtime checks but lets a malformed .zap file slip through the
+    // headless validate path, so we explicitly catch null/empty values here.
+    if (ep.endpointIdentifier == null || ep.endpointIdentifier === '') {
+      if (!epIssues.endpointId.includes('EndpointId is missing')) {
+        epIssues.endpointId.push('EndpointId is missing')
+      }
+    }
+    if (ep.networkId == null || ep.networkId === '') {
+      if (!epIssues.networkId.includes('NetworkId is missing')) {
+        epIssues.networkId.push('NetworkId is missing')
+      }
+    }
+    const hasEpIssues =
+      epIssues.endpointId.length > 0 || epIssues.networkId.length > 0
+    if (hasEpIssues) {
+      errorCount += epIssues.endpointId.length + epIssues.networkId.length
+      endpointRows.push({
+        endpointDbId: ep.id,
+        endpointId: ep.endpointIdentifier,
+        issues: epIssues
+      })
+    }
+  }
+
+  const endpointTypes = await queryEndpointType.selectAllEndpointTypes(
+    db,
+    sessionId
+  )
+
+  for (const et of endpointTypes) {
+    const endpointTypeId = et.endpointTypeId
+    const attrs = await queryZcl.selectEndpointTypeAttributesByEndpointId(
+      db,
+      endpointTypeId
+    )
+    for (const row of attrs) {
+      if (!row.included) continue
+      if (row.storageOption === dbEnum.storageOption.external) continue
+      attributesChecked++
+      const result = await validation.validateAttribute(
+        db,
+        endpointTypeId,
+        row.attributeRef,
+        row.clusterRef,
+        sessionId
+      )
+      const dvIssues = result.defaultValue || []
+      if (dvIssues.length > 0) {
+        errorCount += dvIssues.length
+        let attributeName = ''
+        let clusterName = ''
+        const attrDef = await queryZcl.selectAttributeById(db, row.attributeRef)
+        if (attrDef) attributeName = attrDef.name
+        const clusterDef = await queryZcl.selectClusterById(db, row.clusterRef)
+        if (clusterDef) clusterName = clusterDef.name
+
+        const endpointIdentifiers =
+          endpointIdentifiersByEndpointTypeId.get(endpointTypeId) || []
+
+        attributeRows.push({
+          endpointIdentifiers,
+          endpointIdentifierLabel:
+            endpointIdentifiers.length > 0
+              ? endpointIdentifiers.join(', ')
+              : '',
+          endpointTypeId,
+          clusterName,
+          clusterRef: row.clusterRef,
+          attributeName,
+          attributeRef: row.attributeRef,
+          defaultValue: row.defaultValue,
+          issues: dvIssues
+        })
+      }
+    }
+  }
+
+  if (conformanceEnabled) {
+    const allZclPackageIds = await queryPackage.getSessionZclPackageIds(
+      db,
+      sessionId
+    )
+    /** Per-endpoint warning bucket: key = `${endpointDbId}:${clusterRef}`. */
+    const conformanceByCluster = new Map()
+    const addConformanceWarning = ({
+      endpointDbId,
+      endpointId,
+      clusterRef,
+      clusterName,
+      message
+    }) => {
+      const key = `${endpointDbId}:${clusterRef ?? '_'}`
+      let bucket = conformanceByCluster.get(key)
+      if (!bucket) {
+        bucket = {
+          endpointDbId,
+          endpointId,
+          clusterRef,
+          clusterName,
+          warnings: []
+        }
+        conformanceByCluster.set(key, bucket)
+      }
+      bucket.warnings.push(message)
+      errorCount++
+    }
+
+    const deviceTypeCache = new Map()
+    /** endpoint type id -> mandatory attribute / command lists across enabled clusters */
+    const endpointTypeMandatoryCache = new Map()
+
+    for (const ep of endpoints) {
+      const endpointTypeId = ep.endpointTypeRef
+      let deviceTypeRefs = deviceTypeCache.get(endpointTypeId)
+      if (!deviceTypeRefs) {
+        const etd = await queryDeviceType.selectDeviceTypesByEndpointTypeId(
+          db,
+          endpointTypeId
+        )
+        deviceTypeRefs = etd.map((x) => x.deviceTypeRef)
+        deviceTypeCache.set(endpointTypeId, deviceTypeRefs)
+      }
+
+      // ---- Feature-map / element conformance from XML ----
+      const clusters = await queryEndpoint.selectEndpointClusters(
+        db,
+        endpointTypeId
+      )
+      for (const cluster of clusters) {
+        clustersChecked++
+        const warnings = await conformChecker.setConformanceWarnings(
+          db,
+          ep.endpointIdentifier,
+          endpointTypeId,
+          cluster.endpointTypeClusterId,
+          deviceTypeRefs,
+          cluster,
+          sessionId,
+          { persistNotifications: persistConformanceNotifications }
+        )
+        if (warnings && warnings.length > 0) {
+          for (const w of warnings) {
+            addConformanceWarning({
+              endpointDbId: ep.id,
+              endpointId: ep.endpointIdentifier,
+              clusterRef: cluster.id,
+              clusterName: cluster.name,
+              message: w
+            })
+          }
+        }
+      }
+
+      // ---- Mandatory cluster compliance (attributes + commands) ----
+      // Mirrors clusterComplianceForAttributes / clusterComplianceForCommands
+      // in import-json.js, but recomputed live from current state.
+      let mandatory = endpointTypeMandatoryCache.get(endpointTypeId)
+      if (!mandatory) {
+        mandatory = await collectMandatoryClusterElements(
+          db,
+          endpointTypeId,
+          allZclPackageIds
+        )
+        endpointTypeMandatoryCache.set(endpointTypeId, mandatory)
+      }
+
+      const endpointTypeAttributes =
+        await queryZcl.selectEndpointTypeAttributesByEndpointId(
+          db,
+          endpointTypeId
+        )
+      const endpointTypeCommands =
+        await queryZcl.selectEndpointTypeCommandsByEndpointId(
+          db,
+          endpointTypeId
+        )
+      const includedAttrIds = new Set(
+        endpointTypeAttributes
+          .filter((a) => a.included)
+          .map((a) => a.attributeRef)
+      )
+      const cmdEnablement = new Map()
+      for (const c of endpointTypeCommands) {
+        cmdEnablement.set(c.commandRef, {
+          incoming: !!c.incoming,
+          outgoing: !!c.outgoing
+        })
+      }
+
+      for (const ma of mandatory.attributes) {
+        if (includedAttrIds.has(ma.id)) continue
+        addConformanceWarning({
+          endpointDbId: ep.id,
+          endpointId: ep.endpointIdentifier,
+          clusterRef: ma.clusterRef,
+          clusterName: ma.clusterName,
+          message: `Check Cluster Compliance on endpoint: ${ep.endpointIdentifier}, cluster: ${ma.clusterName}, mandatory attribute: ${ma.name} needs to be enabled`
+        })
+      }
+      for (const mc of mandatory.commands) {
+        const enab = cmdEnablement.get(mc.id) || {
+          incoming: false,
+          outgoing: false
+        }
+        // import-json only flags incoming side here (matches existing UX).
+        if (mc.isIncoming && !enab.incoming) {
+          addConformanceWarning({
+            endpointDbId: ep.id,
+            endpointId: ep.endpointIdentifier,
+            clusterRef: mc.clusterRef,
+            clusterName: mc.clusterName,
+            message: `Check Cluster Compliance on endpoint: ${ep.endpointIdentifier}, cluster: ${mc.clusterName} ${mc.clusterSide}, mandatory command: ${mc.name} incoming needs to be enabled`
+          })
+        } else if (!mc.isIncoming && !enab.outgoing) {
+          addConformanceWarning({
+            endpointDbId: ep.id,
+            endpointId: ep.endpointIdentifier,
+            clusterRef: mc.clusterRef,
+            clusterName: mc.clusterName,
+            message: `Check Cluster Compliance on endpoint: ${ep.endpointIdentifier}, cluster: ${mc.clusterName} ${mc.clusterSide}, mandatory command: ${mc.name} outgoing needs to be enabled`
+          })
+        }
+      }
+
+      // ---- Device type compliance (clusters/attrs/cmds required by device type) ----
+      const dtcRows = await collectDeviceTypeRequirements(db, endpointTypeId)
+      const epClusterMap = {}
+      for (const c of await queryZcl.selectEndpointTypeClustersByEndpointTypeId(
+        db,
+        endpointTypeId
+      )) {
+        epClusterMap[c.clusterRef] = epClusterMap[c.clusterRef] || {}
+        epClusterMap[c.clusterRef][c.side] = c.enabled
+      }
+      for (const r of dtcRows.clusters) {
+        const present = epClusterMap[r.clusterRef] || {}
+        if (r.includeClient && r.lockClient && !present.client) {
+          addConformanceWarning({
+            endpointDbId: ep.id,
+            endpointId: ep.endpointIdentifier,
+            clusterRef: r.clusterRef,
+            clusterName: r.clusterName,
+            message: `Check Device Type Compliance on endpoint: ${ep.endpointIdentifier}, device type: ${r.deviceTypeName}, cluster: ${r.clusterName} client needs to be enabled`
+          })
+        }
+        if (r.includeServer && r.lockServer && !present.server) {
+          addConformanceWarning({
+            endpointDbId: ep.id,
+            endpointId: ep.endpointIdentifier,
+            clusterRef: r.clusterRef,
+            clusterName: r.clusterName,
+            message: `Check Device Type Compliance on endpoint: ${ep.endpointIdentifier}, device type: ${r.deviceTypeName}, cluster: ${r.clusterName} server needs to be enabled`
+          })
+        }
+      }
+      const epAttrEnabled = new Set(
+        endpointTypeAttributes
+          .filter((a) => a.included)
+          .map((a) => a.attributeRef)
+      )
+      for (const r of dtcRows.attributes) {
+        if (epAttrEnabled.has(r.attributeRef)) continue
+        addConformanceWarning({
+          endpointDbId: ep.id,
+          endpointId: ep.endpointIdentifier,
+          clusterRef: r.clusterRef,
+          clusterName: r.clusterName,
+          message: `Check Device Type Compliance on endpoint: ${ep.endpointIdentifier}, device type: ${r.deviceTypeName}, cluster: ${r.clusterName}, attribute: ${r.name} needs to be enabled`
+        })
+      }
+      for (const r of dtcRows.commands) {
+        const enab = cmdEnablement.get(r.commandRef) || {
+          incoming: false,
+          outgoing: false
+        }
+        const incomingMissing = !enab.incoming
+        const outgoingMissing = !enab.outgoing
+        if (
+          r.includeClient &&
+          r.commandSource === 'client' &&
+          outgoingMissing
+        ) {
+          addConformanceWarning({
+            endpointDbId: ep.id,
+            endpointId: ep.endpointIdentifier,
+            clusterRef: r.clusterRef,
+            clusterName: r.clusterName,
+            message: `Check Device Type Compliance on endpoint: ${ep.endpointIdentifier}, device type: ${r.deviceTypeName}, cluster: ${r.clusterName} client, command: ${r.name} outgoing needs to be enabled`
+          })
+        }
+        if (
+          r.includeClient &&
+          r.commandSource === 'server' &&
+          incomingMissing
+        ) {
+          addConformanceWarning({
+            endpointDbId: ep.id,
+            endpointId: ep.endpointIdentifier,
+            clusterRef: r.clusterRef,
+            clusterName: r.clusterName,
+            message: `Check Device Type Compliance on endpoint: ${ep.endpointIdentifier}, device type: ${r.deviceTypeName}, cluster: ${r.clusterName} client, command: ${r.name} incoming needs to be enabled`
+          })
+        }
+        if (
+          r.includeServer &&
+          r.commandSource === 'client' &&
+          incomingMissing
+        ) {
+          addConformanceWarning({
+            endpointDbId: ep.id,
+            endpointId: ep.endpointIdentifier,
+            clusterRef: r.clusterRef,
+            clusterName: r.clusterName,
+            message: `Check Device Type Compliance on endpoint: ${ep.endpointIdentifier}, device type: ${r.deviceTypeName}, cluster: ${r.clusterName} server, command: ${r.name} incoming needs to be enabled`
+          })
+        }
+        if (
+          r.includeServer &&
+          r.commandSource === 'server' &&
+          outgoingMissing
+        ) {
+          addConformanceWarning({
+            endpointDbId: ep.id,
+            endpointId: ep.endpointIdentifier,
+            clusterRef: r.clusterRef,
+            clusterName: r.clusterName,
+            message: `Check Device Type Compliance on endpoint: ${ep.endpointIdentifier}, device type: ${r.deviceTypeName}, cluster: ${r.clusterName} server, command: ${r.name} outgoing needs to be enabled`
+          })
+        }
+      }
+    }
+
+    for (const bucket of conformanceByCluster.values()) {
+      conformanceRows.push(bucket)
+    }
+  }
+
+  return {
+    summary: {
+      errors: errorCount,
+      warnings: 0,
+      attributes: attributesChecked,
+      endpoints: endpoints.length,
+      clusters: clustersChecked
+    },
+    endpoints: endpointRows,
+    attributes: attributeRows,
+    conformance: conformanceRows
+  }
+}
+
+/**
+ * Collect mandatory (non-optional, non-global) attributes and mandatory commands
+ * across every enabled cluster on an endpoint type.
+ *
+ * Mirrors getMandatoryClusterAttributes / getMandatoryClusterCommands in
+ * import-json.js, returning a flat list with cluster context attached.
+ *
+ * @param {*} db
+ * @param {*} endpointTypeId
+ * @param {number[]} packageIds
+ * @returns {Promise<{attributes: object[], commands: object[]}>}
+ */
+async function collectMandatoryClusterElements(db, endpointTypeId, packageIds) {
+  const epClusters = await queryZcl.selectEndpointTypeClustersByEndpointTypeId(
+    db,
+    endpointTypeId
+  )
+  const attributes = []
+  const commands = []
+  for (const epc of epClusters) {
+    if (!epc.enabled) continue
+    const cluster = await queryZcl.selectClusterById(db, epc.clusterRef)
+    if (!cluster) continue
+
+    const clusterAttrs =
+      await queryZcl.selectAttributesByClusterIdAndSideIncludingGlobal(
+        db,
+        epc.clusterRef,
+        packageIds,
+        epc.side
+      )
+    for (const a of clusterAttrs) {
+      // ignore global attributes (clusterRef null) and optional ones
+      if (a.isOptional || a.clusterRef == null) continue
+      attributes.push({
+        id: a.id,
+        name: a.name,
+        clusterRef: epc.clusterRef,
+        clusterName: cluster.name,
+        side: epc.side
+      })
+    }
+
+    const clusterCmds = await queryCommand.selectCommandsByClusterId(
+      db,
+      epc.clusterRef,
+      packageIds
+    )
+    for (const c of clusterCmds) {
+      if (c.isOptional) continue
+      commands.push({
+        id: c.id,
+        name: c.name,
+        clusterRef: epc.clusterRef,
+        clusterName: cluster.name,
+        clusterSide: epc.side,
+        // import-json: isIncoming when source side != cluster side
+        isIncoming: c.source !== epc.side
+      })
+    }
+  }
+  return { attributes, commands }
+}
+
+/**
+ * Collect device-type required clusters / attributes / commands for an endpoint type.
+ *
+ * Mirrors deviceTypeClustersAttributesAndCommands in import-json.js and joins in
+ * names + side flags so the validator can report compliance gaps without re-querying.
+ *
+ * @param {*} db
+ * @param {*} endpointTypeId
+ * @returns {Promise<{clusters: object[], attributes: object[], commands: object[]}>}
+ */
+async function collectDeviceTypeRequirements(db, endpointTypeId) {
+  const dts = await queryDeviceType.selectDeviceTypesByEndpointTypeId(
+    db,
+    endpointTypeId
+  )
+  const clusters = []
+  const attributes = []
+  const commands = []
+  for (const dt of dts) {
+    const deviceType = await queryDeviceType.selectDeviceTypeById(
+      db,
+      dt.deviceTypeRef
+    )
+    const dtName = deviceType ? deviceType.name : ''
+
+    const dtClusters =
+      await queryDeviceType.selectDeviceTypeClustersByDeviceTypeRef(
+        db,
+        dt.deviceTypeRef
+      )
+    for (const dtc of dtClusters) {
+      clusters.push({
+        deviceTypeRef: dt.deviceTypeRef,
+        deviceTypeName: dtName,
+        clusterRef: dtc.clusterRef,
+        clusterName: dtc.clusterName,
+        includeClient: !!dtc.includeClient,
+        includeServer: !!dtc.includeServer,
+        lockClient: !!dtc.lockClient,
+        lockServer: !!dtc.lockServer
+      })
+    }
+
+    const dtAttrs =
+      await queryDeviceType.selectDeviceTypeAttributesByDeviceTypeRef(
+        db,
+        dt.deviceTypeRef
+      )
+    for (const a of dtAttrs) {
+      if (a.attributeRef == null) continue
+      const dtCluster = await queryDeviceType
+        .selectDeviceTypeClusterByDeviceTypeClusterId(
+          db,
+          a.deviceTypeClusterRef
+        )
+        .catch(() => null)
+      if (!dtCluster) continue
+      const cluster = await queryZcl.selectClusterById(db, dtCluster.clusterRef)
+      attributes.push({
+        deviceTypeRef: dt.deviceTypeRef,
+        deviceTypeName: dtName,
+        clusterRef: dtCluster.clusterRef,
+        clusterName: cluster ? cluster.name : '',
+        attributeRef: a.attributeRef,
+        name: a.name,
+        includeClient: !!dtCluster.includeClient,
+        includeServer: !!dtCluster.includeServer
+      })
+    }
+
+    const dtCmds =
+      await queryDeviceType.selectDeviceTypeCommandsByDeviceTypeRef(
+        db,
+        dt.deviceTypeRef
+      )
+    for (const c of dtCmds) {
+      if (c.commandRef == null) continue
+      const dtCluster = await queryDeviceType
+        .selectDeviceTypeClusterByDeviceTypeClusterId(
+          db,
+          c.deviceTypeClusterRef
+        )
+        .catch(() => null)
+      if (!dtCluster) continue
+      const cluster = await queryZcl.selectClusterById(db, dtCluster.clusterRef)
+      commands.push({
+        deviceTypeRef: dt.deviceTypeRef,
+        deviceTypeName: dtName,
+        clusterRef: dtCluster.clusterRef,
+        clusterName: cluster ? cluster.name : '',
+        commandRef: c.commandRef,
+        name: c.name,
+        commandSource: c.source,
+        includeClient: !!dtCluster.includeClient,
+        includeServer: !!dtCluster.includeServer
+      })
+    }
+  }
+  return { clusters, attributes, commands }
+}
+
+exports.validateAll = validateAll

--- a/src-electron/validation/validation.js
+++ b/src-electron/validation/validation.js
@@ -29,6 +29,7 @@ const types = require('../util/types.js')
 const queryPackage = require('../db/query-package.js')
 const env = require('../util/env')
 const queryNotification = require('../db/query-package-notification.js')
+const dbEnum = require('../../src-shared/db-enum.js')
 
 /**
  * Main attribute validation function.
@@ -65,6 +66,10 @@ async function validateAttribute(
     return { defaultValue: ['Attribute not found in endpoint configuration'] }
   }
 
+  if (endpointAttribute.storageOption === dbEnum.storageOption.external) {
+    return { defaultValue: [] }
+  }
+
   let attribute = await queryZcl.selectAttributeById(db, attributeRef)
   // Null check for attribute
   if (!attribute) {
@@ -91,7 +96,8 @@ async function validateAttribute(
  */
 async function validateEndpoint(db, endpointId) {
   let endpoint = await queryEndpoint.selectEndpoint(db, endpointId)
-  let currentIssues = validateSpecificEndpoint(endpoint)
+  const isMatter = await isMatterSession(db, endpoint.sessionRef)
+  let currentIssues = validateSpecificEndpoint(endpoint, { isMatter })
   let noDuplicates = await validateNoDuplicateEndpoints(
     db,
     endpoint.endpointId,
@@ -104,7 +110,12 @@ async function validateEndpoint(db, endpointId) {
 }
 
 /**
- * Check if there are no duplicate endpoints.
+ * Returns true when this endpoint identifier is unique within the session.
+ *
+ * The schema enforces UNIQUE(ENDPOINT_TYPE_REF, ENDPOINT_IDENTIFIER), but for the
+ * user-visible "duplicate endpoint" check we want session-wide uniqueness: two
+ * endpoints with the same identifier are wrong on a real device regardless of
+ * which endpoint type they belong to.
  *
  * @param {*} db
  * @param {*} endpointIdentifier
@@ -116,13 +127,34 @@ async function validateNoDuplicateEndpoints(
   endpointIdentifier,
   sessionRef
 ) {
-  let count =
+  const count =
     await queryConfig.selectCountOfEndpointsWithGivenEndpointIdentifier(
       db,
       endpointIdentifier,
       sessionRef
     )
-  return count.length <= 1
+  // helper returns the integer count (0/1/...). Anything other than 0 or 1 means duplicate.
+  const n = Number(count)
+  return Number.isFinite(n) ? n <= 1 : true
+}
+
+/**
+ * True when the session uses Matter ZCL packages (CATEGORY = 'matter').
+ * Used to relax Zigbee-only rules (e.g. endpoint 0 is reserved in Zigbee but is
+ * the root node in Matter).
+ *
+ * @param {*} db
+ * @param {*} sessionId
+ * @returns Promise<boolean>
+ */
+async function isMatterSession(db, sessionId) {
+  if (sessionId == null) return false
+  try {
+    const pkgs = await queryPackage.getSessionZclPackages(db, sessionId)
+    return pkgs.some((p) => p.category === dbEnum.helperCategory.matter)
+  } catch (e) {
+    return false
+  }
 }
 
 /**
@@ -156,12 +188,27 @@ async function validateXmlAttributeDefault(db, attribute, packageId) {
   // Validate numeric types
   else if (!types.isString(attribute.type)) {
     if (types.isFloat(attribute.type)) {
-      // Validate float
-      if (!isValidFloat(attribute.defaultValue)) {
+      // Resolve the float bit width so hex IEEE 754 bit-pattern bounds
+      // and defaults (the ZCL XML convention, e.g. min="0x0000"
+      // max="0x3F800000" for float_single) are decoded correctly. We
+      // have a packageId rather than a session here, so use the
+      // package-scoped type lookup directly.
+      let size
+      try {
+        const lookup = await types.getSignAndSizeOfZclType(db, attribute.type, [
+          packageId
+        ])
+        size =
+          lookup && lookup.dataTypesize ? lookup.dataTypesize * 8 : undefined
+      } catch (e) {
+        size = undefined
+      }
+      if (!isValidFloat(attribute.defaultValue, size)) {
         issues.push('Invalid Float')
       } else if (attribute.min != null || attribute.max != null) {
-        let bounds = getBoundsFloat(attribute)
-        if (!checkBoundsFloat(attribute.defaultValue, bounds.min, bounds.max)) {
+        let bounds = getBoundsFloat(attribute, size)
+        let value = getFloatFromAttribute(attribute.defaultValue, size)
+        if (!checkBoundsFloat(value, bounds.min, bounds.max)) {
           issues.push(`Out of range (min: ${bounds.min}, max: ${bounds.max})`)
         }
       }
@@ -245,11 +292,28 @@ async function validateSpecificAttribute(
     return { defaultValue: defaultAttributeIssues }
   } else if (!types.isString(attribute.type)) {
     if (types.isFloat(attribute.type)) {
-      if (!isValidFloat(endpointAttribute.defaultValue))
+      // Resolve the float type's bit width so hex IEEE 754 bit patterns
+      // (e.g. "0x3F800000" => 1.0 for float_single) are recognized as
+      // valid float defaults. This matches the ZCL/Matter XML convention
+      // for float min/max bounds.
+      const { size } = await getFloatAttributeSize(
+        db,
+        zapSessionId,
+        attribute.type,
+        attribute.clusterRef
+      )
+      if (!isValidFloat(endpointAttribute.defaultValue, size)) {
         defaultAttributeIssues.push('Invalid Float')
-      //Interpreting float values
-      if (!checkAttributeBoundsFloat(attribute, endpointAttribute))
+      } else if (
+        !(await checkAttributeBoundsFloat(
+          attribute,
+          endpointAttribute,
+          db,
+          zapSessionId
+        ))
+      ) {
         defaultAttributeIssues.push('Out of range')
+      }
     } else {
       // we shouldn't check boundaries for an invalid number string
       if (!isValidNumberString(endpointAttribute.defaultValue)) {
@@ -289,7 +353,8 @@ async function validateSpecificAttribute(
  * @param {*} endpoint
  * @returns object
  */
-function validateSpecificEndpoint(endpoint) {
+function validateSpecificEndpoint(endpoint, options = {}) {
+  const isMatter = options.isMatter === true
   let zclEndpointIdIssues = []
   let zclNetworkIdIssues = []
   if (!isValidNumberString(endpoint.endpointId))
@@ -301,7 +366,8 @@ function validateSpecificEndpoint(endpoint) {
     zclEndpointIdIssues.push('EndpointId is out of valid range')
   if (!isValidNumberString(endpoint.networkId))
     zclNetworkIdIssues.push('NetworkId is invalid number string')
-  if (extractIntegerValue(endpoint.endpointId) == 0)
+  // Matter reserves endpoint 0 as the Root Node. Zigbee reserves it for ZDO.
+  if (!isMatter && extractIntegerValue(endpoint.endpointId) == 0)
     zclEndpointIdIssues.push('0 is not a valid endpointId')
   return {
     endpointId: zclEndpointIdIssues,
@@ -344,21 +410,105 @@ function isValidDecimalString(value) {
 /**
  * Check if value is a valid float value.
  *
+ * Decimal literals (e.g. "1.5", "-0.25", "1e40") are always accepted.
+ * When a typeSize is supplied, hex IEEE 754 bit-pattern literals are
+ * also accepted as long as they fit within the type's nibble width
+ * (e.g. "0x3F800000" for `float_single` decodes to 1.0). This mirrors
+ * the ZCL/Matter XML convention used for float min/max bounds.
+ *
  * @param {*} value
+ * @param {*} typeSize Optional bit width of the float type (16, 32, or 64).
+ * When omitted, hex strings are rejected (legacy decimal-only behavior).
  * @returns boolean
  */
-function isValidFloat(value) {
-  return !/^0x/i.test(value) && !isNaN(Number(value))
+function isValidFloat(value, typeSize) {
+  if (value == null) return false
+  const s = String(value)
+  if (/^0x/i.test(s)) {
+    if (typeSize == null) return false
+    return /^0x[0-9A-F]+$/i.test(s) && s.length - 2 <= typeSize / 4
+  }
+  return !isNaN(Number(s))
 }
 
 /**
  * Get float value from the given value.
+ * Hex strings (e.g. "0x42C80000") cannot be reliably decoded without knowing
+ * the bit-width, so they are returned as NaN and treated as unconstrained.
+ * Use {@link getFloatFromAttribute} when the float type's bit width is known
+ * and IEEE 754 hex bit patterns should be decoded.
  *
  * @param {*} value
- * @returns float value
+ * @returns float value, or NaN if value is null/undefined/hex
  */
 function extractFloatValue(value) {
+  if (value == null || /^0x/i.test(String(value))) return NaN
   return parseFloat(value)
+}
+
+/**
+ * Decodes a 16-bit IEEE 754 half-precision bit pattern into a Number.
+ * Implemented manually because Float16Array is not yet available across
+ * all supported Node versions. Counterpart of `convertFloatToBigEndian`
+ * for sizes the 32/64-bit DataView path cannot handle.
+ *
+ * @param {*} bits Unsigned 16-bit integer (0..0xFFFF)
+ * @returns Number
+ */
+function decodeFloat16(bits) {
+  const sign = (bits >> 15) & 0x1
+  const exp = (bits >> 10) & 0x1f
+  const frac = bits & 0x3ff
+  let value
+  if (exp === 0) {
+    // Subnormal (or signed zero when frac === 0).
+    value = frac === 0 ? 0 : Math.pow(2, -14) * (frac / 1024)
+  } else if (exp === 0x1f) {
+    value = frac === 0 ? Infinity : NaN
+  } else {
+    value = Math.pow(2, exp - 15) * (1 + frac / 1024)
+  }
+  return sign ? -value : value
+}
+
+/**
+ * Converts a float attribute string into a Number, honoring the IEEE 754
+ * bit-pattern hex convention used by ZCL/Matter XML for float min/max
+ * bounds and defaults (e.g. "0x3F800000" => 1.0 for `float_single`).
+ *
+ * Mirrors `getIntegerFromAttribute` on the integer side: the type's bit
+ * width drives how the string is decoded. Decimal literals fall through
+ * to `parseFloat`. Hex literals wider than the type can encode (more
+ * than `typeSize / 4` nibbles) return NaN so the caller can flag them.
+ *
+ * @param {*} attribute string representation of a float
+ * @param {*} typeSize bit width of the float type (16, 32, or 64)
+ * @returns Number, or NaN if the value cannot be decoded for typeSize
+ */
+function getFloatFromAttribute(attribute, typeSize) {
+  if (attribute == null) return NaN
+  const s = String(attribute)
+  if (/^0x/i.test(s)) {
+    // Anything that looks hex-prefixed must round-trip through a strict
+    // hex-digit check; otherwise parseFloat would silently consume just
+    // the leading "0" and return 0 for inputs like "0x12GH".
+    if (typeSize == null || !/^0x[0-9A-F]+$/i.test(s)) return NaN
+    const hex = s.slice(2)
+    if (hex.length > typeSize / 4) return NaN
+    if (typeSize === 16) {
+      return decodeFloat16(parseInt(hex, 16) & 0xffff)
+    } else if (typeSize === 32) {
+      const view = new DataView(new ArrayBuffer(4))
+      view.setUint32(0, parseInt(hex, 16) >>> 0, false)
+      return view.getFloat32(0, false)
+    } else if (typeSize === 64) {
+      const view = new DataView(new ArrayBuffer(8))
+      view.setBigUint64(0, BigInt(s), false)
+      return view.getFloat64(0, false)
+    }
+    return NaN
+  }
+  return parseFloat(s)
 }
 
 /**
@@ -555,28 +705,116 @@ function checkBoundsInteger(defaultValue, min, max) {
 }
 
 /**
- * Check if float attribute's value is within the bounds.
+ * Returns information about a float type by querying the data type
+ * metadata stored in the database. Mirrors getIntegerAttributeSize so
+ * the size lookup uses the same source of truth for both integer and
+ * float types and works for any float type defined in the loaded ZCL
+ * (e.g. silabs `float_semi`/`float_single`/`float_double` and Matter
+ * `single`/`double`).
+ *
+ * @param {*} db
+ * @param {*} zapSessionId
+ * @param {*} attribType
+ * @param {*} clusterRef
+ * @returns {*} { size: bit representation }
+ */
+async function getFloatAttributeSize(db, zapSessionId, attribType, clusterRef) {
+  let packageIds = await queryPackage.getSessionZclPackageIds(db, zapSessionId)
+  const attribData = await types.getSignAndSizeOfZclTypeAndClusterId(
+    db,
+    attribType,
+    clusterRef,
+    packageIds
+  )
+  if (attribData && attribData.dataTypesize) {
+    return { size: attribData.dataTypesize * 8 }
+  } else {
+    return { size: undefined }
+  }
+}
+
+/**
+ * Gets the representable range of a float type. Mirrors getTypeRange for
+ * integer types and is used as the fallback when an attribute does not
+ * explicitly declare min/max.
+ *
+ * @param {*} typeSize bit width of the float type
+ * @param {*} isMin true to return the minimum, false for the maximum
+ * @returns float
+ */
+function getFloatTypeRange(typeSize, isMin) {
+  let mag
+  switch (typeSize) {
+    case 16:
+      // IEEE 754 half precision: max representable finite magnitude
+      mag = 65504
+      break
+    case 32:
+      // IEEE 754 single precision: FLT_MAX
+      mag = 3.4028234663852886e38
+      break
+    case 64:
+    default:
+      mag = Number.MAX_VALUE
+      break
+  }
+  return isMin ? -mag : mag
+}
+
+/**
+ * Checks if the incoming float is within its attribute's bounds while
+ * honoring the representable range of the float type. Mirrors
+ * checkAttributeBoundsInteger: it first resolves the type metadata
+ * from the database, bails out if the type is unknown, and then
+ * compares against the (possibly type-defaulted) min/max bounds.
  *
  * @param {*} attribute
  * @param {*} endpointAttribute
+ * @param {*} db
+ * @param {*} zapSessionId
  * @returns boolean
  */
-function checkAttributeBoundsFloat(attribute, endpointAttribute) {
-  let { min, max } = getBoundsFloat(attribute)
-  let defaultValue = extractFloatValue(endpointAttribute.defaultValue)
+async function checkAttributeBoundsFloat(
+  attribute,
+  endpointAttribute,
+  db,
+  zapSessionId
+) {
+  const { size } = await getFloatAttributeSize(
+    db,
+    zapSessionId,
+    attribute.type,
+    attribute.clusterRef
+  )
+  if (size === undefined) {
+    return false
+  }
+  let { min, max } = getBoundsFloat(attribute, size)
+  let defaultValue = getFloatFromAttribute(endpointAttribute.defaultValue, size)
   return checkBoundsFloat(defaultValue, min, max)
 }
 
 /**
- * Get the bounds on a float attribute's value.
+ * Get the bounds on a float attribute's value. When the attribute does
+ * not declare an explicit min/max, the type's representable range is
+ * used as the fallback (mirroring getBoundsInteger).
  *
  * @param {*} attribute
+ * @param {*} typeSize bit width of the float type. When omitted the
+ * 64-bit IEEE 754 range is assumed, which keeps legacy single-argument
+ * callers (e.g. XML pre-validation, which has no session) working.
  * @returns object
  */
-function getBoundsFloat(attribute) {
+function getBoundsFloat(attribute, typeSize) {
   return {
-    min: extractFloatValue(attribute.min),
-    max: extractFloatValue(attribute.max)
+    min:
+      attribute.min != null
+        ? getFloatFromAttribute(attribute.min, typeSize)
+        : getFloatTypeRange(typeSize, true),
+    max:
+      attribute.max != null
+        ? getFloatFromAttribute(attribute.max, typeSize)
+        : getFloatTypeRange(typeSize, false)
   }
 }
 
@@ -589,8 +827,8 @@ function getBoundsFloat(attribute) {
  * @returns boolean
  */
 function checkBoundsFloat(defaultValue, min, max) {
-  if (Number.isNaN(min)) min = Number.MIN_VALUE
-  if (Number.isNaN(max)) max = Number.MAX_VALUE
+  if (min == null || Number.isNaN(min)) min = -Number.MAX_VALUE
+  if (max == null || Number.isNaN(max)) max = Number.MAX_VALUE
   return defaultValue >= min && defaultValue <= max
 }
 
@@ -600,6 +838,7 @@ exports.validateEndpoint = validateEndpoint
 exports.validateNoDuplicateEndpoints = validateNoDuplicateEndpoints
 exports.validateSpecificAttribute = validateSpecificAttribute
 exports.validateSpecificEndpoint = validateSpecificEndpoint
+exports.isMatterSession = isMatterSession
 exports.isValidNumberString = isValidNumberString
 exports.isValidFloat = isValidFloat
 exports.extractFloatValue = extractFloatValue
@@ -608,6 +847,9 @@ exports.getBoundsInteger = getBoundsInteger
 exports.checkBoundsInteger = checkBoundsInteger
 exports.getBoundsFloat = getBoundsFloat
 exports.checkBoundsFloat = checkBoundsFloat
+exports.getFloatAttributeSize = getFloatAttributeSize
+exports.getFloatTypeRange = getFloatTypeRange
+exports.getFloatFromAttribute = getFloatFromAttribute
 exports.unsignedToSignedInteger = unsignedToSignedInteger
 exports.extractBigIntegerValue = extractBigIntegerValue
 exports.getIntegerAttributeSize = getIntegerAttributeSize

--- a/src-script/zap-start.js
+++ b/src-script/zap-start.js
@@ -45,6 +45,11 @@ scriptUtil
         executable = 'node'
         main = scriptUtil.mainPath(false)
         break
+      case 'validate':
+        executable = 'node'
+        main = scriptUtil.mainPath(false)
+        extraArgs = ['--noUi', '--noServer']
+        break
       case 'convert':
         executable = 'node'
         main = scriptUtil.mainPath(false)

--- a/src-shared/rest-api.js
+++ b/src-shared/rest-api.js
@@ -86,7 +86,8 @@ const uri = {
   reloadSession: '/zcl/reloadSession',
   init: '/init',
   forcedExternal: '/zcl/forcedExternal',
-  loadComposition: '/zcl/loadComposition'
+  loadComposition: '/zcl/loadComposition',
+  validate: '/validate'
 }
 
 const uiMode = {

--- a/src/components/ZCLToolbar.vue
+++ b/src/components/ZCLToolbar.vue
@@ -7,7 +7,10 @@
     }"
   >
     <q-toolbar-title
-      :class="{ 'logo-margin': showPreviewTab || showNotificationTab }"
+      :class="{
+        'logo-margin':
+          showPreviewTab || showNotificationTab || showValidationTab
+      }"
       style="width: 180px"
     >
       <Transition mode="out-in" name="slide-up">
@@ -67,6 +70,32 @@
       <div class="text-center">
         <q-icon name="o_save" />
         <div>Save</div>
+      </div>
+    </q-btn>
+    <q-btn
+      id="validate"
+      class="navmenu-item"
+      :class="{ 'navmenu-item--active': showValidationTab }"
+      color="grey"
+      flat
+      no-caps
+      data-cy="btn-validate"
+      title="Validate this configuration, view results in the side panel (click again to close)"
+      @click="toggleValidate"
+    >
+      <div class="text-center">
+        <q-icon name="o_fact_check" />
+        <div>
+          Validate
+          <q-badge
+            v-if="validationIssueBadgeCount > 0"
+            style="top: 5px; right: 5px"
+            color="red"
+            floating
+          >
+            {{ validationIssueBadgeCount }}
+          </q-badge>
+        </div>
       </div>
     </q-btn>
     <q-btn
@@ -289,6 +318,16 @@ export default {
         return this.$store.dispatch('zap/toggleNotificationTab')
       }
     },
+    showValidationTab: {
+      get() {
+        return this.$store.state.zap.showValidationTab
+      }
+    },
+    validationIssueBadgeCount() {
+      const r = this.$store.state.zap.validationReport
+      if (!r?.summary) return 0
+      return r.summary.errors || 0
+    },
     isMultiProtocolTutorialAvailable: {
       get() {
         return this.$store.state.zap.isMultiConfig
@@ -338,13 +377,27 @@ export default {
       if (this.showNotificationTab) {
         this.$store.commit('zap/toggleNotificationTab')
       }
+      if (this.showValidationTab) {
+        this.$store.commit('zap/toggleValidationTab')
+      }
       this.$store.commit('zap/togglePreviewTab')
     },
     toggleNotificationTab() {
       if (this.showPreviewTab) {
         this.$store.commit('zap/togglePreviewTab')
       }
+      if (this.showValidationTab) {
+        this.$store.commit('zap/toggleValidationTab')
+      }
       this.$store.commit('zap/toggleNotificationTab')
+    },
+    /** Opens validation panel: runs checks and shows results; closes panel if already open. */
+    toggleValidate() {
+      if (this.showValidationTab) {
+        this.$store.commit('zap/setShowValidationTab', false)
+        return
+      }
+      this.runValidation()
     },
     generateIntoDirectory(currentPath) {
       window[rendApi.GLOBAL_SYMBOL_NOTIFY](rendApi.notifyKey.fileBrowse, {
@@ -373,6 +426,51 @@ export default {
         })
         .catch((err) => {
           console.log(err)
+        })
+    },
+    runValidation() {
+      if (this.$serverGet == null) return
+      window[rendApi.GLOBAL_SYMBOL_EXECUTE](
+        rendApi.id.progressStart,
+        'Validating configuration...'
+      )
+      this.$serverGet(restApi.uri.validate)
+        .then((resp) => {
+          const body = resp?.data
+          if (body == null) {
+            if (this.$q && this.$q.notify) {
+              this.$q.notify({
+                type: 'negative',
+                message: 'Validation returned no data'
+              })
+            }
+            return
+          }
+          this.$store.commit('zap/setValidationReport', body)
+          if (this.showPreviewTab) {
+            this.$store.commit('zap/togglePreviewTab')
+          }
+          if (this.showNotificationTab) {
+            this.$store.commit('zap/toggleNotificationTab')
+          }
+          this.$store.commit('zap/setShowValidationTab', true)
+        })
+        .catch((err) => {
+          console.error(err)
+          if (this.$q && this.$q.notify) {
+            this.$q.notify({
+              type: 'negative',
+              message:
+                (err.response &&
+                  err.response.data &&
+                  err.response.data.error) ||
+                err.message ||
+                'Validation failed'
+            })
+          }
+        })
+        .finally(() => {
+          window[rendApi.GLOBAL_SYMBOL_EXECUTE](rendApi.id.progressEnd)
         })
     }
   },

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -4,7 +4,7 @@
       <ZCLToolbar />
     </q-header>
     <q-drawer
-      v-if="!showPreviewTab && !showNotificationTab"
+      v-if="!showPreviewTab && !showNotificationTab && !showValidationTab"
       class="bg-glass"
       v-model="leftDrawerOpen"
       show-if-above
@@ -89,6 +89,18 @@
       <NotificationPage />
     </q-drawer>
 
+    <q-drawer
+      :width="$q.screen.width * 0.4"
+      bordered
+      v-model="showValidationTab"
+      side="right"
+      :breakpoint="0"
+      class="bg-glass column"
+      id="ValidationPanel"
+    >
+      <ValidationPanelPage class="col" />
+    </q-drawer>
+
     <q-page-container>
       <router-view v-slot="{ Component }">
         <transition mode="out-in" name="slide-down">
@@ -101,13 +113,15 @@
 <script>
 import ZCLToolbar from '../components/ZCLToolbar.vue'
 import NotificationPage from '../pages/NotificationsPage.vue'
+import ValidationPanelPage from '../pages/ValidationPanelPage.vue'
 import { isElectron, isMac } from '../util/platform'
 const restApi = require(`../../src-shared/rest-api.js`)
 
 export default {
   components: {
     ZCLToolbar,
-    NotificationPage
+    NotificationPage,
+    ValidationPanelPage
   },
   name: 'MainLayout',
   data() {
@@ -143,6 +157,14 @@ export default {
       },
       set() {
         return this.$store.dispatch('zap/showNotificationTab')
+      }
+    },
+    showValidationTab: {
+      get() {
+        return this.$store.state.zap.showValidationTab
+      },
+      set(value) {
+        this.$store.commit('zap/setShowValidationTab', value)
       }
     },
     leftDrawerOpen: {

--- a/src/pages/ValidationPanelPage.vue
+++ b/src/pages/ValidationPanelPage.vue
@@ -1,0 +1,273 @@
+<!--
+Copyright (c) 2025 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+-->
+<template>
+  <div class="column fit">
+    <q-toolbar class="bg-transparent q-px-sm border-bottom">
+      <div class="text-h6">Validation</div>
+      <q-space />
+      <q-btn
+        flat
+        dense
+        icon="refresh"
+        label="Refresh"
+        no-caps
+        data-cy="btn-validation-refresh"
+        :loading="loading"
+        @click="refreshValidation"
+      />
+    </q-toolbar>
+    <q-scroll-area class="col">
+      <div class="q-pa-sm">
+        <div v-if="!validationReport" class="text-grey q-pa-md text-body2">
+          No validation results yet. Click Refresh or choose Validate on the
+          toolbar to run a full check.
+        </div>
+        <template v-else>
+          <div class="text-body2 q-mb-md">
+            <span
+              v-if="validationReport.summary.errors > 0"
+              class="text-negative"
+            >
+              {{ validationReport.summary.errors }} error(s)
+            </span>
+            <span
+              v-if="validationReport.summary.errors === 0"
+              class="text-positive"
+            >
+              No validation issues found.
+            </span>
+            <span class="text-caption q-ml-sm text-grey">
+              Checked {{ validationReport.summary.attributes }} attribute(s),
+              {{ validationReport.summary.endpoints }} endpoint(s),
+              {{ validationReport.summary.clusters }} cluster check(s).
+            </span>
+          </div>
+
+          <q-expansion-item
+            v-if="validationReport.endpoints.length > 0"
+            default-opened
+            icon="settings_input_component"
+            label="Endpoints"
+            header-class="text-subtitle1"
+          >
+            <q-table
+              flat
+              dense
+              :rows="validationReport.endpoints"
+              :columns="endpointIssueColumns"
+              row-key="endpointDbId"
+            >
+              <template #body-cell-issues="props">
+                <q-td :props="props">
+                  <div v-if="props.row.issues.endpointId.length">
+                    <strong>Endpoint ID:</strong>
+                    {{ props.row.issues.endpointId.join('; ') }}
+                  </div>
+                  <div v-if="props.row.issues.networkId.length">
+                    <strong>Network ID:</strong>
+                    {{ props.row.issues.networkId.join('; ') }}
+                  </div>
+                </q-td>
+              </template>
+            </q-table>
+          </q-expansion-item>
+
+          <q-expansion-item
+            v-if="validationReport.attributes.length > 0"
+            default-opened
+            icon="tune"
+            label="Attributes"
+            header-class="text-subtitle1"
+          >
+            <q-table
+              flat
+              dense
+              wrap-cells
+              :rows="validationReport.attributes"
+              :columns="attributeIssueColumns"
+              :row-key="attributeRowKey"
+            >
+              <template #body-cell-issues="props">
+                <q-td :props="props">
+                  {{ props.row.issues.join('; ') }}
+                </q-td>
+              </template>
+            </q-table>
+          </q-expansion-item>
+
+          <q-expansion-item
+            v-if="validationReport.conformance.length > 0"
+            default-opened
+            icon="rule_folder"
+            label="Conformance"
+            header-class="text-subtitle1"
+          >
+            <q-table
+              flat
+              dense
+              wrap-cells
+              :rows="validationReport.conformance"
+              :columns="conformanceIssueColumns"
+              :row-key="conformanceRowKey"
+            >
+              <template #body-cell-warnings="props">
+                <q-td :props="props">
+                  <ul class="q-ma-none">
+                    <li v-for="(w, i) in props.row.warnings" :key="i">
+                      {{ w }}
+                    </li>
+                  </ul>
+                </q-td>
+              </template>
+            </q-table>
+          </q-expansion-item>
+        </template>
+      </div>
+    </q-scroll-area>
+  </div>
+</template>
+
+<script>
+import commonMixin from '../util/common-mixin'
+const restApi = require('../../src-shared/rest-api.js')
+const rendApi = require('../../src-shared/rend-api.js')
+
+export default {
+  name: 'ValidationPanelPage',
+  mixins: [commonMixin],
+  data() {
+    return {
+      loading: false,
+      endpointIssueColumns: [
+        {
+          name: 'endpointId',
+          label: 'Endpoint #',
+          field: 'endpointId',
+          align: 'left'
+        },
+        {
+          name: 'endpointDbId',
+          label: 'DB id',
+          field: 'endpointDbId',
+          align: 'left'
+        },
+        {
+          name: 'issues',
+          label: 'Issues',
+          field: 'issues',
+          align: 'left'
+        }
+      ],
+      attributeIssueColumns: [
+        {
+          name: 'endpointIdentifierLabel',
+          label: 'Endpoint #',
+          field: 'endpointIdentifierLabel',
+          align: 'left'
+        },
+        {
+          name: 'clusterName',
+          label: 'Cluster',
+          field: 'clusterName',
+          align: 'left'
+        },
+        {
+          name: 'attributeName',
+          label: 'Attribute',
+          field: 'attributeName',
+          align: 'left'
+        },
+        {
+          name: 'defaultValue',
+          label: 'Default',
+          field: 'defaultValue',
+          align: 'left'
+        },
+        {
+          name: 'issues',
+          label: 'Issues',
+          field: 'issues',
+          align: 'left'
+        }
+      ],
+      conformanceIssueColumns: [
+        {
+          name: 'endpointId',
+          label: 'Endpoint #',
+          field: 'endpointId',
+          align: 'left'
+        },
+        {
+          name: 'clusterName',
+          label: 'Cluster',
+          field: 'clusterName',
+          align: 'left'
+        },
+        {
+          name: 'warnings',
+          label: 'Issues',
+          field: 'warnings',
+          align: 'left'
+        }
+      ]
+    }
+  },
+  computed: {
+    validationReport() {
+      return this.$store.state.zap.validationReport
+    }
+  },
+  methods: {
+    attributeRowKey(row) {
+      return `${row.endpointTypeId}-${row.clusterRef}-${row.attributeRef}`
+    },
+    conformanceRowKey(row) {
+      return `${row.endpointDbId}-${row.clusterRef}`
+    },
+    refreshValidation() {
+      if (this.$serverGet == null) return
+      this.loading = true
+      window[rendApi.GLOBAL_SYMBOL_EXECUTE](
+        rendApi.id.progressStart,
+        'Validating configuration...'
+      )
+      this.$serverGet(restApi.uri.validate)
+        .then((resp) => {
+          const body = resp?.data
+          if (body == null) {
+            if (this.$q && this.$q.notify) {
+              this.$q.notify({
+                type: 'negative',
+                message: 'Validation returned no data'
+              })
+            }
+            return
+          }
+          this.$store.commit('zap/setValidationReport', body)
+        })
+        .catch((err) => {
+          console.error(err)
+          if (this.$q && this.$q.notify) {
+            this.$q.notify({
+              type: 'negative',
+              message:
+                (err.response &&
+                  err.response.data &&
+                  err.response.data.error) ||
+                err.message ||
+                'Validation failed'
+            })
+          }
+        })
+        .finally(() => {
+          this.loading = false
+          window[rendApi.GLOBAL_SYMBOL_EXECUTE](rendApi.id.progressEnd)
+        })
+    }
+  }
+}
+</script>

--- a/src/store/zap/mutations.js
+++ b/src/store/zap/mutations.js
@@ -47,6 +47,18 @@ export const toggleNotificationTab = (state) => {
   state.showNotificationTab = !state.showNotificationTab
 }
 
+export const toggleValidationTab = (state) => {
+  state.showValidationTab = !state.showValidationTab
+}
+
+export const setShowValidationTab = (state, value) => {
+  state.showValidationTab = value
+}
+
+export const setValidationReport = (state, report) => {
+  state.validationReport = report
+}
+
 export const updateShowDevTools = (state) => {
   state.showDevTools = !state.showDevTools
 }

--- a/src/store/zap/state.js
+++ b/src/store/zap/state.js
@@ -36,6 +36,8 @@ export default function () {
     showCreateModifyEndpoint: false,
     showPreviewTab: false,
     showNotificationTab: false,
+    showValidationTab: false,
+    validationReport: null,
     isExceptionsExpanded: false,
     exceptions: [],
     showExceptionIcon: false,

--- a/test/arg.test.js
+++ b/test/arg.test.js
@@ -64,6 +64,41 @@ test(
 )
 
 test(
+  'validate: --logToStdout is boolean and does not consume the .zap path',
+  () => {
+    let a = args.processCommandLineArguments([
+      'node',
+      'main.js',
+      '--noUi',
+      '--noServer',
+      'validate',
+      '--logToStdout',
+      '/tmp/test.zap'
+    ])
+    expect(a.logToStdout).toBe(true)
+    expect(a.zapFiles).toEqual(['/tmp/test.zap'])
+  },
+  timeout.short()
+)
+
+test(
+  'validate: -i a,b is split into two zap paths',
+  () => {
+    let a = args.processCommandLineArguments([
+      'node',
+      'main.js',
+      '--noUi',
+      '--noServer',
+      'validate',
+      '-i',
+      '/tmp/one.zap,/tmp/two.zap'
+    ])
+    expect(a.zapFiles).toEqual(['/tmp/one.zap', '/tmp/two.zap'])
+  },
+  timeout.short()
+)
+
+test(
   'Verify how yargs works',
   () => {
     let argv = yargs(['a', '--x', 1, 'b', '--y', 2, '--tst', 42]).parse()

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -33,6 +33,11 @@ const env = require('../src-electron/util/env')
 const types = require('../src-electron/util/types')
 const { timeout } = require('./test-util')
 const queryPackageNotification = require('../src-electron/db/query-package-notification')
+const validateAll = require('../src-electron/validation/validate-all')
+const importJs = require('../src-electron/importexport/import.js')
+const util = require('../src-electron/util/util.js')
+const generatorEngine = require('../src-electron/generator/generation-engine.js')
+const path = require('path')
 
 let db
 let sid
@@ -197,9 +202,9 @@ test(
     expect(validation.checkBoundsInteger(-32, -128, 127)).toBeTruthy()
 
     //Float
-    expect(validation.checkBoundsFloat(35.0, 25, 50.0))
-    expect(!validation.checkBoundsFloat(351.0, 25, 50.0))
-    expect(!validation.checkBoundsFloat(351.0, 355, 5650.0))
+    expect(validation.checkBoundsFloat(35.0, 25, 50.0)).toBeTruthy()
+    expect(validation.checkBoundsFloat(351.0, 25, 50.0)).toBeFalsy()
+    expect(validation.checkBoundsFloat(351.0, 355, 5650.0)).toBeFalsy()
   },
   timeout.medium()
 )
@@ -569,6 +574,206 @@ test(
   timeout.medium()
 )
 
+describe('Float validation', () => {
+  test(
+    'sync helpers (type range, extract, bounds, getBoundsFloat)',
+    () => {
+      const fltMax = 3.4028234663852886e38
+      ;[
+        [16, true, -65504],
+        [16, false, 65504],
+        [32, true, -fltMax],
+        [32, false, fltMax],
+        [64, true, -Number.MAX_VALUE],
+        [64, false, Number.MAX_VALUE]
+      ].forEach(([bits, isMin, exp]) =>
+        expect(validation.getFloatTypeRange(bits, isMin)).toBeCloseTo(exp)
+      )
+      expect(validation.getFloatTypeRange(undefined, true)).toBe(
+        -Number.MAX_VALUE
+      )
+      expect(validation.getFloatTypeRange(99, false)).toBe(Number.MAX_VALUE)
+
+      expect(Number.isNaN(validation.extractFloatValue(null))).toBeTruthy()
+      expect(
+        Number.isNaN(validation.extractFloatValue('0x42C80000'))
+      ).toBeTruthy()
+      expect(validation.extractFloatValue('1.5')).toBe(1.5)
+
+      expect(validation.checkBoundsFloat(0, NaN, NaN)).toBeTruthy()
+      expect(validation.checkBoundsFloat(0, null, null)).toBeTruthy()
+      expect(validation.checkBoundsFloat(NaN, 0, 10)).toBeFalsy()
+
+      const b = validation.getBoundsFloat({ min: '0.5', max: '2.5' }, 32)
+      expect(b.min).toBe(0.5)
+      expect(b.max).toBe(2.5)
+      const s = validation.getBoundsFloat({}, 32)
+      expect(s.min).toBeCloseTo(-fltMax)
+      expect(s.max).toBeCloseTo(fltMax)
+      const h = validation.getBoundsFloat({}, 16)
+      expect(h.min).toBeCloseTo(-65504)
+      expect(h.max).toBeCloseTo(65504)
+      const ns = validation.getBoundsFloat({})
+      expect(ns.min).toBe(-Number.MAX_VALUE)
+      expect(ns.max).toBe(Number.MAX_VALUE)
+      const om = validation.getBoundsFloat({ min: '-1' }, 32)
+      expect(om.min).toBe(-1)
+      expect(om.max).toBeCloseTo(fltMax)
+      const ox = validation.getBoundsFloat(
+        { min: '0x00000000', max: '0x3F800000' },
+        32
+      )
+      expect(ox.min).toBe(0)
+      expect(ox.max).toBeCloseTo(1.0)
+      const oxNs = validation.getBoundsFloat({
+        min: '0x00000000',
+        max: '0x3F800000'
+      })
+      expect(Number.isNaN(oxNs.min)).toBeTruthy()
+      expect(Number.isNaN(oxNs.max)).toBeTruthy()
+    },
+    timeout.short()
+  )
+
+  test(
+    'getFloatFromAttribute / isValidFloat (IEEE hex + rejections)',
+    () => {
+      const g = validation.getFloatFromAttribute
+      const close = [
+        ['0x3C00', 16, 1],
+        ['0x4000', 16, 2],
+        ['0xBC00', 16, -1],
+        ['0xFBFF', 16, -65504],
+        ['0x3F800000', 32, 1],
+        ['0x40000000', 32, 2],
+        ['0xBF800000', 32, -1],
+        ['0x7F7FFFFF', 32, 3.4028234663852886e38],
+        ['0x3FF0000000000000', 64, 1],
+        ['0xBFF0000000000000', 64, -1]
+      ]
+      close.forEach(([hex, bits, exp]) => expect(g(hex, bits)).toBeCloseTo(exp))
+      expect(g('0x0000', 16)).toBe(0)
+      expect(g('0x00000000', 32)).toBe(0)
+      expect(g('0x0000000000000000', 64)).toBe(0)
+      expect(g('0x7C00', 16)).toBe(Infinity)
+      expect(g('0xFC00', 16)).toBe(-Infinity)
+      expect(Number.isNaN(g('0x7E00', 16))).toBeTruthy()
+      expect(g('0x7FEFFFFFFFFFFFFF', 64)).toBe(Number.MAX_VALUE)
+      expect(g('1.5', 32)).toBe(1.5)
+      expect(g('0', undefined)).toBe(0)
+      ;[
+        ['0x3F800000', undefined],
+        ['0x3F800000', 16],
+        ['0x3FF0000000000000', 32],
+        ['0x3C00', 24],
+        ['0x12GH', 16],
+        [null, 32]
+      ].forEach(([h, b]) => expect(Number.isNaN(g(h, b))).toBeTruthy())
+
+      expect(validation.isValidFloat('0x3F800000')).toBeFalsy()
+      expect(validation.isValidFloat('0x3F800000', 32)).toBeTruthy()
+      expect(validation.isValidFloat('0x3F800000', 16)).toBeFalsy()
+      expect(validation.isValidFloat('0x000G', 32)).toBeFalsy()
+    },
+    timeout.short()
+  )
+
+  test(
+    'getFloatAttributeSize and validateSpecificAttribute (float)',
+    async () => {
+      const sz = (t) => validation.getFloatAttributeSize(db, sid, t, null)
+      expect((await sz('float_semi')).size).toBe(16)
+      expect((await sz('float_single')).size).toBe(32)
+      expect((await sz('float_double')).size).toBe(64)
+      expect(
+        (await sz('definitely_not_a_real_float_type')).size
+      ).toBeUndefined()
+
+      const run = async (dv, attr) =>
+        (
+          await validation.validateSpecificAttribute(
+            { defaultValue: dv },
+            attr,
+            db,
+            sid
+          )
+        ).defaultValue
+
+      const cases = [
+        ['1.5', { type: 'float_single', min: '0.5', max: '2.5' }, 'ok'],
+        [
+          '0.25',
+          { type: 'float_single', min: '0.5', max: '2.5' },
+          'Out of range'
+        ],
+        [
+          '4.5',
+          { type: 'float_single', min: '0.5', max: '2.5' },
+          'Out of range'
+        ],
+        ['-1.0', { type: 'float_single', min: '-2.0', max: '2.0' }, 'ok'],
+        [
+          'not a number',
+          { type: 'float_single', min: '0', max: '10' },
+          'Invalid Float'
+        ],
+        [
+          '1.2.3',
+          { type: 'float_single', min: '0', max: '10' },
+          'Invalid Float'
+        ],
+        [
+          '0x3F8000GG',
+          { type: 'float_single', min: '0', max: '10' },
+          'Invalid Float'
+        ],
+        [
+          '0x3F8000000000',
+          { type: 'float_single', min: '0', max: '10' },
+          'Invalid Float'
+        ],
+        ['1e40', { type: 'float_single' }, 'Out of range'],
+        ['1e40', { type: 'float_double' }, 'ok'],
+        ['70000', { type: 'float_semi' }, 'Out of range'],
+        ['65504', { type: 'float_semi' }, 'ok'],
+        [
+          null,
+          { type: 'float_single', isNullable: true, min: '0', max: '1' },
+          'ok'
+        ],
+        ['0x3F800000', { type: 'float_single', min: '0', max: '2' }, 'ok'],
+        [
+          '0xC0000000',
+          { type: 'float_single', min: '0', max: '2' },
+          'Out of range'
+        ],
+        ['0x3C00', { type: 'float_semi', min: '0', max: '2' }, 'ok'],
+        [
+          '0x3FF0000000000000',
+          { type: 'float_double', min: '0', max: '2' },
+          'ok'
+        ],
+        [
+          '0.5',
+          { type: 'float_single', min: '0x00000000', max: '0x3F800000' },
+          'ok'
+        ],
+        [
+          '1.5',
+          { type: 'float_single', min: '0x00000000', max: '0x3F800000' },
+          'Out of range'
+        ]
+      ]
+      for (const [dv, attr, want] of cases) {
+        const issues = await run(dv, attr)
+        if (want === 'ok') expect(issues.length).toBe(0)
+        else expect(issues).toContain(want)
+      }
+    },
+    timeout.medium()
+  )
+})
+
 describe('Validate endpoint for duplicate endpointIds', () => {
   let endpointTypeIdOnOff
   let endpointTypeReference
@@ -609,6 +814,23 @@ describe('Validate endpoint for duplicate endpointIds', () => {
     )
     endpointTypeIdOnOff = rowId
     let endpointType = await queryEndpointType.selectEndpointType(db, rowId)
+    // The schema's UNIQUE(ENDPOINT_TYPE_REF, ENDPOINT_IDENTIFIER) plus
+    // INSERT OR REPLACE in queryEndpoint.insertEndpoint means the only way
+    // to actually have two endpoints sharing an identifier is to put them
+    // on different endpoint types, so create a second endpoint type here.
+    let secondEndpointTypeRowId = await queryConfig.insertEndpointType(
+      db,
+      sessionPartitionInfo[0],
+      'testEndpointTypeDup',
+      deviceTypeId,
+      haOnOffDeviceType.code,
+      0,
+      true
+    )
+    let secondEndpointType = await queryEndpointType.selectEndpointType(
+      db,
+      secondEndpointTypeRowId
+    )
     await queryEndpoint.insertEndpoint(
       db,
       sid,
@@ -621,7 +843,7 @@ describe('Validate endpoint for duplicate endpointIds', () => {
       db,
       sid,
       1,
-      endpointType.endpointTypeId,
+      secondEndpointType.endpointTypeId,
       1,
       23
     )
@@ -631,10 +853,143 @@ describe('Validate endpoint for duplicate endpointIds', () => {
     () =>
       validation
         .validateEndpoint(db, eptId)
-        .then((data) => validation.validateNoDuplicateEndpoints(db, eptId, sid))
+        .then((data) => validation.validateNoDuplicateEndpoints(db, 1, sid))
         .then((hasNoDuplicates) => {
           expect(hasNoDuplicates).toBeFalsy()
         }),
+    timeout.medium()
+  )
+})
+
+describe('validateAll', () => {
+  let vdb
+  beforeAll(async () => {
+    let file = env.sqliteTestFile('validate-all')
+    vdb = await dbApi.initDatabaseAndLoadSchema(
+      file,
+      env.schemaFile(),
+      env.zapVersion()
+    )
+    await zclLoader.loadZcl(vdb, env.builtinMatterZclMetafile())
+    let ctx = await generatorEngine.loadTemplates(
+      vdb,
+      env.builtinTemplateMetafile(),
+      {
+        failOnLoadingError: true
+      }
+    )
+    if (ctx.error) {
+      throw ctx.error
+    }
+  }, timeout.long())
+  afterAll(() => dbApi.closeDatabase(vdb), timeout.short())
+
+  test(
+    'full session validation report for matter-test.zap',
+    async () => {
+      const zapPath = path.join(__dirname, 'resource/matter-test.zap')
+      const importResult = await importJs.importDataFromFile(vdb, zapPath, {
+        defaultZclMetafile: env.builtinMatterZclMetafile(),
+        packageMatch: 'fuzzy'
+      })
+      await util.ensurePackagesAndPopulateSessionOptions(
+        vdb,
+        importResult.sessionId,
+        {
+          zcl: env.builtinMatterZclMetafile(),
+          template: env.builtinTemplateMetafile()
+        }
+      )
+      const report = await validateAll.validateAll(vdb, importResult.sessionId)
+      expect(report.summary).toBeDefined()
+      expect(typeof report.summary.errors).toBe('number')
+      expect(typeof report.summary.warnings).toBe('number')
+      expect(report.summary.endpoints).toBeGreaterThan(0)
+      expect(report.summary.attributes).toBeGreaterThan(0)
+      expect(Array.isArray(report.endpoints)).toBe(true)
+      expect(Array.isArray(report.attributes)).toBe(true)
+      expect(Array.isArray(report.conformance)).toBe(true)
+    },
+    timeout.long()
+  )
+})
+
+describe('validateSpecificEndpoint Matter root-node handling', () => {
+  test(
+    'flags endpoint 0 in a non-Matter (Zigbee) session',
+    () => {
+      const issues = validation.validateSpecificEndpoint(
+        { endpointId: '0', networkId: '0' },
+        { isMatter: false }
+      )
+      expect(issues.endpointId).toContain('0 is not a valid endpointId')
+    },
+    timeout.short()
+  )
+
+  test(
+    'allows endpoint 0 in a Matter session (Root Node)',
+    () => {
+      const issues = validation.validateSpecificEndpoint(
+        { endpointId: '0', networkId: '0' },
+        { isMatter: true }
+      )
+      expect(issues.endpointId).not.toContain('0 is not a valid endpointId')
+    },
+    timeout.short()
+  )
+
+  test(
+    'still flags out-of-range endpoint ids in Matter sessions',
+    () => {
+      const issues = validation.validateSpecificEndpoint(
+        { endpointId: '0xFFFFFF', networkId: '0' },
+        { isMatter: true }
+      )
+      expect(issues.endpointId).toContain('EndpointId is out of valid range')
+    },
+    timeout.short()
+  )
+})
+
+describe('validate-all null pre-check', () => {
+  let nvdb
+  let nsid
+  beforeAll(async () => {
+    let file = env.sqliteTestFile('validate-all-null')
+    nvdb = await dbApi.initDatabaseAndLoadSchema(
+      file,
+      env.schemaFile(),
+      env.zapVersion()
+    )
+    await zclLoader.loadZcl(nvdb, env.builtinSilabsZclMetafile())
+    nsid = await testQuery.createSession(
+      nvdb,
+      'USER',
+      'NULL_EP_SESSION',
+      env.builtinSilabsZclMetafile(),
+      env.builtinTemplateMetafile()
+    )
+    await dbApi.dbInsert(
+      nvdb,
+      'INSERT INTO ENDPOINT (SESSION_REF, ENDPOINT_TYPE_REF, ENDPOINT_IDENTIFIER, NETWORK_IDENTIFIER) VALUES (?, NULL, NULL, NULL)',
+      [nsid]
+    )
+  }, timeout.long())
+  afterAll(() => dbApi.closeDatabase(nvdb), timeout.short())
+
+  test(
+    'validateAll flags endpoints with a missing identifier',
+    async () => {
+      const report = await validateAll.validateAll(nvdb, nsid, {
+        conformance: false
+      })
+      expect(report.endpoints.length).toBeGreaterThan(0)
+      const allEndpointIssues = report.endpoints.flatMap(
+        (e) => e.issues.endpointId
+      )
+      expect(allEndpointIssues).toContain('EndpointId is missing')
+    },
     timeout.medium()
   )
 })


### PR DESCRIPTION
- Add validate-all session orchestration and GET /validate REST support
- Wire main-process startValidate: merged report, optional file or stdout
- CLI: register logToStdout; support multiple .zap paths (positionals, repeat -i, comma-separated for validate)
- Conformance: optional skip writing SESSION_NOTICE during bulk validate so that it does not go into session notifications on every run
- Validation: Matter root endpoint 0, session-wide duplicate check fix, external storage attribute skip; validate-all null endpoint pre-check
- UI: Validate in ZCL toolbar, side panel (ValidationPanelPage), layout/store
- Docs: add docs/validating-zap-files.md; trim README to link developer docs
- Tests: extend arg and validation tests; fix duplicate-endpoint test data
- Github: ZAP #1678