### PR TITLE
Skip Node/Electron version warnings for packaged binaries.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19277,6 +19277,7 @@ Environment utilities for ZAP
     * [~logDebug(msg, err)](#module_JS API_ Environment utilities..logDebug)
     * [~logWarningToFile(msg)](#module_JS API_ Environment utilities..logWarningToFile)
     * [~isMatchingVersion(versionsArray, providedVersion)](#module_JS API_ Environment utilities..isMatchingVersion) ⇒
+    * [~isPackagedElectronApp()](#module_JS API_ Environment utilities..isPackagedElectronApp) ⇒ <code>boolean</code>
     * [~versionsCheck()](#module_JS API_ Environment utilities..versionsCheck) ⇒
     * [~httpStaticContent()](#module_JS API_ Environment utilities..httpStaticContent) ⇒
     * [~formatEmojiMessage(emoji, message)](#module_JS API_ Environment utilities..formatEmojiMessage) ⇒ <code>string</code>
@@ -19620,12 +19621,21 @@ Returns true if major or minor component of versions is different.
 | versionsArray | <code>\*</code> | 
 | providedVersion | <code>\*</code> | 
 
+<a name="module_JS API_ Environment utilities..isPackagedElectronApp"></a>
+
+### JS API: Environment utilities~isPackagedElectronApp() ⇒ <code>boolean</code>
+True when running inside a packaged Electron binary.
+Node/Electron versions are fixed at build time there, so version
+warnings are not actionable for the user.
+
+**Kind**: inner method of [<code>JS API: Environment utilities</code>](#module_JS API_ Environment utilities)  
 <a name="module_JS API_ Environment utilities..versionsCheck"></a>
 
 ### JS API: Environment utilities~versionsCheck() ⇒
 Returns true if versions of node and electron are matching.
 If versions are not matching, it  prints out a warhing
 and returns false.
+Skipped for packaged Electron binaries (runtime is fixed at build time).
 
 **Kind**: inner method of [<code>JS API: Environment utilities</code>](#module_JS API_ Environment utilities)  
 **Returns**: true or false, depending on match  

--- a/docs/api.md
+++ b/docs/api.md
@@ -19633,7 +19633,7 @@ warnings are not actionable for the user.
 
 ### JS API: Environment utilities~versionsCheck() ⇒
 Returns true if versions of node and electron are matching.
-If versions are not matching, it  prints out a warhing
+If versions are not matching, it  prints out a warning
 and returns false.
 Skipped for packaged Electron binaries (runtime is fixed at build time).
 

--- a/src-electron/util/env.js
+++ b/src-electron/util/env.js
@@ -583,14 +583,53 @@ function isMatchingVersion(versionsArray, providedVersion) {
 }
 
 /**
+ * True when running inside a packaged Electron binary.
+ * Node/Electron versions are fixed at build time there, so version
+ * warnings are not actionable for the user.
+ *
+ * @returns {boolean}
+ */
+function isPackagedElectronApp() {
+  if (process.versions.electron == null) {
+    return false
+  }
+  try {
+    // Under Electron this is the API object; under plain Node the electron
+    // package exports a path string to the binary.
+    const electron = require('electron')
+    if (
+      electron == null ||
+      typeof electron === 'string' ||
+      electron.app == null
+    ) {
+      return false
+    }
+    return electron.app.isPackaged === true
+  } catch (e) {
+    return false
+  }
+}
+
+/**
  * Returns true if versions of node and electron are matching.
  * If versions are not matching, it  prints out a warhing
  * and returns false.
+ * Skipped for packaged Electron binaries (runtime is fixed at build time).
  *
  * @returns true or false, depending on match
  */
 function versionsCheck() {
-  let expectedNodeVersion = ['v14.x.x', 'v16.x.x', 'v18.x.x', 'v20.x.x']
+  if (isPackagedElectronApp()) {
+    return true
+  }
+  let expectedNodeVersion = [
+    'v14.x.x',
+    'v16.x.x',
+    'v18.x.x',
+    'v20.x.x',
+    'v22.x.x',
+    'v24.x.x'
+  ]
   let expectedElectronVersion = [
     '17.4.x',
     '18.x.x',

--- a/src-electron/util/env.js
+++ b/src-electron/util/env.js
@@ -597,14 +597,7 @@ function isPackagedElectronApp() {
     // Under Electron this is the API object; under plain Node the electron
     // package exports a path string to the binary.
     const electron = require('electron')
-    if (
-      electron == null ||
-      typeof electron === 'string' ||
-      electron.app == null
-    ) {
-      return false
-    }
-    return electron.app.isPackaged === true
+    return electron?.app?.isPackaged === true
   } catch (e) {
     return false
   }

--- a/src-electron/util/env.js
+++ b/src-electron/util/env.js
@@ -25,6 +25,7 @@ const path = require('path')
 const os = require('os')
 const fs = require('fs')
 const pino = require('pino')
+const electron = require('electron')
 const emojiUtil = require('./emoji-util')
 const zapBaseUrl = 'http://localhost:'
 
@@ -593,14 +594,9 @@ function isPackagedElectronApp() {
   if (process.versions.electron == null) {
     return false
   }
-  try {
-    // Under Electron this is the API object; under plain Node the electron
-    // package exports a path string to the binary.
-    const electron = require('electron')
-    return electron?.app?.isPackaged === true
-  } catch (e) {
-    return false
-  }
+  // Under Electron this is the API object; under plain Node the electron
+  // package exports a path string to the binary.
+  return electron?.app?.isPackaged === true
 }
 
 /**

--- a/src-electron/util/env.js
+++ b/src-electron/util/env.js
@@ -612,7 +612,7 @@ function isPackagedElectronApp() {
 
 /**
  * Returns true if versions of node and electron are matching.
- * If versions are not matching, it  prints out a warhing
+ * If versions are not matching, it  prints out a warning
  * and returns false.
  * Skipped for packaged Electron binaries (runtime is fixed at build time).
  *


### PR DESCRIPTION
Packaged Electron runtimes are fixed at build time, so those checks are not actionable; also allow Node 22/24 for source runs with Electron 41.