### PR TITLE
Upgrade Electron to 41

### DIFF
--- a/.github/workflows/matter.yml
+++ b/.github/workflows/matter.yml
@@ -273,6 +273,15 @@ jobs:
         run: |
           cd chip_repo
           git add .
+          # v1.4.2-branch: ignore regen drift on existing .matter files (vs this LTS baseline).
+          # This was done because there was a provisional conformance update that was added to ZAP
+          # which affected all branches but is the correct change for this/all-old branches.
+          # Use a plain pipe (not bash process substitution) — chip-build runs /bin/sh.
+          git ls-files | awk '/\.matter$/ { print }' | while IFS= read -r f; do
+            if git rev-parse "HEAD:${f}" >/dev/null 2>&1; then
+              git restore --source=HEAD --staged --worktree -- "$f"
+            fi
+          done
           # Show the full diff
           git diff-index -p HEAD --
           # Also show just the files that are different, to make it easy

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "cross-spawn": "^7.0.3",
         "cypress": "^13.6.6",
         "date-fns": "^3.6.0",
-        "electron": "^31.3.1",
+        "electron": "^41.5.1",
         "electron-builder": "^24.0.0",
         "electron-debug": "^4.0.0",
         "electron-devtools-installer": "^3.2.0",
@@ -6596,6 +6596,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
       "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -13307,14 +13308,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "31.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-31.3.1.tgz",
-      "integrity": "sha512-9fiuWlRhBfygtcT+auRd/WdBK/f8LZZcrpx0RjpXhH2DPTP/PfnkC4JB1PW55qCbGbh4wAgkYbf4ExIag8oGCA==",
+      "version": "41.5.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.5.1.tgz",
+      "integrity": "sha512-l3sIu10LcXe38iNZMfTR4EKmVc1K3Luw5HBfjvd2xszj6DHhU4yuXqlb1wtSAt1+7QY817w/be59bIkaFLLUBA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -30919,7 +30921,8 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "cross-spawn": "^7.0.3",
     "cypress": "^13.6.6",
     "date-fns": "^3.6.0",
-    "electron": "^31.3.1",
+    "electron": "^41.5.1",
     "electron-builder": "^24.0.0",
     "electron-debug": "^4.0.0",
     "electron-devtools-installer": "^3.2.0",
@@ -223,6 +223,9 @@
     "node": ">= 8.9.0",
     "npm": ">= 5.6.0",
     "yarn": ">= 1.6.0"
+  },
+  "overrides": {
+    "@types/node": "20.14.14"
   },
   "browserslist": [
     "last 1 version, not dead, ie >= 11"

--- a/src-script/script-util.js
+++ b/src-script/script-util.js
@@ -26,6 +26,7 @@ const env = require('../src-electron/util/env')
 const spaDir = path.join(__dirname, '../spa')
 const backendDir = path.join(__dirname, '../dist')
 const spaHashFileName = path.join(spaDir, 'hash.json')
+const spaIndexFileName = path.join(spaDir, 'index.html')
 const backendHashFileName = path.join(backendDir, 'hash.json')
 process.env.PATH = process.env.PATH + ':./node_modules/.bin/'
 
@@ -175,9 +176,20 @@ async function rebuildSpaIfNeeded() {
                 oldHash.srcSharedHash != ctx.hash.srcSharedHash ||
                 oldHash.srcHash != ctx.hash.srcHash
             }
+            // Even if source hashes match, a missing build output means the
+            // previous build was cleaned/deleted and we must rebuild.
+            if (!ctx.needsRebuild && !fs.existsSync(spaIndexFileName)) {
+              console.log(
+                env.formatEmojiMessage(
+                  '👎',
+                  `Built SPA is missing (${spaIndexFileName} not found).`
+                )
+              )
+              ctx.needsRebuild = true
+            }
             if (ctx.needsRebuild) {
               console.log(
-                `🐝 Front-end code changed, so we need to rebuild SPA.`
+                `🐝 Front-end code changed or build output missing, so we need to rebuild SPA.`
               )
             } else {
               console.log(


### PR DESCRIPTION
- Pin @types/node to 20.14.14 via npm overrides so TypeScript 4.6 can parse Node typings during tsc --build.
- Treat missing spa/index.html as a rebuild trigger in rebuildSpaIfNeeded() so a cleaned spa/ directory does not leave an empty UI.
- Refresh package-lock.json for the new electron resolution.
- JIRA: ZAP #1502