### PR TITLE
Allow template control over endpoint_config attribute metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This software is licensed under [Apache 2.0 license](LICENSE.txt).
 - [Validating `.zap` files](docs/validating-zap-files.md)
 - [ZAP Template Helpers](docs/helpers.md)
 - [ZAP External Template Helpers](docs/external-helpers.md)
+- [Endpoint configuration generation](docs/endpoint-config-generation.md)
 - [ZAP file Extensions](docs/zap-file-extensions.md)
 - [Upgrading ZAP files with GSDK upgrades](docs/zap-file-upgrade.md)
 - [FAQ/Developer dependencies](docs/faq.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,6 +109,21 @@ across different query files.</p>
 <dt><a href="#module_DB API_ zcl database access">DB API: zcl database access</a></dt>
 <dd><p>This module provides queries for ZCL static queries.</p>
 </dd>
+<dt><a href="#Generator_ endpoint configuration formatters">Generator: endpoint configuration formatters</a></dt>
+<dd><p>Formatting of individual endpoint configuration rows.</p>
+<p>The endpoint configuration is produced in three layers:</p>
+<ol>
+<li>collection: <code>helper-endpointconfig.js</code> turns the session database into
+lists of plain objects (attributes, clusters, commands, ...).</li>
+<li>formatting: this module turns one such object into the C tokens that
+end up in the generated file.</li>
+<li>layout: templates decide where those tokens go, either through the
+aggregate helpers in <code>helper-endpointconfig.js</code> or through the
+iterators in <code>helper-endpointconfig-iterators.js</code>.</li>
+</ol>
+<p>Functions here are pure: no database, no handlebars context. That is what
+lets the aggregate helpers and the per-row helpers emit identical output.</p>
+</dd>
 <dt><a href="#module_JS API_ generator logic">JS API: generator logic</a></dt>
 <dd></dd>
 <dt><a href="#module_Templating API_ Access helpers">Templating API: Access helpers</a></dt>
@@ -122,6 +137,19 @@ across different query files.</p>
 </dd>
 <dt><a href="#module_Templating API_ Command helpers">Templating API: Command helpers</a></dt>
 <dd><p>This module contains the API for templating. For more detailed instructions, read {@tutorial template-tutorial}</p>
+</dd>
+<dt><a href="#module_Templating API_ Matter endpoint config iterators">Templating API: Matter endpoint config iterators</a></dt>
+<dd><p>Iterators over the endpoint configuration.</p>
+<p>The helpers in <code>helper-endpointconfig.js</code> return a whole generated table as
+a single string, which means the layout of that table is decided in
+javascript. The helpers here iterate the same data one row at a time, so a
+template can decide the layout, annotate rows, group them, or leave them
+out. All of them are used inside <code>{{#endpoint_config}}</code>, which is what
+collects the data.</p>
+<p>Companion formatting helpers turn the current row into the C tokens that the
+table needs, so a template can reproduce the output of the aggregate helpers
+exactly, and then change only the part it cares about.</p>
+<p>See docs/endpoint-config-generation.md for the guide and examples.</p>
 </dd>
 <dt><a href="#module_Templating API_ Matter endpoint config helpers">Templating API: Matter endpoint config helpers</a></dt>
 <dd><p>This module contains the API for templating. For more detailed instructions, read {@tutorial template-tutorial}</p>
@@ -8505,6 +8533,236 @@ Get endpoint type events from the given endpoint type ID.
 | db | <code>\*</code> | 
 | endpointTypeId | <code>\*</code> | 
 
+<a name="Generator_ endpoint configuration formatters"></a>
+
+## Generator: endpoint configuration formatters
+Formatting of individual endpoint configuration rows.
+
+The endpoint configuration is produced in three layers:
+  1. collection: `helper-endpointconfig.js` turns the session database into
+     lists of plain objects (attributes, clusters, commands, ...).
+  2. formatting: this module turns one such object into the C tokens that
+     end up in the generated file.
+  3. layout: templates decide where those tokens go, either through the
+     aggregate helpers in `helper-endpointconfig.js` or through the
+     iterators in `helper-endpointconfig-iterators.js`.
+
+Functions here are pure: no database, no handlebars context. That is what
+lets the aggregate helpers and the per-row helpers emit identical output.
+
+
+* [Generator: endpoint configuration formatters](#Generator_ endpoint configuration formatters)
+    * [~maskExpression(mask, macro)](#Generator_ endpoint configuration formatters..maskExpression) ⇒
+    * [~attributeMask(mask)](#Generator_ endpoint configuration formatters..attributeMask) ⇒
+    * [~clusterMask(mask)](#Generator_ endpoint configuration formatters..clusterMask) ⇒
+    * [~commandMask(mask)](#Generator_ endpoint configuration formatters..commandMask) ⇒
+    * [~endianOptions(hash)](#Generator_ endpoint configuration formatters..endianOptions) ⇒
+    * [~attributeDefaultValue(attribute, hash)](#Generator_ endpoint configuration formatters..attributeDefaultValue) ⇒
+    * [~attributeItems(attribute, order, hash)](#Generator_ endpoint configuration formatters..attributeItems) ⇒
+    * [~minMaxValues(minMax, category)](#Generator_ endpoint configuration formatters..minMaxValues) ⇒
+    * [~asCastHex(value)](#Generator_ endpoint configuration formatters..asCastHex) ⇒
+    * [~minMaxItems(minMax, order, category)](#Generator_ endpoint configuration formatters..minMaxItems) ⇒
+    * [~longDefaultValue(longDefault, hash)](#Generator_ endpoint configuration formatters..longDefaultValue) ⇒
+    * [~reportingItems(report, order, minMaxOrder)](#Generator_ endpoint configuration formatters..reportingItems) ⇒
+    * [~parseClusterTokens(value)](#Generator_ endpoint configuration formatters..parseClusterTokens) ⇒
+    * [~clusterMatches(cluster, tokens)](#Generator_ endpoint configuration formatters..clusterMatches) ⇒
+
+<a name="Generator_ endpoint configuration formatters..maskExpression"></a>
+
+### Generator: endpoint configuration formatters~maskExpression(mask, macro) ⇒
+Formats an array of mask names into a C expression.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: '0' for an empty mask, or the masks combined with '|'  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| mask | <code>\*</code> | array of mask names |
+| macro | <code>\*</code> | name of the wrapping macro |
+
+<a name="Generator_ endpoint configuration formatters..attributeMask"></a>
+
+### Generator: endpoint configuration formatters~attributeMask(mask) ⇒
+Formats the mask of a single attribute.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: attribute mask expression  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| mask | <code>\*</code> | array of mask names |
+
+<a name="Generator_ endpoint configuration formatters..clusterMask"></a>
+
+### Generator: endpoint configuration formatters~clusterMask(mask) ⇒
+Formats the mask of a single cluster. Reporting configuration rows use the
+cluster mask macro as well.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: cluster mask expression  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| mask | <code>\*</code> | array of mask names |
+
+<a name="Generator_ endpoint configuration formatters..commandMask"></a>
+
+### Generator: endpoint configuration formatters~commandMask(mask) ⇒
+Formats the mask of a single command.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: command mask expression  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| mask | <code>\*</code> | array of mask names |
+
+<a name="Generator_ endpoint configuration formatters..endianOptions"></a>
+
+### Generator: endpoint configuration formatters~endianOptions(hash) ⇒
+Reads the endianness and pointer size out of template hash arguments.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: object with littleEndian and pointerSize  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| hash | <code>\*</code> | handlebars hash arguments, may be undefined |
+
+<a name="Generator_ endpoint configuration formatters..attributeDefaultValue"></a>
+
+### Generator: endpoint configuration formatters~attributeDefaultValue(attribute, hash) ⇒
+Formats the default value of a single attribute.
+
+Attributes whose default lives in the long defaults or min/max tables carry
+a macro reference as their default value, which is emitted verbatim.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: default value expression  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| attribute | <code>\*</code> | attribute row |
+| hash | <code>\*</code> | handlebars hash arguments (endian, pointer) |
+
+<a name="Generator_ endpoint configuration formatters..attributeItems"></a>
+
+### Generator: endpoint configuration formatters~attributeItems(attribute, order, hash) ⇒
+Formats one attribute as the body of a C struct initializer, in the order
+requested by the template.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: comma separated initializer items  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| attribute | <code>\*</code> | attribute row |
+| order | <code>\*</code> | comma separated list of 'default', 'id', 'size', 'type', 'mask' |
+| hash | <code>\*</code> | handlebars hash arguments (endian, pointer) |
+
+<a name="Generator_ endpoint configuration formatters..minMaxValues"></a>
+
+### Generator: endpoint configuration formatters~minMaxValues(minMax, category) ⇒
+Resolves the default, minimum and maximum of a min/max row into the values
+that go into the generated min/max table.
+
+Attributes that specify neither a minimum nor a maximum get the extremes of
+their type, which depends on the size and signedness of that type.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: object with def, min and max, formatted as hexadecimal strings  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| minMax | <code>\*</code> | min/max row |
+| category | <code>\*</code> | template package category, used for Zigbee validation |
+
+<a name="Generator_ endpoint configuration formatters..asCastHex"></a>
+
+### Generator: endpoint configuration formatters~asCastHex(value) ⇒
+Formats a min/max table value as a cast hexadecimal number.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: value cast to uint16_t  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| value | <code>\*</code> | number or hexadecimal string |
+
+<a name="Generator_ endpoint configuration formatters..minMaxItems"></a>
+
+### Generator: endpoint configuration formatters~minMaxItems(minMax, order, category) ⇒
+Formats one min/max row as the body of a C struct initializer.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: comma separated initializer items  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| minMax | <code>\*</code> | min/max row |
+| order | <code>\*</code> | comma separated list of 'def', 'min', 'max' |
+| category | <code>\*</code> | template package category |
+
+<a name="Generator_ endpoint configuration formatters..longDefaultValue"></a>
+
+### Generator: endpoint configuration formatters~longDefaultValue(longDefault, hash) ⇒
+Formats the bytes of one long default value.
+
+Values are collected in big-endian order. For types where endianness
+matters, the bytes are reversed for little-endian targets.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: comma separated list of bytes  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| longDefault | <code>\*</code> | long default row |
+| hash | <code>\*</code> | handlebars hash arguments (endian) |
+
+<a name="Generator_ endpoint configuration formatters..reportingItems"></a>
+
+### Generator: endpoint configuration formatters~reportingItems(report, order, minMaxOrder) ⇒
+Formats one reporting configuration row as the body of a C struct
+initializer.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: comma separated initializer items  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| report | <code>\*</code> | reporting row |
+| order | <code>\*</code> | comma separated list of 'direction', 'endpoint', 'clusterId', 'attributeId', 'mask', 'mfgCode', 'minmax' |
+| minMaxOrder | <code>\*</code> | comma separated list of 'min', 'max', 'change' |
+
+<a name="Generator_ endpoint configuration formatters..parseClusterTokens"></a>
+
+### Generator: endpoint configuration formatters~parseClusterTokens(value) ⇒
+Parses a template argument that carries a set of cluster names or cluster
+codes. Both commas and newlines separate entries, so that long lists stay
+readable inside a template.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: array of trimmed, non empty tokens  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| value | <code>\*</code> | hash argument value |
+
+<a name="Generator_ endpoint configuration formatters..clusterMatches"></a>
+
+### Generator: endpoint configuration formatters~clusterMatches(cluster, tokens) ⇒
+Checks whether a cluster is named by one of the given tokens. A token
+matches either the cluster name, case insensitively, or the cluster code in
+any numeric notation.
+
+**Kind**: inner method of [<code>Generator: endpoint configuration formatters</code>](#Generator_ endpoint configuration formatters)  
+**Returns**: true if the cluster matches  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| cluster | <code>\*</code> | cluster with name and code |
+| tokens | <code>\*</code> | array of tokens, as returned by parseClusterTokens |
+
 <a name="module_JS API_ generator logic"></a>
 
 ## JS API: generator logic
@@ -10226,6 +10484,493 @@ command is not fixed length
 | commandId |  |
 | options | Returns content in the handlebar template based on the command being fixed length or not as shown in the example above. |
 
+<a name="module_Templating API_ Matter endpoint config iterators"></a>
+
+## Templating API: Matter endpoint config iterators
+Iterators over the endpoint configuration.
+
+The helpers in `helper-endpointconfig.js` return a whole generated table as
+a single string, which means the layout of that table is decided in
+javascript. The helpers here iterate the same data one row at a time, so a
+template can decide the layout, annotate rows, group them, or leave them
+out. All of them are used inside `{{#endpoint_config}}`, which is what
+collects the data.
+
+Companion formatting helpers turn the current row into the C tokens that the
+table needs, so a template can reproduce the output of the aggregate helpers
+exactly, and then change only the part it cares about.
+
+See docs/endpoint-config-generation.md for the guide and examples.
+
+
+* [Templating API: Matter endpoint config iterators](#module_Templating API_ Matter endpoint config iterators)
+    * [~requireEndpointConfigData(context, list, helperName)](#module_Templating API_ Matter endpoint config iterators..requireEndpointConfigData) ⇒
+    * [~deviceIdentifiersOf(endpointType)](#module_Templating API_ Matter endpoint config iterators..deviceIdentifiersOf) ⇒
+    * [~withoutIterationClash(list, name)](#module_Templating API_ Matter endpoint config iterators..withoutIterationClash) ⇒
+    * [~withCommentGroups(list)](#module_Templating API_ Matter endpoint config iterators..withCommentGroups) ⇒
+    * [~endpoint_attributes(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_attributes) ⇒
+    * [~endpoint_clusters(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_clusters) ⇒
+    * [~endpoint_commands(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_commands) ⇒
+    * [~endpoint_events(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_events) ⇒
+    * [~endpoint_types(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_types) ⇒
+    * [~endpoint_fixed_endpoints(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_fixed_endpoints) ⇒
+    * [~endpoint_device_types(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_device_types) ⇒
+    * [~endpoint_min_max_defaults(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_defaults) ⇒
+    * [~endpoint_reporting_defaults(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_reporting_defaults) ⇒
+    * [~endpoint_long_defaults(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_long_defaults) ⇒
+    * [~endpoint_manufacturer_codes(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_manufacturer_codes) ⇒
+    * [~endpoint_attribute_mask(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_attribute_mask) ⇒
+    * [~endpoint_attribute_default(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_attribute_default) ⇒
+    * [~endpoint_attribute_items(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_attribute_items) ⇒
+    * [~endpoint_cluster_mask(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_cluster_mask) ⇒
+    * [~endpoint_command_mask(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_command_mask) ⇒
+    * [~endpoint_reporting_mask(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_reporting_mask) ⇒
+    * [~endpoint_reporting_items(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_reporting_items) ⇒
+    * [~templateCategory(options)](#module_Templating API_ Matter endpoint config iterators..templateCategory) ⇒
+    * [~endpoint_min_max_items(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_items) ⇒
+    * [~endpoint_min_max_default(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_default) ⇒
+    * [~endpoint_min_max_min(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_min) ⇒
+    * [~endpoint_min_max_max(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_max) ⇒
+    * [~endpoint_long_default_value(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_long_default_value) ⇒
+    * [~if_endpoint_cluster_in(clusters, options)](#module_Templating API_ Matter endpoint config iterators..if_endpoint_cluster_in) ⇒
+    * [~if_endpoint_cluster_server(options)](#module_Templating API_ Matter endpoint config iterators..if_endpoint_cluster_server) ⇒
+
+<a name="module_Templating API_ Matter endpoint config iterators..requireEndpointConfigData"></a>
+
+### Templating API: Matter endpoint config iterators~requireEndpointConfigData(context, list, helperName) ⇒
+Reports the name of the enclosing block when data is missing, which happens
+when an iterator is used outside of `{{#endpoint_config}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: the list  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| context | <code>\*</code> | handlebars context |
+| list | <code>\*</code> | list that should have been collected |
+| helperName | <code>\*</code> | name of the helper, used in the error message |
+
+<a name="module_Templating API_ Matter endpoint config iterators..deviceIdentifiersOf"></a>
+
+### Templating API: Matter endpoint config iterators~deviceIdentifiersOf(endpointType) ⇒
+Device types of an endpoint type, leaving out the entries that carry no
+device identifier. Those contribute nothing to the generated arrays, so
+counting them would put the offsets of the following endpoints out by one.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: array of device identifiers  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| endpointType | <code>\*</code> | endpoint type, may be undefined |
+
+<a name="module_Templating API_ Matter endpoint config iterators..withoutIterationClash"></a>
+
+### Templating API: Matter endpoint config iterators~withoutIterationClash(list, name) ⇒
+Renames the `index` of a row, which some lists use for an index into a
+generated table, out of the way.
+
+Iteration adds an `index` and a `count` of its own, which is what
+`{{#first}}`, `{{#last}}` and `{{#not_last}}` read. A row field of the same
+name would hide those and make the position of a row look like something
+else, so the row keeps its value under a name that says what it is.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: copy of the list, with the row index renamed  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| list | <code>\*</code> | list of rows |
+| name | <code>\*</code> | name to give the index of the row |
+
+<a name="module_Templating API_ Matter endpoint config iterators..withCommentGroups"></a>
+
+### Templating API: Matter endpoint config iterators~withCommentGroups(list) ⇒
+Marks the rows that start a new comment group.
+
+The aggregate helpers print a comment naming the endpoint and the cluster
+whenever consecutive rows belong to a different cluster. Templates need the
+same information to reproduce that grouping, so every row reports whether it
+opens a group.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: copy of the list, with isNewComment on every row  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| list | <code>\*</code> | list of rows |
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_attributes"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_attributes(options) ⇒
+Iterates over the attributes of the endpoint configuration, in the order in
+which they appear in the generated attribute table.
+
+Row data includes the generated tokens (id, type, size, mask, defaultValue),
+where the attribute came from (endpointId, clusterId, clusterCode,
+clusterName, clusterSide), and how it is configured (storage, isWritable,
+isReadable, isNullable, isSingleton, isReportable).
+
+example:
+{{#endpoint_attributes}}
+  { {{endpoint_attribute_default}}, {{id}}, {{size}}, {{type}}, {{endpoint_attribute_mask}} },
+{{/endpoint_attributes}}
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_clusters"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_clusters(options) ⇒
+Iterates over the clusters of the endpoint configuration.
+
+Row data includes the indexes into the attribute, command and event tables,
+so a template can emit its own cluster table, and omitsAttributeMetadata,
+omitsCommandMetadata and omitsEventMetadata, which tell whether the metadata
+of that cluster was left out on purpose.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_commands"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_commands(options) ⇒
+Iterates over the commands of the endpoint configuration.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_events"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_events(options) ⇒
+Iterates over the events of the endpoint configuration.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_types"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_types(options) ⇒
+Iterates over the endpoint types, which is what the generated endpoint type
+table is built from. Every row carries the index of its first cluster, the
+number of clusters, and the size of the attributes of the endpoint.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_fixed_endpoints"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_fixed\_endpoints(options) ⇒
+Iterates over the endpoints of the configuration, with everything the
+generated fixed endpoint arrays need: identifier, profile, network, parent
+and the index of the endpoint type of the endpoint.
+
+Values are provided both as numbers and preformatted as hexadecimal, since
+the generated arrays use hexadecimal.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_device_types"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_device\_types(options) ⇒
+Iterates over all device types of the configuration, one row per device type
+per endpoint, which is what the generated device type array is built from.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_defaults"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_defaults(options) ⇒
+Iterates over the attributes that have a minimum and a maximum, which is
+what the generated min/max table is built from.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_reporting_defaults"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_reporting\_defaults(options) ⇒
+Iterates over the attributes that have reporting enabled, which is what the
+generated reporting configuration table is built from.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_long_defaults"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_long\_defaults(options) ⇒
+Iterates over the default values that do not fit inline, which is what the
+generated defaults blob is built from. Every row carries its `offset` into
+that blob and the number of bytes it occupies.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_manufacturer_codes"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_manufacturer\_codes(options) ⇒
+Iterates over the manufacturer code pairs of the configuration. The list is
+selected with the type hash argument, which is one of 'attribute', 'command'
+or 'cluster' and defaults to 'attribute'. Every row carries its
+`entryIndex` into the matching generated table and the manufacturer code.
+
+example:
+{{#endpoint_manufacturer_codes type="cluster"}}
+  { {{entryIndex}}, {{mfgCode}} }, \
+{{/endpoint_manufacturer_codes}}
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_attribute_mask"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_attribute\_mask(options) ⇒
+Formats the mask of the current attribute, inside
+`{{#endpoint_attributes}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: attribute mask expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_attribute_default"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_attribute\_default(options) ⇒
+Formats the default value of the current attribute, inside
+`{{#endpoint_attributes}}`. Takes the same endian and pointer hash
+arguments as `{{endpoint_attribute_list}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: default value expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_attribute_items"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_attribute\_items(options) ⇒
+Formats the current attribute as the body of a C struct initializer, in the
+order given by the order hash argument, which defaults to the order used by
+`{{endpoint_attribute_list}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: comma separated initializer items  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_cluster_mask"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_cluster\_mask(options) ⇒
+Formats the mask of the current cluster, inside `{{#endpoint_clusters}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: cluster mask expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_command_mask"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_command\_mask(options) ⇒
+Formats the mask of the current command, inside `{{#endpoint_commands}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: command mask expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_reporting_mask"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_reporting\_mask(options) ⇒
+Formats the mask of the current reporting row, inside
+`{{#endpoint_reporting_defaults}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: cluster mask expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_reporting_items"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_reporting\_items(options) ⇒
+Formats the current reporting row as the body of a C struct initializer.
+Takes the same order and minmaxorder hash arguments as
+`{{endpoint_reporting_config_defaults}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: comma separated initializer items  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..templateCategory"></a>
+
+### Templating API: Matter endpoint config iterators~templateCategory(options) ⇒
+Returns the template package category, which min/max formatting needs in
+order to apply the Zigbee restriction on value sizes.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: category or undefined  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_items"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_items(options) ⇒
+Formats the current min/max row as the body of a C struct initializer, in
+the order given by the order hash argument, which defaults to the order used
+by `{{endpoint_attribute_min_max_list}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: comma separated initializer items  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_default"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_default(options) ⇒
+Formats the default value of the current min/max row.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: default value, cast to uint16_t  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_min"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_min(options) ⇒
+Formats the minimum of the current min/max row.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: minimum, cast to uint16_t  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_max"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_max(options) ⇒
+Formats the maximum of the current min/max row.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: maximum, cast to uint16_t  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_long_default_value"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_long\_default\_value(options) ⇒
+Formats the bytes of the current long default value, inside
+`{{#endpoint_long_defaults}}`. Takes the same endian hash argument as
+`{{endpoint_attribute_long_defaults}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: comma separated list of bytes  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..if_endpoint_cluster_in"></a>
+
+### Templating API: Matter endpoint config iterators~if\_endpoint\_cluster\_in(clusters, options) ⇒
+Block helper that runs its body when the current row belongs to a cluster
+named by the argument. Names are matched case insensitively, codes in any
+numeric notation, and several of them can be given separated by commas or
+newlines.
+
+example:
+{{#endpoint_attributes}}
+{{#if_endpoint_cluster_in "Identify,0x0006"}}...{{else}}...{{/if_endpoint_cluster_in}}
+{{/endpoint_attributes}}
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| clusters | <code>\*</code> | cluster names or codes |
+| options | <code>\*</code> |  |
+
+<a name="module_Templating API_ Matter endpoint config iterators..if_endpoint_cluster_server"></a>
+
+### Templating API: Matter endpoint config iterators~if\_endpoint\_cluster\_server(options) ⇒
+Block helper that runs its body when the current row belongs to a server
+side cluster.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
 <a name="module_Templating API_ Matter endpoint config helpers"></a>
 
 ## Templating API: Matter endpoint config helpers
@@ -10274,6 +11019,7 @@ This module contains the API for templating. For more detailed instructions, rea
     * [~collectAttributeSizes(db, zclPackageIds, endpointTypes)](#module_Templating API_ Matter endpoint config helpers..collectAttributeSizes) ⇒
     * [~collectAttributeTypeInfo(db, zclPackageIds, endpointTypes)](#module_Templating API_ Matter endpoint config helpers..collectAttributeTypeInfo) ⇒
     * [~isGlobalAttrExcludedFromMetadata(attr)](#module_Templating API_ Matter endpoint config helpers..isGlobalAttrExcludedFromMetadata) ⇒
+    * [~applyMetadataOmissions(cluster, omitted)](#module_Templating API_ Matter endpoint config helpers..applyMetadataOmissions)
     * [~endpoint_config(options)](#module_Templating API_ Matter endpoint config helpers..endpoint_config) ⇒
 
 <a name="module_Templating API_ Matter endpoint config helpers..endpoint_type_count"></a>
@@ -10564,6 +11310,11 @@ Get count of endpoint type attributes.
 ### Templating API: Matter endpoint config helpers~endpoint\_attribute\_list(options) ⇒
 Get endpoint type attribute information.
 
+This emits the whole attribute table as one blob. Templates that need to
+decide the layout themselves, or that need to leave attributes out, should
+iterate with `{{#endpoint_attributes}}` instead. See
+docs/endpoint-config-generation.md.
+
 **Kind**: inner method of [<code>Templating API: Matter endpoint config helpers</code>](#module_Templating API_ Matter endpoint config helpers)  
 **Returns**: endpoint type attribute information  
 
@@ -10774,11 +11525,41 @@ Checks if global attribute is excluded from the meta data.
 | --- | --- |
 | attr | <code>\*</code> | 
 
+<a name="module_Templating API_ Matter endpoint config helpers..applyMetadataOmissions"></a>
+
+### Templating API: Matter endpoint config helpers~applyMetadataOmissions(cluster, omitted)
+Drops the metadata that a template asked not to be generated for a cluster.
+
+Code driven clusters keep their own attribute, command and event tables in
+C++, so generating them here as well costs flash without adding anything.
+Dropping the rows at load time, before indexes and counts are calculated,
+keeps the generated tables and the indexes pointing into them consistent.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config helpers</code>](#module_Templating API_ Matter endpoint config helpers)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| cluster | <code>\*</code> | cluster as loaded from the database |
+| omitted | <code>\*</code> | omitted metadata token sets |
+
 <a name="module_Templating API_ Matter endpoint config helpers..endpoint_config"></a>
 
 ### Templating API: Matter endpoint config helpers~endpoint\_config(options) ⇒
 Starts the endpoint configuration block.,
 longDefaults: longDefaults
+
+Hash arguments:
+- allowUnknownStorageOption: tolerate attributes with an unknown storage
+  policy instead of failing generation.
+- spaceForDefaultValue: how many bytes a default value can occupy inline
+  before it moves into the long defaults table.
+- isReadableMaskGenerationEnabled: add the readable mask to attributes.
+- omitAttributeMetadataClusters, omitCommandMetadataClusters,
+  omitEventMetadataClusters: cluster names or codes, separated by commas or
+  newlines, whose metadata is left out of the generated tables. The clusters
+  themselves stay in the cluster table, with a count of zero. Prefer codes
+  for names that contain a slash, such as On/Off, because handlebars reads a
+  slash inside a block tag as the start of the closing tag.
 
 **Kind**: inner method of [<code>Templating API: Matter endpoint config helpers</code>](#module_Templating API_ Matter endpoint config helpers)  
 **Returns**: a promise of a rendered block  

--- a/docs/endpoint-config-generation.md
+++ b/docs/endpoint-config-generation.md
@@ -1,0 +1,380 @@
+# Endpoint configuration generation
+
+This guide is about the generated endpoint configuration: what it contains, how
+ZAP produces it, and how a template takes control of that output. It is written
+for SDK integrators, in particular for the Matter SDK, where the endpoint
+configuration is compiled into firmware and every byte of it costs flash.
+
+- [What the endpoint configuration is](#what-the-endpoint-configuration-is)
+- [How generation is layered](#how-generation-is-layered)
+- [Taking control from a template](#taking-control-from-a-template)
+- [Leaving metadata out for code driven clusters](#leaving-metadata-out-for-code-driven-clusters)
+- [Helper reference](#helper-reference)
+- [Row reference](#row-reference)
+- [Replacing a helper instead](#replacing-a-helper-instead)
+- [Migrating a template](#migrating-a-template)
+
+## What the endpoint configuration is
+
+A `.zap` file says which endpoints exist, which clusters are enabled on them,
+and how every attribute is configured. Generation turns that into a set of C
+tables that the SDK compiles in, for example in the Matter SDK through
+`src/app/zap-templates/templates/app/endpoint_config.zapt`:
+
+| Generated table              | Holds                                                                       |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| `GENERATED_ATTRIBUTES`       | one metadata entry per enabled attribute                                    |
+| `GENERATED_CLUSTERS`         | one entry per enabled cluster, with indexes into the tables above and below |
+| `GENERATED_COMMANDS`         | accepted and generated command identifiers                                  |
+| `GENERATED_EVENTS`           | event identifiers                                                           |
+| `GENERATED_ENDPOINT_TYPES`   | one entry per endpoint type, with the index of its first cluster            |
+| `GENERATED_DEFAULTS`         | default values that do not fit inline                                       |
+| `GENERATED_MIN_MAX_DEFAULTS` | default, minimum and maximum of range checked attributes                    |
+| `FIXED_*`                    | per endpoint arrays: identifier, profile, parent, network, device types     |
+
+The tables are cross referenced by index. A cluster entry points at a range of
+the attribute table, an endpoint type entry points at a range of the cluster
+table, and an attribute entry can point into the defaults or the min/max table.
+Whatever changes the contents of one table has to keep those indexes right,
+which is the reason for the structure described below.
+
+## How generation is layered
+
+Generation runs in three layers. The split matters because it decides what a
+template can change.
+
+```
+{{#endpoint_config}}                     collection
+  session database -> lists of rows      src-electron/generator/helper-endpointconfig.js
+        |
+        v
+  row -> C tokens                        formatting
+                                         src-electron/generator/endpointconfig-format.js
+        |
+        v
+  tokens -> generated file               layout
+                                         the template, or the aggregate helpers
+```
+
+**Collection** happens once, when `{{#endpoint_config}}` opens. It reads the
+session, resolves attribute types, sizes and default values, sorts everything
+into the order the tables need, and calculates the indexes and counts that tie
+the tables together. The result is a set of plain lists on the block context:
+`attributeList`, `clusterList`, `commandList`, `eventList`, `endpointList`,
+`minMaxList`, `reportList`, `longDefaultsList` and the manufacturer code lists.
+
+**Formatting** turns one row into the C tokens for that row: an attribute mask
+into `ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(NULLABLE)`, a default
+value into `ZAP_SIMPLE_DEFAULT(0x8000)`, and so on. These are pure functions,
+which is what lets the aggregate helpers and the per row helpers produce exactly
+the same text.
+
+**Layout** decides where those tokens end up. There are two ways to do it:
+
+- the aggregate helpers, such as `{{endpoint_attribute_list}}`, which return a
+  whole table as one string, with the layout fixed in javascript;
+- the iterators, such as `{{#endpoint_attributes}}`, which hand the template one
+  row at a time and let it write the table itself.
+
+Both are supported, and both can be used in the same template. Nothing has to
+be migrated in one step.
+
+## Taking control from a template
+
+The Matter SDK generates the attribute table like this:
+
+```handlebars
+#define GENERATED_ATTRIBUTES
+{{endpoint_attribute_list order='default,id,size,type,mask'}}
+```
+
+The same table, written out in the template:
+
+```handlebars
+#define GENERATED_ATTRIBUTES { \
+{{#endpoint_attributes}}
+  {{#if isNewComment}}
+    \ /*
+    {{comment}}
+    */ \
+  {{/if}}
+  {
+  {{endpoint_attribute_items order='default,id,size,type,mask'}}
+  }, /*
+  {{name}}
+  */ \
+{{/endpoint_attributes}}
+}
+```
+
+Those two produce identical output, byte for byte. There is a test that asserts
+it, for the attribute, min/max, cluster, command, endpoint type, defaults,
+manufacturer code and fixed array tables:
+`test/gen-template/matter3/endpoint_config_iterators.zapt`.
+
+That equality is the point of the iterators. An SDK can move a table into its
+own template without any churn in the generated file, confirm that the output
+did not change, and only then start changing the part it cares about. For
+example, spelling out the fields instead of using `endpoint_attribute_items`:
+
+```handlebars
+{{#endpoint_attributes}}
+  {
+  {{endpoint_attribute_default}},
+  {{id}},
+  {{size}},
+  {{type}},
+  {{endpoint_attribute_mask}}
+  }, /*
+  {{clusterName}}.{{name}}
+  */ \
+{{/endpoint_attributes}}
+```
+
+or emitting something different for one group of clusters:
+
+```handlebars
+{{#endpoint_attributes}}
+  {{#if_endpoint_cluster_in 'Descriptor,Identify'}}
+    //
+    {{clusterName}}.{{name}}
+    is provided by the cluster implementation
+  {{else}}
+    {
+    {{endpoint_attribute_items}}
+    }, /*
+    {{name}}
+    */ \
+  {{/if_endpoint_cluster_in}}
+{{/endpoint_attributes}}
+```
+
+Two things are worth knowing when writing these loops:
+
+- Rows carry `index` and `count`, which are the position in the iteration, so
+  `{{#first}}`, `{{#last}}`, `{{#not_last}}` and `{{#middle}}` work inside every
+  iterator. Where a row has an index of its own into a generated table, it is
+  named for what it is, `offset` for long defaults and `entryIndex` for
+  manufacturer codes, so that it cannot be confused with the position.
+- Rows that belong to the same cluster carry the same `comment`, and the first
+  row of each group has `isNewComment` set. That is how the group headers of the
+  aggregate helpers are reproduced.
+
+## Leaving metadata out for code driven clusters
+
+A code driven cluster in the Matter SDK implements `ServerClusterInterface` and
+keeps its own attribute, command and event metadata in C++. Generating the same
+metadata into the ember tables as well costs flash and buys nothing.
+
+Filtering rows in the template is not enough for that, because the counts and
+the indexes of the other tables were already calculated over the full lists.
+Dropping a row in the layout layer would leave the cluster table pointing at the
+wrong place. The rows have to disappear during collection, so
+`{{#endpoint_config}}` takes the list of clusters to leave out:
+
+```handlebars
+{{#endpoint_config
+  allowUnknownStorageOption="false"
+  spaceForDefaultValue=4
+  omitAttributeMetadataClusters="Energy EVSE,0x0025"
+}}
+```
+
+For every named cluster:
+
+- its attributes do not appear in `GENERATED_ATTRIBUTES`, and do not consume
+  space in the attribute store, the defaults blob, the min/max table or the
+  reporting table;
+- the cluster keeps its entry in `GENERATED_CLUSTERS`, with an attribute count
+  of zero, so endpoint composition and cluster lookup do not change;
+- all indexes and counts are calculated over what is left, so the tables stay
+  consistent.
+
+`omitCommandMetadataClusters` and `omitEventMetadataClusters` do the same for
+the command and event tables.
+
+Everything of that cluster is left out, including the global attributes such as
+`FeatureMap` and `ClusterRevision`. Only name a cluster here when its
+implementation answers reads and writes for all of its attributes itself, which
+is exactly what a code driven cluster does.
+
+Clusters are named either by name, case insensitively, or by code in any
+numeric notation. Prefer the code when a name contains a slash, such as On/Off,
+because handlebars reads a slash inside a block tag as the start of the closing
+tag. Entries are separated by commas or by newlines.
+
+Rows of a cluster whose metadata was left out report it, which is useful when a
+template generates something else in its place:
+
+```handlebars
+{{#endpoint_clusters}}
+  {{#if omitsAttributeMetadata}}
+    //
+    {{clusterName}}
+    manages its own attributes
+  {{/if}}
+{{/endpoint_clusters}}
+```
+
+## Helper reference
+
+All helpers below are used inside `{{#endpoint_config}}`.
+
+### Iterators
+
+| Helper                                              | Iterates                                                         |
+| --------------------------------------------------- | ---------------------------------------------------------------- |
+| `{{#endpoint_attributes}}`                          | attributes, in attribute table order                             |
+| `{{#endpoint_clusters}}`                            | clusters, in cluster table order                                 |
+| `{{#endpoint_commands}}`                            | commands, in command table order                                 |
+| `{{#endpoint_events}}`                              | events, in event table order                                     |
+| `{{#endpoint_types}}`                               | endpoint types                                                   |
+| `{{#endpoint_fixed_endpoints}}`                     | endpoints, with everything the `FIXED_*` arrays need             |
+| `{{#endpoint_device_types}}`                        | device types, one row per device type per endpoint               |
+| `{{#endpoint_min_max_defaults}}`                    | attributes that have a minimum and a maximum                     |
+| `{{#endpoint_reporting_defaults}}`                  | attributes that have reporting enabled                           |
+| `{{#endpoint_long_defaults}}`                       | default values that do not fit inline                            |
+| `{{#endpoint_manufacturer_codes type="attribute"}}` | manufacturer code pairs, for `attribute`, `command` or `cluster` |
+
+### Formatting the current row
+
+| Helper                                                   | Returns                                                |
+| -------------------------------------------------------- | ------------------------------------------------------ |
+| `{{endpoint_attribute_mask}}`                            | attribute mask expression                              |
+| `{{endpoint_attribute_default}}`                         | default value expression, takes `endian` and `pointer` |
+| `{{endpoint_attribute_items order=...}}`                 | the whole attribute row body                           |
+| `{{endpoint_cluster_mask}}`                              | cluster mask expression                                |
+| `{{endpoint_command_mask}}`                              | command mask expression                                |
+| `{{endpoint_reporting_mask}}`                            | mask of a reporting row                                |
+| `{{endpoint_reporting_items order=... minmaxorder=...}}` | the whole reporting row body                           |
+| `{{endpoint_min_max_items order=...}}`                   | the whole min/max row body                             |
+| `{{endpoint_min_max_default}}`                           | default of a min/max row                               |
+| `{{endpoint_min_max_min}}`                               | minimum of a min/max row                               |
+| `{{endpoint_min_max_max}}`                               | maximum of a min/max row                               |
+| `{{endpoint_long_default_value endian=...}}`             | bytes of a long default value                          |
+
+### Conditionals
+
+| Helper                                   | Runs its body when                           |
+| ---------------------------------------- | -------------------------------------------- |
+| `{{#if_endpoint_cluster_in "A,0x0006"}}` | the row belongs to one of the named clusters |
+| `{{#if_endpoint_cluster_server}}`        | the row belongs to a server side cluster     |
+
+Rows are matched by the cluster they belong to, never by their own name or code,
+so `{{#if_endpoint_cluster_in "Identify"}}` inside `{{#endpoint_attributes}}`
+selects the attributes of Identify. Clusters are named the same way as in
+`omitAttributeMetadataClusters`, by name or by code.
+
+### Aggregate helpers
+
+The aggregate helpers are unchanged and remain supported:
+`endpoint_attribute_list`, `endpoint_cluster_list`, `endpoint_command_list`,
+`endpoint_types_list`, `endpoint_attribute_min_max_list`,
+`endpoint_reporting_config_defaults`, `endpoint_attribute_long_defaults`, the
+`endpoint_*_manufacturer_codes` helpers, the `endpoint_fixed_*` helpers and all
+of the counts. See [ZAP Template Helpers](helpers.md) for the generated
+reference of every one of them.
+
+## Row reference
+
+Every row carries `index` and `count` for the iteration, and the fields below.
+
+**Attributes** (`{{#endpoint_attributes}}`)
+
+`id`, `type`, `size`, `mask`, `defaultValue`, `isMacro` are the generated
+values. `code`, `name`, `define`, `zclType`, `storage`, `storageSize`,
+`isWritable`, `isReadable`, `isNullable`, `isSingleton`, `isReportable`,
+`manufacturerCode` describe the attribute. `endpointId`, `clusterId`,
+`clusterCode`, `clusterName`, `clusterSide`, `comment`, `isNewComment` say where
+it came from.
+
+**Clusters** (`{{#endpoint_clusters}}`)
+
+`clusterId`, `clusterCode`, `clusterName`, `clusterDefine`, `clusterSide`,
+`manufacturerCode`, `endpointId`, `attributeIndex`, `attributeCount`,
+`attributeSize`, `eventIndex`, `eventCount`, `commandCount`, `mask`,
+`functions`, `commands`, `comment`, and `omitsAttributeMetadata`,
+`omitsCommandMetadata`, `omitsEventMetadata`.
+
+**Commands** (`{{#endpoint_commands}}`)
+
+`clusterId`, `clusterCode`, `clusterName`, `clusterSide`, `commandId`, `code`,
+`name`, `source`, `isIncoming`, `isOutgoing`, `manufacturerCode`, `mask`,
+`responseName`, `responseId`, `endpointId`, `comment`, `isNewComment`.
+
+**Events** (`{{#endpoint_events}}`)
+
+`eventId`, `code`, `name`, `manufacturerCode`, `endpointId`, `clusterId`,
+`clusterCode`, `clusterName`, `clusterSide`, `comment`, `isNewComment`.
+
+**Endpoint types** (`{{#endpoint_types}}`)
+
+`clusterIndex`, `clusterCount`, `attributeSize`, `endpointId`,
+`endpointTypeName`, `deviceIdentifier`, `deviceVersion`.
+
+**Endpoints** (`{{#endpoint_fixed_endpoints}}`)
+
+`endpointId`, `endpointIdHex`, `profileId`, `profileIdHex`, `networkId`,
+`parentEndpointIdentifier`, `parentId`, `endpointTypeIndex`, `endpointTypeName`,
+`deviceTypeCount`, `deviceTypeOffset`. `parentId` is `kInvalidEndpointId` when
+there is no parent, which is what the generated array expects.
+
+**Device types** (`{{#endpoint_device_types}}`)
+
+`endpointId`, `deviceId`, `deviceIdHex`, `deviceVersion`, `indexOnEndpoint`,
+`deviceTypeCountOnEndpoint`. An endpoint type that carries no device identifier
+produces no row, and is not counted in the `deviceTypeCount` and
+`deviceTypeOffset` of its endpoint, which matches what the generated device type
+array contains.
+
+**Min/max** (`{{#endpoint_min_max_defaults}}`)
+
+`default`, `min`, `max`, `typeSize`, `isTypeSigned`, `name`, `code`,
+`endpointId`, `clusterCode`, `clusterName`, `clusterSide`, `comment`,
+`isNewComment`.
+
+**Reporting** (`{{#endpoint_reporting_defaults}}`)
+
+`direction`, `endpoint`, `clusterId`, `attributeId`, `mask`, `mfgCode`,
+`minOrSource`, `maxOrEndpoint`, `reportableChangeOrTimeout`, `name`, `code`,
+`clusterCode`, `clusterName`, `clusterSide`, `comment`, `isNewComment`.
+
+**Long defaults** (`{{#endpoint_long_defaults}}`)
+
+`value`, `size`, `offset`, `type`, `name`, `code`, `endpointId`, `clusterCode`,
+`clusterName`, `clusterSide`, `comment`, `isNewComment`. The `offset` is where
+the value sits in the defaults blob, which is what the attribute table refers
+to.
+
+**Manufacturer codes** (`{{#endpoint_manufacturer_codes}}`)
+
+`entryIndex`, `mfgCode`. The `entryIndex` is the position in the matching
+generated table. The list is empty for most configurations, so use the
+`{{else}}` branch for the placeholder entry that the tables need.
+
+## Replacing a helper instead
+
+Sometimes an SDK needs logic that does not belong in a template. Helpers listed
+under `"helpers"` in `gen-templates.json` are loaded after the built-in ones, so
+an export with the same name as a built-in helper replaces it for that template
+package. Reimplementing `endpoint_attribute_list` in the SDK is therefore a
+supported option, and needs no changes in ZAP. See
+[ZAP External Template Helpers](external-helpers.md).
+
+The iterators are usually the better tool, because the SDK then only owns the
+layout, and the collection of the data, its ordering and the index arithmetic
+stay in ZAP where they are tested.
+
+## Migrating a template
+
+1. Pick one table and keep everything else as it is.
+2. Replace the aggregate helper with the equivalent loop from
+   [Taking control from a template](#taking-control-from-a-template).
+3. Generate and diff against the previous output. It should be identical.
+4. Now make the change you wanted: reorder fields, add comments, or leave rows
+   out with `omitAttributeMetadataClusters`.
+5. Repeat for the next table.
+
+One detail that is easy to miss: the aggregate helpers end their output with a
+newline. When comparing output during a migration, close the tag with `~}}` to
+drop the newline that the template would add on top of it.

--- a/docs/external-helpers.md
+++ b/docs/external-helpers.md
@@ -105,6 +105,16 @@ For example, in your SDK code, you can call the helpers like this:
 <p>Attributes Count: {{ get_total_attributes_helper }}</p>
 The api object, provided by ZAP, contains the data and methods required for these helpers to work.
 
+## Replacing a built-in helper
+
+Helpers listed under `"helpers"` are loaded **after** ZAP's built-in helpers, so
+an export that uses the name of a built-in helper replaces it for that template
+package. That is how an SDK takes over generation logic without changes in ZAP.
+
+For the endpoint configuration there is usually a lighter alternative, where the
+SDK owns the layout of a generated table but not the collection of the data. See
+[Endpoint configuration generation](endpoint-config-generation.md).
+
 ## Conclusion
 
 This design pattern allows SDK developers to create externalized helpers. By leveraging the gen-template.json configuration file and the API object, SDK developers can interact with ZAP without needing direct access to ZAP’s internal source code. The approach abstracts method and query name changes in ZAP, ensuring that SDK code remains resilient to changes in the ZAP API.

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -13,6 +13,19 @@
 <dt><a href="#module_Templating API_ Command helpers">Templating API: Command helpers</a></dt>
 <dd><p>This module contains the API for templating. For more detailed instructions, read {@tutorial template-tutorial}</p>
 </dd>
+<dt><a href="#module_Templating API_ Matter endpoint config iterators">Templating API: Matter endpoint config iterators</a></dt>
+<dd><p>Iterators over the endpoint configuration.</p>
+<p>The helpers in <code>helper-endpointconfig.js</code> return a whole generated table as
+a single string, which means the layout of that table is decided in
+javascript. The helpers here iterate the same data one row at a time, so a
+template can decide the layout, annotate rows, group them, or leave them
+out. All of them are used inside <code>{{#endpoint_config}}</code>, which is what
+collects the data.</p>
+<p>Companion formatting helpers turn the current row into the C tokens that the
+table needs, so a template can reproduce the output of the aggregate helpers
+exactly, and then change only the part it cares about.</p>
+<p>See docs/endpoint-config-generation.md for the guide and examples.</p>
+</dd>
 <dt><a href="#module_Templating API_ Matter endpoint config helpers">Templating API: Matter endpoint config helpers</a></dt>
 <dd><p>This module contains the API for templating. For more detailed instructions, read {@tutorial template-tutorial}</p>
 </dd>
@@ -1062,6 +1075,493 @@ command is not fixed length
 | commandId |  |
 | options | Returns content in the handlebar template based on the command being fixed length or not as shown in the example above. |
 
+<a name="module_Templating API_ Matter endpoint config iterators"></a>
+
+## Templating API: Matter endpoint config iterators
+Iterators over the endpoint configuration.
+
+The helpers in `helper-endpointconfig.js` return a whole generated table as
+a single string, which means the layout of that table is decided in
+javascript. The helpers here iterate the same data one row at a time, so a
+template can decide the layout, annotate rows, group them, or leave them
+out. All of them are used inside `{{#endpoint_config}}`, which is what
+collects the data.
+
+Companion formatting helpers turn the current row into the C tokens that the
+table needs, so a template can reproduce the output of the aggregate helpers
+exactly, and then change only the part it cares about.
+
+See docs/endpoint-config-generation.md for the guide and examples.
+
+
+* [Templating API: Matter endpoint config iterators](#module_Templating API_ Matter endpoint config iterators)
+    * [~requireEndpointConfigData(context, list, helperName)](#module_Templating API_ Matter endpoint config iterators..requireEndpointConfigData) ⇒
+    * [~deviceIdentifiersOf(endpointType)](#module_Templating API_ Matter endpoint config iterators..deviceIdentifiersOf) ⇒
+    * [~withoutIterationClash(list, name)](#module_Templating API_ Matter endpoint config iterators..withoutIterationClash) ⇒
+    * [~withCommentGroups(list)](#module_Templating API_ Matter endpoint config iterators..withCommentGroups) ⇒
+    * [~endpoint_attributes(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_attributes) ⇒
+    * [~endpoint_clusters(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_clusters) ⇒
+    * [~endpoint_commands(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_commands) ⇒
+    * [~endpoint_events(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_events) ⇒
+    * [~endpoint_types(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_types) ⇒
+    * [~endpoint_fixed_endpoints(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_fixed_endpoints) ⇒
+    * [~endpoint_device_types(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_device_types) ⇒
+    * [~endpoint_min_max_defaults(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_defaults) ⇒
+    * [~endpoint_reporting_defaults(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_reporting_defaults) ⇒
+    * [~endpoint_long_defaults(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_long_defaults) ⇒
+    * [~endpoint_manufacturer_codes(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_manufacturer_codes) ⇒
+    * [~endpoint_attribute_mask(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_attribute_mask) ⇒
+    * [~endpoint_attribute_default(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_attribute_default) ⇒
+    * [~endpoint_attribute_items(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_attribute_items) ⇒
+    * [~endpoint_cluster_mask(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_cluster_mask) ⇒
+    * [~endpoint_command_mask(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_command_mask) ⇒
+    * [~endpoint_reporting_mask(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_reporting_mask) ⇒
+    * [~endpoint_reporting_items(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_reporting_items) ⇒
+    * [~templateCategory(options)](#module_Templating API_ Matter endpoint config iterators..templateCategory) ⇒
+    * [~endpoint_min_max_items(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_items) ⇒
+    * [~endpoint_min_max_default(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_default) ⇒
+    * [~endpoint_min_max_min(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_min) ⇒
+    * [~endpoint_min_max_max(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_min_max_max) ⇒
+    * [~endpoint_long_default_value(options)](#module_Templating API_ Matter endpoint config iterators..endpoint_long_default_value) ⇒
+    * [~if_endpoint_cluster_in(clusters, options)](#module_Templating API_ Matter endpoint config iterators..if_endpoint_cluster_in) ⇒
+    * [~if_endpoint_cluster_server(options)](#module_Templating API_ Matter endpoint config iterators..if_endpoint_cluster_server) ⇒
+
+<a name="module_Templating API_ Matter endpoint config iterators..requireEndpointConfigData"></a>
+
+### Templating API: Matter endpoint config iterators~requireEndpointConfigData(context, list, helperName) ⇒
+Reports the name of the enclosing block when data is missing, which happens
+when an iterator is used outside of `{{#endpoint_config}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: the list  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| context | <code>\*</code> | handlebars context |
+| list | <code>\*</code> | list that should have been collected |
+| helperName | <code>\*</code> | name of the helper, used in the error message |
+
+<a name="module_Templating API_ Matter endpoint config iterators..deviceIdentifiersOf"></a>
+
+### Templating API: Matter endpoint config iterators~deviceIdentifiersOf(endpointType) ⇒
+Device types of an endpoint type, leaving out the entries that carry no
+device identifier. Those contribute nothing to the generated arrays, so
+counting them would put the offsets of the following endpoints out by one.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: array of device identifiers  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| endpointType | <code>\*</code> | endpoint type, may be undefined |
+
+<a name="module_Templating API_ Matter endpoint config iterators..withoutIterationClash"></a>
+
+### Templating API: Matter endpoint config iterators~withoutIterationClash(list, name) ⇒
+Renames the `index` of a row, which some lists use for an index into a
+generated table, out of the way.
+
+Iteration adds an `index` and a `count` of its own, which is what
+`{{#first}}`, `{{#last}}` and `{{#not_last}}` read. A row field of the same
+name would hide those and make the position of a row look like something
+else, so the row keeps its value under a name that says what it is.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: copy of the list, with the row index renamed  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| list | <code>\*</code> | list of rows |
+| name | <code>\*</code> | name to give the index of the row |
+
+<a name="module_Templating API_ Matter endpoint config iterators..withCommentGroups"></a>
+
+### Templating API: Matter endpoint config iterators~withCommentGroups(list) ⇒
+Marks the rows that start a new comment group.
+
+The aggregate helpers print a comment naming the endpoint and the cluster
+whenever consecutive rows belong to a different cluster. Templates need the
+same information to reproduce that grouping, so every row reports whether it
+opens a group.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: copy of the list, with isNewComment on every row  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| list | <code>\*</code> | list of rows |
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_attributes"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_attributes(options) ⇒
+Iterates over the attributes of the endpoint configuration, in the order in
+which they appear in the generated attribute table.
+
+Row data includes the generated tokens (id, type, size, mask, defaultValue),
+where the attribute came from (endpointId, clusterId, clusterCode,
+clusterName, clusterSide), and how it is configured (storage, isWritable,
+isReadable, isNullable, isSingleton, isReportable).
+
+example:
+{{#endpoint_attributes}}
+  { {{endpoint_attribute_default}}, {{id}}, {{size}}, {{type}}, {{endpoint_attribute_mask}} },
+{{/endpoint_attributes}}
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_clusters"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_clusters(options) ⇒
+Iterates over the clusters of the endpoint configuration.
+
+Row data includes the indexes into the attribute, command and event tables,
+so a template can emit its own cluster table, and omitsAttributeMetadata,
+omitsCommandMetadata and omitsEventMetadata, which tell whether the metadata
+of that cluster was left out on purpose.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_commands"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_commands(options) ⇒
+Iterates over the commands of the endpoint configuration.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_events"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_events(options) ⇒
+Iterates over the events of the endpoint configuration.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_types"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_types(options) ⇒
+Iterates over the endpoint types, which is what the generated endpoint type
+table is built from. Every row carries the index of its first cluster, the
+number of clusters, and the size of the attributes of the endpoint.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_fixed_endpoints"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_fixed\_endpoints(options) ⇒
+Iterates over the endpoints of the configuration, with everything the
+generated fixed endpoint arrays need: identifier, profile, network, parent
+and the index of the endpoint type of the endpoint.
+
+Values are provided both as numbers and preformatted as hexadecimal, since
+the generated arrays use hexadecimal.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_device_types"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_device\_types(options) ⇒
+Iterates over all device types of the configuration, one row per device type
+per endpoint, which is what the generated device type array is built from.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_defaults"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_defaults(options) ⇒
+Iterates over the attributes that have a minimum and a maximum, which is
+what the generated min/max table is built from.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_reporting_defaults"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_reporting\_defaults(options) ⇒
+Iterates over the attributes that have reporting enabled, which is what the
+generated reporting configuration table is built from.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_long_defaults"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_long\_defaults(options) ⇒
+Iterates over the default values that do not fit inline, which is what the
+generated defaults blob is built from. Every row carries its `offset` into
+that blob and the number of bytes it occupies.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_manufacturer_codes"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_manufacturer\_codes(options) ⇒
+Iterates over the manufacturer code pairs of the configuration. The list is
+selected with the type hash argument, which is one of 'attribute', 'command'
+or 'cluster' and defaults to 'attribute'. Every row carries its
+`entryIndex` into the matching generated table and the manufacturer code.
+
+example:
+{{#endpoint_manufacturer_codes type="cluster"}}
+  { {{entryIndex}}, {{mfgCode}} }, \
+{{/endpoint_manufacturer_codes}}
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_attribute_mask"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_attribute\_mask(options) ⇒
+Formats the mask of the current attribute, inside
+`{{#endpoint_attributes}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: attribute mask expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_attribute_default"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_attribute\_default(options) ⇒
+Formats the default value of the current attribute, inside
+`{{#endpoint_attributes}}`. Takes the same endian and pointer hash
+arguments as `{{endpoint_attribute_list}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: default value expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_attribute_items"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_attribute\_items(options) ⇒
+Formats the current attribute as the body of a C struct initializer, in the
+order given by the order hash argument, which defaults to the order used by
+`{{endpoint_attribute_list}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: comma separated initializer items  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_cluster_mask"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_cluster\_mask(options) ⇒
+Formats the mask of the current cluster, inside `{{#endpoint_clusters}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: cluster mask expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_command_mask"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_command\_mask(options) ⇒
+Formats the mask of the current command, inside `{{#endpoint_commands}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: command mask expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_reporting_mask"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_reporting\_mask(options) ⇒
+Formats the mask of the current reporting row, inside
+`{{#endpoint_reporting_defaults}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: cluster mask expression  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_reporting_items"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_reporting\_items(options) ⇒
+Formats the current reporting row as the body of a C struct initializer.
+Takes the same order and minmaxorder hash arguments as
+`{{endpoint_reporting_config_defaults}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: comma separated initializer items  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..templateCategory"></a>
+
+### Templating API: Matter endpoint config iterators~templateCategory(options) ⇒
+Returns the template package category, which min/max formatting needs in
+order to apply the Zigbee restriction on value sizes.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: category or undefined  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_items"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_items(options) ⇒
+Formats the current min/max row as the body of a C struct initializer, in
+the order given by the order hash argument, which defaults to the order used
+by `{{endpoint_attribute_min_max_list}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: comma separated initializer items  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_default"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_default(options) ⇒
+Formats the default value of the current min/max row.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: default value, cast to uint16_t  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_min"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_min(options) ⇒
+Formats the minimum of the current min/max row.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: minimum, cast to uint16_t  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_min_max_max"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_min\_max\_max(options) ⇒
+Formats the maximum of the current min/max row.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: maximum, cast to uint16_t  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..endpoint_long_default_value"></a>
+
+### Templating API: Matter endpoint config iterators~endpoint\_long\_default\_value(options) ⇒
+Formats the bytes of the current long default value, inside
+`{{#endpoint_long_defaults}}`. Takes the same endian hash argument as
+`{{endpoint_attribute_long_defaults}}`.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: comma separated list of bytes  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
+<a name="module_Templating API_ Matter endpoint config iterators..if_endpoint_cluster_in"></a>
+
+### Templating API: Matter endpoint config iterators~if\_endpoint\_cluster\_in(clusters, options) ⇒
+Block helper that runs its body when the current row belongs to a cluster
+named by the argument. Names are matched case insensitively, codes in any
+numeric notation, and several of them can be given separated by commas or
+newlines.
+
+example:
+{{#endpoint_attributes}}
+{{#if_endpoint_cluster_in "Identify,0x0006"}}...{{else}}...{{/if_endpoint_cluster_in}}
+{{/endpoint_attributes}}
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| clusters | <code>\*</code> | cluster names or codes |
+| options | <code>\*</code> |  |
+
+<a name="module_Templating API_ Matter endpoint config iterators..if_endpoint_cluster_server"></a>
+
+### Templating API: Matter endpoint config iterators~if\_endpoint\_cluster\_server(options) ⇒
+Block helper that runs its body when the current row belongs to a server
+side cluster.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config iterators</code>](#module_Templating API_ Matter endpoint config iterators)  
+**Returns**: promise of a rendered block  
+
+| Param | Type |
+| --- | --- |
+| options | <code>\*</code> | 
+
 <a name="module_Templating API_ Matter endpoint config helpers"></a>
 
 ## Templating API: Matter endpoint config helpers
@@ -1110,6 +1610,7 @@ This module contains the API for templating. For more detailed instructions, rea
     * [~collectAttributeSizes(db, zclPackageIds, endpointTypes)](#module_Templating API_ Matter endpoint config helpers..collectAttributeSizes) ⇒
     * [~collectAttributeTypeInfo(db, zclPackageIds, endpointTypes)](#module_Templating API_ Matter endpoint config helpers..collectAttributeTypeInfo) ⇒
     * [~isGlobalAttrExcludedFromMetadata(attr)](#module_Templating API_ Matter endpoint config helpers..isGlobalAttrExcludedFromMetadata) ⇒
+    * [~applyMetadataOmissions(cluster, omitted)](#module_Templating API_ Matter endpoint config helpers..applyMetadataOmissions)
     * [~endpoint_config(options)](#module_Templating API_ Matter endpoint config helpers..endpoint_config) ⇒
 
 <a name="module_Templating API_ Matter endpoint config helpers..endpoint_type_count"></a>
@@ -1400,6 +1901,11 @@ Get count of endpoint type attributes.
 ### Templating API: Matter endpoint config helpers~endpoint\_attribute\_list(options) ⇒
 Get endpoint type attribute information.
 
+This emits the whole attribute table as one blob. Templates that need to
+decide the layout themselves, or that need to leave attributes out, should
+iterate with `{{#endpoint_attributes}}` instead. See
+docs/endpoint-config-generation.md.
+
 **Kind**: inner method of [<code>Templating API: Matter endpoint config helpers</code>](#module_Templating API_ Matter endpoint config helpers)  
 **Returns**: endpoint type attribute information  
 
@@ -1610,11 +2116,41 @@ Checks if global attribute is excluded from the meta data.
 | --- | --- |
 | attr | <code>\*</code> | 
 
+<a name="module_Templating API_ Matter endpoint config helpers..applyMetadataOmissions"></a>
+
+### Templating API: Matter endpoint config helpers~applyMetadataOmissions(cluster, omitted)
+Drops the metadata that a template asked not to be generated for a cluster.
+
+Code driven clusters keep their own attribute, command and event tables in
+C++, so generating them here as well costs flash without adding anything.
+Dropping the rows at load time, before indexes and counts are calculated,
+keeps the generated tables and the indexes pointing into them consistent.
+
+**Kind**: inner method of [<code>Templating API: Matter endpoint config helpers</code>](#module_Templating API_ Matter endpoint config helpers)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| cluster | <code>\*</code> | cluster as loaded from the database |
+| omitted | <code>\*</code> | omitted metadata token sets |
+
 <a name="module_Templating API_ Matter endpoint config helpers..endpoint_config"></a>
 
 ### Templating API: Matter endpoint config helpers~endpoint\_config(options) ⇒
 Starts the endpoint configuration block.,
 longDefaults: longDefaults
+
+Hash arguments:
+- allowUnknownStorageOption: tolerate attributes with an unknown storage
+  policy instead of failing generation.
+- spaceForDefaultValue: how many bytes a default value can occupy inline
+  before it moves into the long defaults table.
+- isReadableMaskGenerationEnabled: add the readable mask to attributes.
+- omitAttributeMetadataClusters, omitCommandMetadataClusters,
+  omitEventMetadataClusters: cluster names or codes, separated by commas or
+  newlines, whose metadata is left out of the generated tables. The clusters
+  themselves stay in the cluster table, with a count of zero. Prefer codes
+  for names that contain a slash, such as On/Off, because handlebars reads a
+  slash inside a block tag as the start of the closing tag.
 
 **Kind**: inner method of [<code>Templating API: Matter endpoint config helpers</code>](#module_Templating API_ Matter endpoint config helpers)  
 **Returns**: a promise of a rendered block  

--- a/src-electron/generator/endpointconfig-format.js
+++ b/src-electron/generator/endpointconfig-format.js
@@ -1,0 +1,408 @@
+/**
+ *
+ *    Copyright (c) 2026 Silicon Labs
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Formatting of individual endpoint configuration rows.
+ *
+ * The endpoint configuration is produced in three layers:
+ *   1. collection: `helper-endpointconfig.js` turns the session database into
+ *      lists of plain objects (attributes, clusters, commands, ...).
+ *   2. formatting: this module turns one such object into the C tokens that
+ *      end up in the generated file.
+ *   3. layout: templates decide where those tokens go, either through the
+ *      aggregate helpers in `helper-endpointconfig.js` or through the
+ *      iterators in `helper-endpointconfig-iterators.js`.
+ *
+ * Functions here are pure: no database, no handlebars context. That is what
+ * lets the aggregate helpers and the per-row helpers emit identical output.
+ *
+ * @module Generator: endpoint configuration formatters
+ */
+
+const types = require('../util/types.js')
+const dbEnum = require('../../src-shared/db-enum.js')
+
+/**
+ * Formats an array of mask names into a C expression.
+ *
+ * @param {*} mask array of mask names
+ * @param {*} macro name of the wrapping macro
+ * @returns '0' for an empty mask, or the masks combined with '|'
+ */
+function maskExpression(mask, macro) {
+  if (mask == null || mask.length == 0) {
+    return '0'
+  }
+  return mask.map((m) => `${macro}(${m.toUpperCase()})`).join(' | ')
+}
+
+/**
+ * Formats the mask of a single attribute.
+ *
+ * @param {*} mask array of mask names
+ * @returns attribute mask expression
+ */
+function attributeMask(mask) {
+  return maskExpression(mask, 'ZAP_ATTRIBUTE_MASK')
+}
+
+/**
+ * Formats the mask of a single cluster. Reporting configuration rows use the
+ * cluster mask macro as well.
+ *
+ * @param {*} mask array of mask names
+ * @returns cluster mask expression
+ */
+function clusterMask(mask) {
+  return maskExpression(mask, 'ZAP_CLUSTER_MASK')
+}
+
+/**
+ * Formats the mask of a single command.
+ *
+ * @param {*} mask array of mask names
+ * @returns command mask expression
+ */
+function commandMask(mask) {
+  return maskExpression(mask, 'ZAP_COMMAND_MASK')
+}
+
+/**
+ * Reads the endianness and pointer size out of template hash arguments.
+ *
+ * @param {*} hash handlebars hash arguments, may be undefined
+ * @returns object with littleEndian and pointerSize
+ */
+function endianOptions(hash) {
+  let littleEndian = true
+  let pointerSize = 4
+  if (hash && hash.endian == 'big') {
+    littleEndian = false
+    if (typeof hash.pointer != 'undefined') {
+      pointerSize = hash.pointer
+    }
+  }
+  return { littleEndian: littleEndian, pointerSize: pointerSize }
+}
+
+/**
+ * Formats the default value of a single attribute.
+ *
+ * Attributes whose default lives in the long defaults or min/max tables carry
+ * a macro reference as their default value, which is emitted verbatim.
+ *
+ * @param {*} attribute attribute row
+ * @param {*} hash handlebars hash arguments (endian, pointer)
+ * @returns default value expression
+ */
+function attributeDefaultValue(attribute, hash) {
+  if (!attribute.defaultValue) {
+    return `ZAP_EMPTY_DEFAULT()`
+  }
+  if (attribute.isMacro) {
+    return attribute.defaultValue
+  }
+  let { littleEndian, pointerSize } = endianOptions(hash)
+  let defaultValue = attribute.defaultValue
+  if (!littleEndian) {
+    defaultValue = Number(defaultValue)
+      .toString(16)
+      .padStart(6, '0x0000')
+      .padEnd(2 + 2 * pointerSize, '0')
+  }
+  return `ZAP_SIMPLE_DEFAULT(${defaultValue})`
+}
+
+/**
+ * Formats one attribute as the body of a C struct initializer, in the order
+ * requested by the template.
+ *
+ * @param {*} attribute attribute row
+ * @param {*} order comma separated list of 'default', 'id', 'size', 'type', 'mask'
+ * @param {*} hash handlebars hash arguments (endian, pointer)
+ * @returns comma separated initializer items
+ */
+function attributeItems(attribute, order, hash) {
+  let mask = attributeMask(attribute.mask)
+  let defaultValue = attributeDefaultValue(attribute, hash)
+  let items = []
+  order
+    .split(',')
+    .map((x) => (x ? x.trim() : ''))
+    .forEach((token) => {
+      switch (token) {
+        case 'default':
+          items.push(defaultValue)
+          break
+        case 'id':
+          items.push(attribute.id)
+          break
+        case 'size':
+          items.push(attribute.size)
+          break
+        case 'type':
+          items.push(attribute.type)
+          break
+        case 'mask':
+          items.push(mask)
+          break
+        default:
+          throw new Error(`Unknown token '${token}' in order optional argument`)
+      }
+    })
+  return items.join(', ')
+}
+
+/**
+ * Resolves the default, minimum and maximum of a min/max row into the values
+ * that go into the generated min/max table.
+ *
+ * Attributes that specify neither a minimum nor a maximum get the extremes of
+ * their type, which depends on the size and signedness of that type.
+ *
+ * @param {*} minMax min/max row
+ * @param {*} category template package category, used for Zigbee validation
+ * @returns object with def, min and max, formatted as hexadecimal strings
+ */
+function minMaxValues(minMax, category) {
+  if (minMax.typeSize > 2 && category === dbEnum.helperCategory.zigbee) {
+    throw new Error(
+      `Can't have min/max for attributes larger than 2 bytes like '${minMax.name}'`
+    )
+  }
+
+  let def = parseInt(minMax.default)
+  let min = parseInt(minMax.min)
+  let max = parseInt(minMax.max)
+
+  if (isNaN(def)) def = 0
+  if (isNaN(min)) {
+    if (minMax.typeSize < 1)
+      throw new Error(
+        'Invalid type size for min value: ' + JSON.stringify(minMax)
+      )
+    if (minMax.isTypeSigned) {
+      min = '0x80' + '00'.repeat(minMax.typeSize - 1)
+    } else {
+      min = 0
+    }
+  }
+  if (isNaN(max)) {
+    if (minMax.typeSize < 1)
+      throw new Error(
+        'Invalid type size for max value: ' + JSON.stringify(minMax)
+      )
+    if (minMax.isTypeSigned) {
+      max = '0x7F' + 'FF'.repeat(minMax.typeSize - 1)
+    } else {
+      max = '0x' + 'FF'.repeat(minMax.typeSize)
+    }
+  }
+
+  return {
+    def: asCastHex(def),
+    min: asCastHex(min),
+    max: asCastHex(max)
+  }
+}
+
+/**
+ * Formats a min/max table value as a cast hexadecimal number.
+ *
+ * @param {*} value number or hexadecimal string
+ * @returns value cast to uint16_t
+ */
+function asCastHex(value) {
+  let sign = value >= 0 ? '' : '-'
+  return `(uint16_t)${sign}0x${Math.abs(value).toString(16).toUpperCase()}`
+}
+
+/**
+ * Formats one min/max row as the body of a C struct initializer.
+ *
+ * @param {*} minMax min/max row
+ * @param {*} order comma separated list of 'def', 'min', 'max'
+ * @param {*} category template package category
+ * @returns comma separated initializer items
+ */
+function minMaxItems(minMax, order, category) {
+  let values = minMaxValues(minMax, category)
+  let items = []
+  order
+    .split(',')
+    .map((x) => (x ? x.trim() : ''))
+    .forEach((token) => {
+      switch (token) {
+        case 'def':
+          items.push(values.def)
+          break
+        case 'min':
+          items.push(values.min)
+          break
+        case 'max':
+          items.push(values.max)
+          break
+      }
+    })
+  return items.join(', ')
+}
+
+/**
+ * Formats the bytes of one long default value.
+ *
+ * Values are collected in big-endian order. For types where endianness
+ * matters, the bytes are reversed for little-endian targets.
+ *
+ * @param {*} longDefault long default row
+ * @param {*} hash handlebars hash arguments (endian)
+ * @returns comma separated list of bytes
+ */
+function longDefaultValue(longDefault, hash) {
+  let { littleEndian } = endianOptions(hash)
+  if (!littleEndian || types.isString(longDefault.type)) {
+    return longDefault.value
+  }
+  let bytes = longDefault.value.split(/\s*,\s*/).filter((s) => s.length != 0)
+  bytes.reverse()
+  return bytes.join(', ') + ', '
+}
+
+/**
+ * Formats one reporting configuration row as the body of a C struct
+ * initializer.
+ *
+ * @param {*} report reporting row
+ * @param {*} order comma separated list of 'direction', 'endpoint', 'clusterId', 'attributeId', 'mask', 'mfgCode', 'minmax'
+ * @param {*} minMaxOrder comma separated list of 'min', 'max', 'change'
+ * @returns comma separated initializer items
+ */
+function reportingItems(report, order, minMaxOrder) {
+  let minMaxItems = []
+  minMaxOrder
+    .split(',')
+    .map((x) => (x ? x.trim() : ''))
+    .forEach((token) => {
+      switch (token) {
+        case 'min':
+          minMaxItems.push(report.minOrSource)
+          break
+        case 'max':
+          minMaxItems.push(report.maxOrEndpoint)
+          break
+        case 'change':
+          minMaxItems.push(report.reportableChangeOrTimeout)
+          break
+      }
+    })
+
+  let mask = clusterMask(report.mask)
+  let items = []
+  order
+    .split(',')
+    .map((x) => (x ? x.trim() : ''))
+    .forEach((token) => {
+      switch (token) {
+        case 'direction':
+          items.push(`ZAP_REPORT_DIRECTION(${report.direction})`)
+          break
+        case 'endpoint':
+          items.push(report.endpoint)
+          break
+        case 'clusterId':
+          items.push(report.clusterId)
+          break
+        case 'attributeId':
+          items.push(report.attributeId)
+          break
+        case 'mask':
+          items.push(mask)
+          break
+        case 'mfgCode':
+          items.push(report.mfgCode)
+          break
+        case 'minmax':
+          items.push(`{{ ${minMaxItems.join(', ')} }}`)
+          break
+        default:
+          throw new Error(`Unknown token '${token}' in order optional argument`)
+      }
+    })
+  return items.join(', ')
+}
+
+/**
+ * Parses a template argument that carries a set of cluster names or cluster
+ * codes. Both commas and newlines separate entries, so that long lists stay
+ * readable inside a template.
+ *
+ * @param {*} value hash argument value
+ * @returns array of trimmed, non empty tokens
+ */
+function parseClusterTokens(value) {
+  if (value == null) return []
+  return String(value)
+    .split(/[,\n]/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+}
+
+/**
+ * Checks whether a cluster is named by one of the given tokens. A token
+ * matches either the cluster name, case insensitively, or the cluster code in
+ * any numeric notation.
+ *
+ * @param {*} cluster cluster with name and code
+ * @param {*} tokens array of tokens, as returned by parseClusterTokens
+ * @returns true if the cluster matches
+ */
+function clusterMatches(cluster, tokens) {
+  if (tokens.length == 0) return false
+  // Rows of the endpoint configuration carry the cluster they belong to in
+  // clusterName and clusterCode, and their own identity in name and code, so
+  // the cluster fields have to win. Otherwise an attribute would be matched by
+  // its own name, and by its own code.
+  let name = cluster.clusterName != null ? cluster.clusterName : cluster.name
+  let code = cluster.clusterCode != null ? cluster.clusterCode : cluster.code
+  let lowerCaseName = name == null ? null : name.toLowerCase()
+  for (let token of tokens) {
+    if (lowerCaseName != null && token.toLowerCase() === lowerCaseName) {
+      return true
+    }
+    let tokenCode = Number(token)
+    if (
+      code != null &&
+      !Number.isNaN(tokenCode) &&
+      tokenCode === Number(code)
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+exports.attributeMask = attributeMask
+exports.clusterMask = clusterMask
+exports.commandMask = commandMask
+exports.attributeDefaultValue = attributeDefaultValue
+exports.attributeItems = attributeItems
+exports.minMaxValues = minMaxValues
+exports.minMaxItems = minMaxItems
+exports.longDefaultValue = longDefaultValue
+exports.reportingItems = reportingItems
+exports.parseClusterTokens = parseClusterTokens
+exports.clusterMatches = clusterMatches
+exports.endianOptions = endianOptions

--- a/src-electron/generator/helper-endpointconfig-iterators.js
+++ b/src-electron/generator/helper-endpointconfig-iterators.js
@@ -1,0 +1,629 @@
+/**
+ *
+ *    Copyright (c) 2026 Silicon Labs
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * Iterators over the endpoint configuration.
+ *
+ * The helpers in `helper-endpointconfig.js` return a whole generated table as
+ * a single string, which means the layout of that table is decided in
+ * javascript. The helpers here iterate the same data one row at a time, so a
+ * template can decide the layout, annotate rows, group them, or leave them
+ * out. All of them are used inside `{{#endpoint_config}}`, which is what
+ * collects the data.
+ *
+ * Companion formatting helpers turn the current row into the C tokens that the
+ * table needs, so a template can reproduce the output of the aggregate helpers
+ * exactly, and then change only the part it cares about.
+ *
+ * See docs/endpoint-config-generation.md for the guide and examples.
+ *
+ * @module Templating API: Matter endpoint config iterators
+ */
+
+const bin = require('../util/bin')
+const dbEnum = require('../../src-shared/db-enum.js')
+const format = require('./endpointconfig-format.js')
+const templateUtil = require('./template-util')
+
+/**
+ * Reports the name of the enclosing block when data is missing, which happens
+ * when an iterator is used outside of `{{#endpoint_config}}`.
+ *
+ * @param {*} context handlebars context
+ * @param {*} list list that should have been collected
+ * @param {*} helperName name of the helper, used in the error message
+ * @returns the list
+ */
+function requireEndpointConfigData(context, list, helperName) {
+  if (list == null) {
+    throw new Error(
+      `Helper {{#${helperName}}} must be used inside {{#endpoint_config}}.`
+    )
+  }
+  return list
+}
+
+/**
+ * Device types of an endpoint type, leaving out the entries that carry no
+ * device identifier. Those contribute nothing to the generated arrays, so
+ * counting them would put the offsets of the following endpoints out by one.
+ *
+ * @param {*} endpointType endpoint type, may be undefined
+ * @returns array of device identifiers
+ */
+function deviceIdentifiersOf(endpointType) {
+  if (endpointType == null || endpointType.deviceIdentifiers == null) return []
+  return endpointType.deviceIdentifiers.filter((id) => id != null)
+}
+
+/**
+ * Renames the `index` of a row, which some lists use for an index into a
+ * generated table, out of the way.
+ *
+ * Iteration adds an `index` and a `count` of its own, which is what
+ * `{{#first}}`, `{{#last}}` and `{{#not_last}}` read. A row field of the same
+ * name would hide those and make the position of a row look like something
+ * else, so the row keeps its value under a name that says what it is.
+ *
+ * @param {*} list list of rows
+ * @param {*} name name to give the index of the row
+ * @returns copy of the list, with the row index renamed
+ */
+function withoutIterationClash(list, name) {
+  return list.map((row) => {
+    let renamed = Object.assign({}, row, { [name]: row.index })
+    delete renamed.index
+    return renamed
+  })
+}
+
+/**
+ * Marks the rows that start a new comment group.
+ *
+ * The aggregate helpers print a comment naming the endpoint and the cluster
+ * whenever consecutive rows belong to a different cluster. Templates need the
+ * same information to reproduce that grouping, so every row reports whether it
+ * opens a group.
+ *
+ * @param {*} list list of rows
+ * @returns copy of the list, with isNewComment on every row
+ */
+function withCommentGroups(list) {
+  let previousComment = null
+  return list.map((row) => {
+    let isNewComment = row.comment != previousComment
+    previousComment = row.comment
+    return Object.assign({}, row, { isNewComment: isNewComment })
+  })
+}
+
+/**
+ * Iterates over the attributes of the endpoint configuration, in the order in
+ * which they appear in the generated attribute table.
+ *
+ * Row data includes the generated tokens (id, type, size, mask, defaultValue),
+ * where the attribute came from (endpointId, clusterId, clusterCode,
+ * clusterName, clusterSide), and how it is configured (storage, isWritable,
+ * isReadable, isNullable, isSingleton, isReportable).
+ *
+ * example:
+ * {{#endpoint_attributes}}
+ *   { {{endpoint_attribute_default}}, {{id}}, {{size}}, {{type}}, {{endpoint_attribute_mask}} },
+ * {{/endpoint_attributes}}
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_attributes(options) {
+  return templateUtil.collectBlocks(
+    withCommentGroups(
+      requireEndpointConfigData(this, this.attributeList, 'endpoint_attributes')
+    ),
+    options,
+    this
+  )
+}
+
+/**
+ * Iterates over the clusters of the endpoint configuration.
+ *
+ * Row data includes the indexes into the attribute, command and event tables,
+ * so a template can emit its own cluster table, and omitsAttributeMetadata,
+ * omitsCommandMetadata and omitsEventMetadata, which tell whether the metadata
+ * of that cluster was left out on purpose.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_clusters(options) {
+  return templateUtil.collectBlocks(
+    withCommentGroups(
+      requireEndpointConfigData(this, this.clusterList, 'endpoint_clusters')
+    ),
+    options,
+    this
+  )
+}
+
+/**
+ * Iterates over the commands of the endpoint configuration.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_commands(options) {
+  return templateUtil.collectBlocks(
+    withCommentGroups(
+      requireEndpointConfigData(this, this.commandList, 'endpoint_commands')
+    ),
+    options,
+    this
+  )
+}
+
+/**
+ * Iterates over the events of the endpoint configuration.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_events(options) {
+  return templateUtil.collectBlocks(
+    withCommentGroups(
+      requireEndpointConfigData(this, this.eventList, 'endpoint_events')
+    ),
+    options,
+    this
+  )
+}
+
+/**
+ * Iterates over the endpoint types, which is what the generated endpoint type
+ * table is built from. Every row carries the index of its first cluster, the
+ * number of clusters, and the size of the attributes of the endpoint.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_types(options) {
+  return templateUtil.collectBlocks(
+    requireEndpointConfigData(this, this.endpointList, 'endpoint_types'),
+    options,
+    this
+  )
+}
+
+/**
+ * Iterates over the endpoints of the configuration, with everything the
+ * generated fixed endpoint arrays need: identifier, profile, network, parent
+ * and the index of the endpoint type of the endpoint.
+ *
+ * Values are provided both as numbers and preformatted as hexadecimal, since
+ * the generated arrays use hexadecimal.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_fixed_endpoints(options) {
+  let endpoints = requireEndpointConfigData(
+    this,
+    this.endpoints,
+    'endpoint_fixed_endpoints'
+  )
+  let endpointTypes = this.endpointTypes || []
+  let deviceTypeOffset = 0
+  let rows = endpoints.map((ep) => {
+    let endpointType = endpointTypes.find((ept) => ept.id == ep.endpointTypeRef)
+    // An endpoint type without a device type contributes nothing to the
+    // generated device type array, so it must not be counted here either.
+    let deviceTypeCount = deviceIdentifiersOf(endpointType).length
+    let row = {
+      endpointId: ep.endpointId,
+      endpointIdHex: '0x' + bin.int16ToHex(ep.endpointId),
+      profileId: ep.profileId,
+      profileIdHex: '0x' + bin.int16ToHex(parseInt(ep.profileId)),
+      networkId: ep.networkId,
+      parentEndpointIdentifier: ep.parentEndpointIdentifier,
+      parentId:
+        ep.parentEndpointIdentifier == null
+          ? 'kInvalidEndpointId'
+          : ep.parentEndpointIdentifier,
+      endpointTypeIndex: endpointTypes.findIndex(
+        (ept) => ept.id == ep.endpointTypeRef
+      ),
+      endpointTypeName: endpointType ? endpointType.name : null,
+      deviceTypeCount: deviceTypeCount,
+      deviceTypeOffset: deviceTypeOffset
+    }
+    deviceTypeOffset += deviceTypeCount
+    return row
+  })
+  return templateUtil.collectBlocks(rows, options, this)
+}
+
+/**
+ * Iterates over all device types of the configuration, one row per device type
+ * per endpoint, which is what the generated device type array is built from.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_device_types(options) {
+  let endpointTypes = requireEndpointConfigData(
+    this,
+    this.endpointTypes,
+    'endpoint_device_types'
+  )
+  let rows = []
+  endpointTypes.forEach((ept) => {
+    // The version of a device type is found at the same position as its
+    // identifier, so the two are paired up before anything is left out.
+    let deviceTypes = (ept.deviceIdentifiers || [])
+      .map((deviceId, index) => {
+        return { deviceId: deviceId, deviceVersion: ept.deviceVersions[index] }
+      })
+      .filter((deviceType) => deviceType.deviceId != null)
+    deviceTypes.forEach((deviceType, indexOnEndpoint) => {
+      rows.push({
+        endpointId: ept.endpointId,
+        deviceId: deviceType.deviceId,
+        deviceIdHex: '0x' + bin.int32ToHex(deviceType.deviceId),
+        deviceVersion: deviceType.deviceVersion,
+        indexOnEndpoint: indexOnEndpoint,
+        deviceTypeCountOnEndpoint: deviceTypes.length
+      })
+    })
+  })
+  return templateUtil.collectBlocks(rows, options, this)
+}
+
+/**
+ * Iterates over the attributes that have a minimum and a maximum, which is
+ * what the generated min/max table is built from.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_min_max_defaults(options) {
+  return templateUtil.collectBlocks(
+    withCommentGroups(
+      requireEndpointConfigData(
+        this,
+        this.minMaxList,
+        'endpoint_min_max_defaults'
+      )
+    ),
+    options,
+    this
+  )
+}
+
+/**
+ * Iterates over the attributes that have reporting enabled, which is what the
+ * generated reporting configuration table is built from.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_reporting_defaults(options) {
+  return templateUtil.collectBlocks(
+    withCommentGroups(
+      requireEndpointConfigData(
+        this,
+        this.reportList,
+        'endpoint_reporting_defaults'
+      )
+    ),
+    options,
+    this
+  )
+}
+
+/**
+ * Iterates over the default values that do not fit inline, which is what the
+ * generated defaults blob is built from. Every row carries its `offset` into
+ * that blob and the number of bytes it occupies.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_long_defaults(options) {
+  return templateUtil.collectBlocks(
+    withCommentGroups(
+      withoutIterationClash(
+        requireEndpointConfigData(
+          this,
+          this.longDefaultsList,
+          'endpoint_long_defaults'
+        ),
+        'offset'
+      )
+    ),
+    options,
+    this
+  )
+}
+
+/**
+ * Iterates over the manufacturer code pairs of the configuration. The list is
+ * selected with the type hash argument, which is one of 'attribute', 'command'
+ * or 'cluster' and defaults to 'attribute'. Every row carries its
+ * `entryIndex` into the matching generated table and the manufacturer code.
+ *
+ * example:
+ * {{#endpoint_manufacturer_codes type="cluster"}}
+ *   { {{entryIndex}}, {{mfgCode}} }, \
+ * {{/endpoint_manufacturer_codes}}
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function endpoint_manufacturer_codes(options) {
+  let type = options.hash.type == null ? 'attribute' : options.hash.type
+  let lists = {
+    attribute: this.attributeMfgCodes,
+    command: this.commandMfgCodes,
+    cluster: this.clusterMfgCodes
+  }
+  if (!(type in lists)) {
+    throw new Error(
+      `Unknown type '${type}' for {{#endpoint_manufacturer_codes}}. Valid values are: ${Object.keys(
+        lists
+      )
+        .map((t) => `"${t}"`)
+        .join(', ')}`
+    )
+  }
+  return templateUtil.collectBlocks(
+    withoutIterationClash(
+      requireEndpointConfigData(
+        this,
+        lists[type],
+        'endpoint_manufacturer_codes'
+      ),
+      'entryIndex'
+    ),
+    options,
+    this
+  )
+}
+
+/**
+ * Formats the mask of the current attribute, inside
+ * `{{#endpoint_attributes}}`.
+ *
+ * @param {*} options
+ * @returns attribute mask expression
+ */
+function endpoint_attribute_mask(options) {
+  return format.attributeMask(this.mask)
+}
+
+/**
+ * Formats the default value of the current attribute, inside
+ * `{{#endpoint_attributes}}`. Takes the same endian and pointer hash
+ * arguments as `{{endpoint_attribute_list}}`.
+ *
+ * @param {*} options
+ * @returns default value expression
+ */
+function endpoint_attribute_default(options) {
+  return format.attributeDefaultValue(this, options.hash)
+}
+
+/**
+ * Formats the current attribute as the body of a C struct initializer, in the
+ * order given by the order hash argument, which defaults to the order used by
+ * `{{endpoint_attribute_list}}`.
+ *
+ * @param {*} options
+ * @returns comma separated initializer items
+ */
+function endpoint_attribute_items(options) {
+  let order = options.hash.order
+  if (order == null || order.length == 0) {
+    order = 'id, type, size, mask, default'
+  }
+  return format.attributeItems(this, order, options.hash)
+}
+
+/**
+ * Formats the mask of the current cluster, inside `{{#endpoint_clusters}}`.
+ *
+ * @param {*} options
+ * @returns cluster mask expression
+ */
+function endpoint_cluster_mask(options) {
+  return format.clusterMask(this.mask)
+}
+
+/**
+ * Formats the mask of the current command, inside `{{#endpoint_commands}}`.
+ *
+ * @param {*} options
+ * @returns command mask expression
+ */
+function endpoint_command_mask(options) {
+  return format.commandMask(this.mask)
+}
+
+/**
+ * Formats the mask of the current reporting row, inside
+ * `{{#endpoint_reporting_defaults}}`.
+ *
+ * @param {*} options
+ * @returns cluster mask expression
+ */
+function endpoint_reporting_mask(options) {
+  return format.clusterMask(this.mask)
+}
+
+/**
+ * Formats the current reporting row as the body of a C struct initializer.
+ * Takes the same order and minmaxorder hash arguments as
+ * `{{endpoint_reporting_config_defaults}}`.
+ *
+ * @param {*} options
+ * @returns comma separated initializer items
+ */
+function endpoint_reporting_items(options) {
+  let order = options.hash.order
+  if (order == null || order.length == 0) {
+    order = 'direction,endpoint,clusterId,attributeId,mask,mfgCode,minmax'
+  }
+  let minMaxOrder = options.hash.minmaxorder
+  if (minMaxOrder == null || minMaxOrder.length == 0) {
+    minMaxOrder = 'min,max,change'
+  }
+  return format.reportingItems(this, order, minMaxOrder)
+}
+
+/**
+ * Returns the template package category, which min/max formatting needs in
+ * order to apply the Zigbee restriction on value sizes.
+ *
+ * @param {*} options
+ * @returns category or undefined
+ */
+function templateCategory(options) {
+  return options.data?.root?.global?.genTemplatePackage?.category
+}
+
+/**
+ * Formats the current min/max row as the body of a C struct initializer, in
+ * the order given by the order hash argument, which defaults to the order used
+ * by `{{endpoint_attribute_min_max_list}}`.
+ *
+ * @param {*} options
+ * @returns comma separated initializer items
+ */
+function endpoint_min_max_items(options) {
+  let order = options.hash.order
+  if (order == null || order.length == 0) {
+    order = 'def,min,max'
+  }
+  return format.minMaxItems(this, order, templateCategory(options))
+}
+
+/**
+ * Formats the default value of the current min/max row.
+ *
+ * @param {*} options
+ * @returns default value, cast to uint16_t
+ */
+function endpoint_min_max_default(options) {
+  return format.minMaxValues(this, templateCategory(options)).def
+}
+
+/**
+ * Formats the minimum of the current min/max row.
+ *
+ * @param {*} options
+ * @returns minimum, cast to uint16_t
+ */
+function endpoint_min_max_min(options) {
+  return format.minMaxValues(this, templateCategory(options)).min
+}
+
+/**
+ * Formats the maximum of the current min/max row.
+ *
+ * @param {*} options
+ * @returns maximum, cast to uint16_t
+ */
+function endpoint_min_max_max(options) {
+  return format.minMaxValues(this, templateCategory(options)).max
+}
+
+/**
+ * Formats the bytes of the current long default value, inside
+ * `{{#endpoint_long_defaults}}`. Takes the same endian hash argument as
+ * `{{endpoint_attribute_long_defaults}}`.
+ *
+ * @param {*} options
+ * @returns comma separated list of bytes
+ */
+function endpoint_long_default_value(options) {
+  return format.longDefaultValue(this, options.hash)
+}
+
+/**
+ * Block helper that runs its body when the current row belongs to a cluster
+ * named by the argument. Names are matched case insensitively, codes in any
+ * numeric notation, and several of them can be given separated by commas or
+ * newlines.
+ *
+ * example:
+ * {{#endpoint_attributes}}
+ * {{#if_endpoint_cluster_in "Identify,0x0006"}}...{{else}}...{{/if_endpoint_cluster_in}}
+ * {{/endpoint_attributes}}
+ *
+ * @param {*} clusters cluster names or codes
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function if_endpoint_cluster_in(clusters, options) {
+  let matches = format.clusterMatches(this, format.parseClusterTokens(clusters))
+  return matches ? options.fn(this) : options.inverse(this)
+}
+
+/**
+ * Block helper that runs its body when the current row belongs to a server
+ * side cluster.
+ *
+ * @param {*} options
+ * @returns promise of a rendered block
+ */
+function if_endpoint_cluster_server(options) {
+  return this.clusterSide == dbEnum.side.server
+    ? options.fn(this)
+    : options.inverse(this)
+}
+
+// WARNING! WARNING! WARNING! WARNING! WARNING! WARNING!
+//
+// Note: these exports are public API. Templates that might have been created
+// in the past and are available in the wild might depend on these names.
+// If you rename the functions, you need to still maintain old exports list.
+
+exports.endpoint_attributes = endpoint_attributes
+exports.endpoint_clusters = endpoint_clusters
+exports.endpoint_commands = endpoint_commands
+exports.endpoint_events = endpoint_events
+exports.endpoint_types = endpoint_types
+exports.endpoint_fixed_endpoints = endpoint_fixed_endpoints
+exports.endpoint_device_types = endpoint_device_types
+exports.endpoint_min_max_defaults = endpoint_min_max_defaults
+exports.endpoint_reporting_defaults = endpoint_reporting_defaults
+exports.endpoint_long_defaults = endpoint_long_defaults
+exports.endpoint_manufacturer_codes = endpoint_manufacturer_codes
+
+exports.endpoint_attribute_mask = endpoint_attribute_mask
+exports.endpoint_attribute_default = endpoint_attribute_default
+exports.endpoint_attribute_items = endpoint_attribute_items
+exports.endpoint_cluster_mask = endpoint_cluster_mask
+exports.endpoint_command_mask = endpoint_command_mask
+exports.endpoint_reporting_mask = endpoint_reporting_mask
+exports.endpoint_reporting_items = endpoint_reporting_items
+exports.endpoint_min_max_items = endpoint_min_max_items
+exports.endpoint_min_max_default = endpoint_min_max_default
+exports.endpoint_min_max_min = endpoint_min_max_min
+exports.endpoint_min_max_max = endpoint_min_max_max
+exports.endpoint_long_default_value = endpoint_long_default_value
+
+exports.if_endpoint_cluster_in = if_endpoint_cluster_in
+exports.if_endpoint_cluster_server = if_endpoint_cluster_server

--- a/src-electron/generator/helper-endpointconfig.js
+++ b/src-electron/generator/helper-endpointconfig.js
@@ -22,6 +22,7 @@
  */
 
 const cHelper = require('./helper-c.js')
+const format = require('./endpointconfig-format.js')
 const templateUtil = require('./template-util')
 const queryEndpoint = require('../db/query-endpoint.js')
 const queryEndpointType = require('../db/query-endpoint-type.js')
@@ -302,14 +303,7 @@ function endpoint_cluster_count(options) {
 function endpoint_cluster_list(options) {
   let ret = '{ \\\n'
   this.clusterList.forEach((c) => {
-    let mask = ''
-    if (c.mask.length == 0) {
-      mask = '0'
-    } else {
-      mask = c.mask
-        .map((m) => `ZAP_CLUSTER_MASK(${m.toUpperCase()})`)
-        .join(' | ')
-    }
+    let mask = format.clusterMask(c.mask)
     ret = ret.concat(
       `  { ${c.clusterId}, ZAP_ATTRIBUTE_INDEX(${c.attributeIndex}), ${c.attributeCount}, ${c.attributeSize}, ${mask}, ${c.functions} }, /* ${c.comment} */ \\\n`
     )
@@ -333,14 +327,7 @@ function endpoint_command_list(options) {
       comment = cmd.comment
     }
 
-    let mask = ''
-    if (cmd.mask.length == 0) {
-      mask = '0'
-    } else {
-      mask = cmd.mask
-        .map((m) => `ZAP_COMMAND_MASK(${m.toUpperCase()})`)
-        .join(' | ')
-    }
+    let mask = format.commandMask(cmd.mask)
     ret += `  { ${cmd.clusterId}, ${cmd.commandId}, ${mask} }, /* ${cmd.name} */ \\\n`
   })
   ret += '}\n'
@@ -361,6 +348,11 @@ function endpoint_attribute_count(options) {
 /**
  * Get endpoint type attribute information.
  *
+ * This emits the whole attribute table as one blob. Templates that need to
+ * decide the layout themselves, or that need to leave attributes out, should
+ * iterate with `{{#endpoint_attributes}}` instead. See
+ * docs/endpoint-config-generation.md.
+ *
  * @param {*} options
  * @returns endpoint type attribute information
  */
@@ -372,71 +364,15 @@ function endpoint_attribute_list(options) {
   }
   let comment = null
 
-  let littleEndian = true
-  let pointerSize = 4
-  if (options.hash.endian == 'big') {
-    littleEndian = false
-    if (typeof options.hash.pointer != 'undefined') {
-      pointerSize = options.hash.pointer
-    }
-  }
-
   let ret = '{ \\\n'
   this.attributeList.forEach((at) => {
     if (at.comment != comment) {
       ret += `\\\n  /* ${at.comment} */ \\\n`
       comment = at.comment
     }
-
-    let mask = ''
-    if (at.mask.length == 0) {
-      mask = '0'
-    } else {
-      mask = at.mask
-        .map((m) => `ZAP_ATTRIBUTE_MASK(${m.toUpperCase()})`)
-        .join(' | ')
-    }
-    // If no default value is found, default to 0
-    let finalDefaultValue
-    if (!at.defaultValue) {
-      finalDefaultValue = `ZAP_EMPTY_DEFAULT()`
-    } else if (at.isMacro) {
-      finalDefaultValue = at.defaultValue
-    } else {
-      let defaultValue = at.defaultValue
-      if (!littleEndian) {
-        defaultValue = Number(defaultValue)
-          .toString(16)
-          .padStart(6, '0x0000')
-          .padEnd(2 + 2 * pointerSize, '0')
-      }
-      finalDefaultValue = `ZAP_SIMPLE_DEFAULT(${defaultValue})`
-    }
-    let orderTokens = order.split(',').map((x) => (x ? x.trim() : ''))
-    let items = []
-    orderTokens.forEach((tok) => {
-      switch (tok) {
-        case 'default':
-          items.push(finalDefaultValue)
-          break
-        case 'id':
-          items.push(at.id)
-          break
-        case 'size':
-          items.push(at.size)
-          break
-        case 'type':
-          items.push(at.type)
-          break
-        case 'mask':
-          items.push(mask)
-          break
-        default:
-          throw new Error(`Unknown token '${tok}' in order optional argument`)
-      }
-    })
-
-    ret += `  { ${items.join(', ')} }, /* ${at.name} */  \\\n`
+    ret += `  { ${format.attributeItems(at, order, options.hash)} }, /* ${
+      at.name
+    } */  \\\n`
   })
   ret += '}\n'
 
@@ -597,68 +533,11 @@ function endpoint_attribute_min_max_list(options) {
   let ret = '{ \\\n'
   const category = options.data?.root?.global?.genTemplatePackage?.category
   this.minMaxList.forEach((mm, index) => {
-    if (mm.typeSize > 2 && category === dbEnum.helperCategory.zigbee) {
-      throw new Error(
-        `Can't have min/max for attributes larger than 2 bytes like '${mm.name}'`
-      )
-    }
     if (mm.comment != comment) {
       ret += `\\\n  /* ${mm.comment} */ \\\n`
       comment = mm.comment
     }
-
-    let def = parseInt(mm.default)
-    let min = parseInt(mm.min)
-    let max = parseInt(mm.max)
-
-    if (isNaN(def)) def = 0
-    if (isNaN(min)) {
-      if (mm.typeSize < 1)
-        throw new Error(
-          'Invalid type size for min value: ' + JSON.stringify(mm)
-        )
-      if (mm.isTypeSigned) {
-        min = '0x80' + '00'.repeat(mm.typeSize - 1)
-      } else {
-        min = 0
-      }
-    }
-    if (isNaN(max)) {
-      if (mm.typeSize < 1)
-        throw new Error(
-          'Invalid type size for max value: ' + JSON.stringify(mm)
-        )
-      if (mm.isTypeSigned) {
-        max = '0x7F' + 'FF'.repeat(mm.typeSize - 1)
-      } else {
-        max = '0x' + 'FF'.repeat(mm.typeSize)
-      }
-    }
-
-    let defS =
-      (def >= 0 ? '' : '-') + '0x' + Math.abs(def).toString(16).toUpperCase()
-    let minS =
-      (min >= 0 ? '' : '-') + '0x' + Math.abs(min).toString(16).toUpperCase()
-    let maxS =
-      (max >= 0 ? '' : '-') + '0x' + Math.abs(max).toString(16).toUpperCase()
-    let defMinMaxItems = []
-    order
-      .split(',')
-      .map((x) => (x ? x.trim() : ''))
-      .forEach((tok) => {
-        switch (tok) {
-          case 'def':
-            defMinMaxItems.push(`(uint16_t)${defS}`)
-            break
-          case 'min':
-            defMinMaxItems.push(`(uint16_t)${minS}`)
-            break
-          case 'max':
-            defMinMaxItems.push(`(uint16_t)${maxS}`)
-            break
-        }
-      })
-    ret += `  { ${defMinMaxItems.join(', ')} }${
+    ret += `  { ${format.minMaxItems(mm, order, category)} }${
       index == this.minMaxList.length - 1 ? '' : ','
     } /* ${mm.name} */ \\\n`
   })
@@ -692,63 +571,9 @@ function endpoint_reporting_config_defaults(options) {
       ret += `\\\n  /* ${r.comment} */ \\\n`
       comment = r.comment
     }
-
-    let minmaxItems = []
-    let minmaxToks = minmaxorder.split(',').map((x) => (x ? x.trim() : ''))
-    minmaxToks.forEach((tok) => {
-      switch (tok) {
-        case 'min':
-          minmaxItems.push(r.minOrSource)
-          break
-        case 'max':
-          minmaxItems.push(r.maxOrEndpoint)
-          break
-        case 'change':
-          minmaxItems.push(r.reportableChangeOrTimeout)
-          break
-      }
-    })
-    let minmax = minmaxItems.join(', ')
-    let mask = ''
-    if (r.mask.length == 0) {
-      mask = '0'
-    } else {
-      mask = r.mask
-        .map((m) => `ZAP_CLUSTER_MASK(${m.toUpperCase()})`)
-        .join(' | ')
-    }
-    let orderTokens = order.split(',').map((x) => (x ? x.trim() : ''))
-    let items = []
-    orderTokens.forEach((tok) => {
-      switch (tok) {
-        case 'direction':
-          items.push(`ZAP_REPORT_DIRECTION(${r.direction})`)
-          break
-        case 'endpoint':
-          items.push(r.endpoint)
-          break
-        case 'clusterId':
-          items.push(r.clusterId)
-          break
-        case 'attributeId':
-          items.push(r.attributeId)
-          break
-        case 'mask':
-          items.push(mask)
-          break
-        case 'mfgCode':
-          items.push(r.mfgCode)
-          break
-        case 'minmax':
-          items.push(`{{ ${minmax} }}`)
-          break
-        default:
-          throw new Error(`Unknown token '${tok}' in order optional argument`)
-      }
-    })
-
-    let singleRow = `  { ${items.join(', ')} }, /* ${r.name} */ \\\n`
-    ret += singleRow
+    ret += `  { ${format.reportingItems(r, order, minmaxorder)} }, /* ${
+      r.name
+    } */ \\\n`
   })
   ret += '}\n'
 
@@ -783,22 +608,11 @@ function endpoint_attribute_long_defaults_count(options) {
  */
 function endpoint_attribute_long_defaults(options) {
   let comment = null
-
-  let littleEndian = true
-  if (options.hash.endian == 'big') {
-    littleEndian = false
-  }
+  let littleEndian = format.endianOptions(options.hash).littleEndian
 
   let ret = '{ \\\n'
   this.longDefaultsList.forEach((ld) => {
-    let value = ld.value
-    if (littleEndian && !types.isString(ld.type)) {
-      // ld.value is in big-endian order.  For types for which endianness
-      // matters, we need to reverse it.
-      let valArr = value.split(/\s*,\s*/).filter((s) => s.length != 0)
-      valArr.reverse()
-      value = valArr.join(', ') + ', '
-    }
+    let value = format.longDefaultValue(ld, options.hash)
     if (ld.comment != comment) {
       ret += `\\\n  /* ${ld.comment}, ${
         littleEndian ? 'little-endian' : 'big-endian'
@@ -914,7 +728,11 @@ async function collectAttributes(
     let endpoint = {
       clusterIndex: clusterIndex,
       clusterCount: ept.clusters.length,
-      attributeSize: 0
+      attributeSize: 0,
+      endpointId: ept.endpointId,
+      endpointTypeName: ept.name,
+      deviceIdentifier: ept.deviceIdentifier,
+      deviceVersion: ept.deviceVersion
     }
 
     let device = {
@@ -932,16 +750,25 @@ async function collectAttributes(
       let cluster = {
         endpointId: ept.endpointId,
         clusterId: asMEI(c.manufacturerCode, c.code),
+        clusterCode: c.code,
         clusterName: c.name,
+        clusterDefine: c.define,
         clusterSide: c.side,
+        manufacturerCode: c.manufacturerCode,
         attributeIndex: attributeIndex,
         attributeCount: c.attributes.length,
         attributeSize: 0,
         eventIndex: eventIndex,
         eventCount: c.events.length,
+        commandCount: c.commands.length,
         mask: [],
         commands: [],
         functions: 'NULL',
+        // Set when a template asked for this cluster's metadata to be left
+        // out, which is how code driven clusters avoid duplicated tables.
+        omitsAttributeMetadata: c.omitsAttributeMetadata === true,
+        omitsCommandMetadata: c.omitsCommandMetadata === true,
+        omitsEventMetadata: c.omitsEventMetadata === true,
         comment: `Endpoint: ${ept.endpointId}, Cluster: ${c.name} (${c.side})`
       }
       clusterAttributeSize = 0
@@ -1053,7 +880,12 @@ async function collectAttributes(
             index: longDefaultsIndex,
             name: a.name,
             comment: cluster.comment,
-            type: a.type
+            type: a.type,
+            code: a.code,
+            endpointId: ept.endpointId,
+            clusterCode: c.code,
+            clusterName: c.name,
+            clusterSide: c.side
           }
           attributeDefaultValue = `ZAP_LONG_DEFAULTS_INDEX(${longDefaultsIndex})`
           defaultValueIsMacro = true
@@ -1100,7 +932,12 @@ async function collectAttributes(
             name: a.name,
             comment: cluster.comment,
             typeSize: typeSize,
-            isTypeSigned: type_size_and_sign.isTypeSigned
+            isTypeSigned: type_size_and_sign.isTypeSigned,
+            code: a.code,
+            endpointId: ept.endpointId,
+            clusterCode: c.code,
+            clusterName: c.name,
+            clusterSide: c.side
           }
 
           attributeDefaultValue = `ZAP_MIN_MAX_DEFAULTS_INDEX(${minMaxIndex})`
@@ -1124,7 +961,11 @@ async function collectAttributes(
             maxOrEndpoint: a.maxInterval,
             reportableChangeOrTimeout: a.reportableChange,
             name: a.name,
-            comment: cluster.comment
+            comment: cluster.comment,
+            code: a.code,
+            clusterCode: c.code,
+            clusterName: c.name,
+            clusterSide: c.side
           }
           reportList.push(rpt)
         }
@@ -1190,7 +1031,26 @@ async function collectAttributes(
           defaultValue: attributeDefaultValue, // default value, pointer to default value, or pointer to min/max/value triplet.
           isMacro: defaultValueIsMacro,
           name: a.name,
-          comment: cluster.comment
+          comment: cluster.comment,
+          // Everything below describes where this attribute came from and how
+          // it is configured. Templates that iterate attributes use these to
+          // filter, group or annotate rows.
+          code: a.code,
+          define: a.define,
+          zclType: a.type,
+          storage: a.storage,
+          storageSize: storageSize,
+          isWritable: a.isWritable,
+          isReadable: a.isReadable,
+          isNullable: a.isNullable,
+          isSingleton: a.isSingleton,
+          isReportable: a.includedReportable ? true : false,
+          manufacturerCode: a.manufacturerCode,
+          endpointId: ept.endpointId,
+          clusterId: cluster.clusterId,
+          clusterCode: c.code,
+          clusterName: c.name,
+          clusterSide: c.side
         }
         attributeList.push(attr)
 
@@ -1244,7 +1104,15 @@ async function collectAttributes(
         let command = {
           endpointId: ept.endpointId,
           clusterId: asMEI(c.manufacturerCode, c.code),
+          clusterCode: c.code,
+          clusterName: c.name,
+          clusterSide: c.side,
           commandId: asMEI(cmd.manufacturerCode, cmd.code),
+          code: cmd.code,
+          source: cmd.source,
+          isIncoming: cmd.isIncoming ? true : false,
+          isOutgoing: cmd.isOutgoing ? true : false,
+          manufacturerCode: cmd.manufacturerCode,
           mask: mask,
           name: cmd.name,
           comment: cluster.comment,
@@ -1272,7 +1140,14 @@ async function collectAttributes(
       c.events.forEach((ev) => {
         let event = {
           eventId: asMEI(ev.manufacturerCode, ev.code),
+          code: ev.code,
           name: ev.name,
+          manufacturerCode: ev.manufacturerCode,
+          endpointId: ept.endpointId,
+          clusterId: cluster.clusterId,
+          clusterCode: c.code,
+          clusterName: c.name,
+          clusterSide: c.side,
           comment: cluster.comment
         }
         eventList.push(event)
@@ -1387,8 +1262,47 @@ function isGlobalAttrExcludedFromMetadata(attr) {
 }
 
 /**
+ * Drops the metadata that a template asked not to be generated for a cluster.
+ *
+ * Code driven clusters keep their own attribute, command and event tables in
+ * C++, so generating them here as well costs flash without adding anything.
+ * Dropping the rows at load time, before indexes and counts are calculated,
+ * keeps the generated tables and the indexes pointing into them consistent.
+ *
+ * @param {*} cluster cluster as loaded from the database
+ * @param {*} omitted omitted metadata token sets
+ */
+function applyMetadataOmissions(cluster, omitted) {
+  if (format.clusterMatches(cluster, omitted.attributes)) {
+    cluster.attributes = []
+    cluster.omitsAttributeMetadata = true
+  }
+  if (format.clusterMatches(cluster, omitted.commands)) {
+    cluster.commands = []
+    cluster.omitsCommandMetadata = true
+  }
+  if (format.clusterMatches(cluster, omitted.events)) {
+    cluster.events = []
+    cluster.omitsEventMetadata = true
+  }
+}
+
+/**
  * Starts the endpoint configuration block.,
  * longDefaults: longDefaults
+ *
+ * Hash arguments:
+ * - allowUnknownStorageOption: tolerate attributes with an unknown storage
+ *   policy instead of failing generation.
+ * - spaceForDefaultValue: how many bytes a default value can occupy inline
+ *   before it moves into the long defaults table.
+ * - isReadableMaskGenerationEnabled: add the readable mask to attributes.
+ * - omitAttributeMetadataClusters, omitCommandMetadataClusters,
+ *   omitEventMetadataClusters: cluster names or codes, separated by commas or
+ *   newlines, whose metadata is left out of the generated tables. The clusters
+ *   themselves stay in the cluster table, with a count of zero. Prefer codes
+ *   for names that contain a slash, such as On/Off, because handlebars reads a
+ *   slash inside a block tag as the start of the closing tag.
  *
  * @param {*} options
  * @returns a promise of a rendered block
@@ -1400,6 +1314,15 @@ function endpoint_config(options) {
   }
   let db = this.global.db
   let sessionId = this.global.sessionId
+  let omittedMetadata = {
+    attributes: format.parseClusterTokens(
+      options.hash.omitAttributeMetadataClusters
+    ),
+    commands: format.parseClusterTokens(
+      options.hash.omitCommandMetadataClusters
+    ),
+    events: format.parseClusterTokens(options.hash.omitEventMetadataClusters)
+  }
   let collectAttributesOptions = {
     allowUnknownStorageOption:
       options.hash.allowUnknownStorageOption !== 'false',
@@ -1502,7 +1425,11 @@ function endpoint_config(options) {
                   })
               )
             })
-            return Promise.all(ps)
+            return Promise.all(ps).then(() =>
+              clusters.forEach((cl) =>
+                applyMetadataOmissions(cl, omittedMetadata)
+              )
+            )
           })
         )
       })
@@ -1525,6 +1452,7 @@ function endpoint_config(options) {
     )
     .then((collection) => {
       Object.assign(newContext, collection)
+      newContext.omittedMetadata = omittedMetadata
     })
     .then(() => options.fn(newContext))
     .catch((err) =>

--- a/src-electron/generator/template-engine.js
+++ b/src-electron/generator/template-engine.js
@@ -37,6 +37,7 @@ const includedHelpers = [
   require('./helper-session'),
   require('./helper-shared-config'),
   require('./helper-endpointconfig'),
+  require('./helper-endpointconfig-iterators'),
   require('./helper-sdkextension'),
   require('./helper-tokens'),
   require('./helper-attribute'),

--- a/test/endpointconfig-format.test.js
+++ b/test/endpointconfig-format.test.js
@@ -1,0 +1,224 @@
+/**
+ *
+ *    Copyright (c) 2026 Silicon Labs
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ * @jest-environment node
+ */
+
+const format = require('../src-electron/generator/endpointconfig-format')
+const dbEnum = require('../src-shared/db-enum')
+const testUtil = require('./test-util')
+
+test(
+  'Endpoint config masks',
+  () => {
+    expect(format.attributeMask([])).toEqual('0')
+    expect(format.attributeMask(['writable', 'nullable'])).toEqual(
+      'ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(NULLABLE)'
+    )
+    expect(format.clusterMask(['server'])).toEqual('ZAP_CLUSTER_MASK(SERVER)')
+    expect(format.commandMask(['incoming_server'])).toEqual(
+      'ZAP_COMMAND_MASK(INCOMING_SERVER)'
+    )
+  },
+  testUtil.timeout.short()
+)
+
+test(
+  'Endpoint config attribute default values',
+  () => {
+    // No default value at all.
+    expect(format.attributeDefaultValue({ defaultValue: null }, {})).toEqual(
+      'ZAP_EMPTY_DEFAULT()'
+    )
+    // Values that live in another table are referenced by macro.
+    expect(
+      format.attributeDefaultValue(
+        { defaultValue: 'ZAP_LONG_DEFAULTS_INDEX(4)', isMacro: true },
+        {}
+      )
+    ).toEqual('ZAP_LONG_DEFAULTS_INDEX(4)')
+    // Inline values are emitted as they are for little-endian targets, and
+    // padded to the pointer size for big-endian ones.
+    expect(
+      format.attributeDefaultValue({ defaultValue: '0x1234' }, {})
+    ).toEqual('ZAP_SIMPLE_DEFAULT(0x1234)')
+    expect(
+      format.attributeDefaultValue(
+        { defaultValue: '0x1234' },
+        { endian: 'big', pointer: 4 }
+      )
+    ).toEqual('ZAP_SIMPLE_DEFAULT(0x12340000)')
+    expect(
+      format.attributeDefaultValue(
+        { defaultValue: '0x1234' },
+        { endian: 'big', pointer: 8 }
+      )
+    ).toEqual('ZAP_SIMPLE_DEFAULT(0x1234000000000000)')
+  },
+  testUtil.timeout.short()
+)
+
+test(
+  'Endpoint config attribute row items follow the requested order',
+  () => {
+    let attribute = {
+      id: '0x00000000',
+      type: 'ZAP_TYPE(INT16U)',
+      size: 2,
+      mask: ['writable'],
+      defaultValue: '0x01'
+    }
+    expect(
+      format.attributeItems(attribute, 'id, type, size, mask, default', {})
+    ).toEqual(
+      '0x00000000, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE), ZAP_SIMPLE_DEFAULT(0x01)'
+    )
+    expect(
+      format.attributeItems(attribute, 'default,id,size,type,mask', {})
+    ).toEqual(
+      'ZAP_SIMPLE_DEFAULT(0x01), 0x00000000, 2, ZAP_TYPE(INT16U), ZAP_ATTRIBUTE_MASK(WRITABLE)'
+    )
+    expect(() => format.attributeItems(attribute, 'nonsense', {})).toThrow(
+      "Unknown token 'nonsense'"
+    )
+  },
+  testUtil.timeout.short()
+)
+
+test(
+  'Endpoint config min max values fall back to the extremes of the type',
+  () => {
+    expect(
+      format.minMaxValues({ default: 5, min: 1, max: 10, typeSize: 1 })
+    ).toEqual({
+      def: '(uint16_t)0x5',
+      min: '(uint16_t)0x1',
+      max: '(uint16_t)0xA'
+    })
+    // Unsigned attributes without a range use the whole range of the type.
+    expect(
+      format.minMaxValues({
+        default: 0,
+        min: NaN,
+        max: NaN,
+        typeSize: 2,
+        isTypeSigned: false
+      })
+    ).toEqual({
+      def: '(uint16_t)0x0',
+      min: '(uint16_t)0x0',
+      max: '(uint16_t)0xFFFF'
+    })
+    // Signed ones use the signed range.
+    expect(
+      format.minMaxValues({
+        default: 0,
+        min: NaN,
+        max: NaN,
+        typeSize: 2,
+        isTypeSigned: true
+      })
+    ).toEqual({
+      def: '(uint16_t)0x0',
+      min: '(uint16_t)0x8000',
+      max: '(uint16_t)0x7FFF'
+    })
+    // Zigbee stores a single 16 bit value, so anything wider is an error.
+    expect(() =>
+      format.minMaxValues(
+        { default: 0, min: 0, max: 1, typeSize: 4, name: 'Wide' },
+        dbEnum.helperCategory.zigbee
+      )
+    ).toThrow("Can't have min/max for attributes larger than 2 bytes")
+  },
+  testUtil.timeout.short()
+)
+
+test(
+  'Endpoint config long default values are reversed for little-endian targets',
+  () => {
+    let longDefault = { value: '0x12, 0x34, ', type: 'int16u' }
+    expect(format.longDefaultValue(longDefault, { endian: 'big' })).toEqual(
+      '0x12, 0x34, '
+    )
+    expect(format.longDefaultValue(longDefault, { endian: 'little' })).toEqual(
+      '0x34, 0x12, '
+    )
+    // Strings are already in the order in which they are stored.
+    let string = { value: "3, 'a', 'b', 'c', ", type: 'char_string' }
+    expect(format.longDefaultValue(string, { endian: 'little' })).toEqual(
+      "3, 'a', 'b', 'c', "
+    )
+  },
+  testUtil.timeout.short()
+)
+
+test(
+  'Endpoint config cluster matching accepts names, codes and separators',
+  () => {
+    let tokens = format.parseClusterTokens(
+      'Level Control, 0x0006 \n Identify,,  '
+    )
+    expect(tokens).toEqual(['Level Control', '0x0006', 'Identify'])
+
+    // Names match case insensitively, codes in any notation.
+    expect(
+      format.clusterMatches({ name: 'level control', code: 8 }, tokens)
+    ).toBeTruthy()
+
+    // Rows of the endpoint configuration are matched by the cluster they
+    // belong to, not by their own name or code.
+    let identifyTime = {
+      name: 'IdentifyTime',
+      code: 0,
+      clusterName: 'Identify',
+      clusterCode: 3
+    }
+    expect(format.clusterMatches(identifyTime, tokens)).toBeTruthy()
+    let onOffAttribute = {
+      name: 'OnOff',
+      code: 0,
+      clusterName: 'On/Off',
+      clusterCode: 6
+    }
+    expect(format.clusterMatches(onOffAttribute, tokens)).toBeTruthy()
+    // An attribute of another cluster whose own code is 0x0006 is not a match.
+    expect(
+      format.clusterMatches(
+        {
+          name: 'Whatever',
+          code: 6,
+          clusterName: 'Basic Information',
+          clusterCode: 40
+        },
+        tokens
+      )
+    ).toBeFalsy()
+    expect(
+      format.clusterMatches({ name: 'On/Off', code: 6 }, tokens)
+    ).toBeTruthy()
+    expect(
+      format.clusterMatches({ clusterName: 'Identify', clusterCode: 3 }, tokens)
+    ).toBeTruthy()
+    expect(
+      format.clusterMatches({ name: 'Descriptor', code: 0x1d }, tokens)
+    ).toBeFalsy()
+    // An empty list never matches, so leaving the option out changes nothing.
+    expect(format.clusterMatches({ name: 'Identify', code: 3 }, [])).toBeFalsy()
+  },
+  testUtil.timeout.short()
+)

--- a/test/gen-matter-3-1.test.js
+++ b/test/gen-matter-3-1.test.js
@@ -345,6 +345,148 @@ test(
   testUtil.timeout.long()
 )
 
+/**
+ * Returns the text between the begin and end markers of a section of the
+ * template driven endpoint configuration.
+ *
+ * @param {*} content generated file content
+ * @param {*} name section name
+ * @returns section text
+ */
+function endpointConfigSection(content, name) {
+  let section = content.match(
+    new RegExp(`// BEGIN ${name}\\n([\\s\\S]*?)// END ${name}`)
+  )
+  expect(section).not.toBeNull()
+  return section[1]
+}
+
+test(
+  `Template driven endpoint configuration: ${path.relative(
+    __dirname,
+    testFile
+  )}`,
+  async () => {
+    let sessionId = await querySession.createBlankSession(db)
+
+    await importJs.importDataFromFile(db, testFile, {
+      sessionId: sessionId
+    })
+
+    let genResult = await genEngine.generate(
+      db,
+      sessionId,
+      templateContext.packageId,
+      {},
+      { disableDeprecationWarnings: true }
+    )
+    expect(genResult.hasErrors).toEqual(false)
+
+    let ept = genResult.content['endpoint_config_iterators.h']
+    expect(ept).not.toBeNull()
+
+    // A template that iterates the endpoint configuration must be able to
+    // produce exactly what the aggregate helpers produce. Anything less means
+    // an SDK cannot move a table into its own template without churn in the
+    // generated output.
+    for (const table of [
+      'ATTRIBUTES',
+      'MIN MAX',
+      'CLUSTERS',
+      'COMMANDS',
+      'ENDPOINT TYPES',
+      'LONG DEFAULTS',
+      'ATTRIBUTE MFG CODES',
+      'FIXED ARRAYS'
+    ]) {
+      expect(endpointConfigSection(ept, `ITERATED ${table}`)).toEqual(
+        endpointConfigSection(ept, `AGGREGATE ${table}`)
+      )
+    }
+
+    // Sanity check that the comparison above is not comparing empty sections.
+    expect(endpointConfigSection(ept, 'AGGREGATE ATTRIBUTES')).toContain(
+      'ZAP_TYPE('
+    )
+    expect(endpointConfigSection(ept, 'AGGREGATE MIN MAX')).toContain(
+      '(uint16_t)'
+    )
+    expect(endpointConfigSection(ept, 'AGGREGATE LONG DEFAULTS')).toContain(
+      "'C', 'o', 'f', 'f', 'e', 'e'"
+    )
+
+    // Lists whose rows carry an index into a generated table keep that value
+    // under its own name, so the position of a row in the iteration, and with
+    // it {{#first}} and {{#last}}, stay usable.
+    let positions = endpointConfigSection(ept, 'LONG DEFAULT POSITIONS')
+      .trim()
+      .split('\n')
+    expect(positions.length).toBeGreaterThan(1)
+    positions.forEach((line, index) => {
+      expect(line).toMatch(
+        new RegExp(`^POSITION ${index} of ${positions.length} offset \\d+`)
+      )
+    })
+    expect(positions[0]).toContain('FIRST')
+    expect(positions[positions.length - 1]).toContain('LAST')
+    expect(positions.filter((line) => line.includes('LAST')).length).toEqual(1)
+
+    // Clusters that keep their own metadata in C++ can have it left out of
+    // the generated tables, while keeping their place in the cluster table.
+    let omitted = endpointConfigSection(ept, 'OMITTED')
+    // Level Control was omitted by name, and keeps its commands.
+    expect(omitted).toContain(
+      'CLUSTER Level Control attributes=0 commands=8 attributesOmitted=true commandsOmitted=false'
+    )
+    // On/Off was omitted by code, for both attributes and commands.
+    expect(omitted).toContain(
+      'CLUSTER On/Off attributes=0 commands=0 attributesOmitted=true commandsOmitted=true'
+    )
+    // Identify was not named, so nothing changes for it.
+    expect(omitted).toContain(
+      'CLUSTER Identify attributes=4 commands=2 attributesOmitted=false commandsOmitted=false'
+    )
+    expect(omitted).not.toContain('LEFTOVER')
+
+    // Rows are matched by the cluster they belong to. Matching by the name or
+    // the code of the row itself would both miss these and pick up attributes
+    // of other clusters.
+    let byName = omitted.match(/BY NAME .*/g)
+    let byCode = omitted.match(/BY CODE .*/g)
+    expect(byName).not.toBeNull()
+    expect(byName).toContain('BY NAME Identify.IdentifyTime')
+    expect(byName.map((l) => l.replace('BY NAME', 'BY CODE'))).toEqual(byCode)
+    byName.forEach((line) => expect(line).toContain('Identify.'))
+
+    // Dropping metadata has to shrink the tables, otherwise there is no flash
+    // to be saved.
+    let attributeCount = Number(omitted.match(/ATTRIBUTE COUNT (\d+)/)[1])
+    let commandCount = Number(omitted.match(/COMMAND COUNT (\d+)/)[1])
+    let full = genResult.content['endpoint_config.h']
+    expect(attributeCount).toBeLessThan(
+      Number(full.match(/#define GENERATED_ATTRIBUTE_COUNT (\d+)/)[1])
+    )
+    expect(commandCount).toBeGreaterThan(0)
+
+    // The cluster table indexes the attribute table, so the ranges of the
+    // clusters have to cover the shortened table without gaps or overlap.
+    let expectedIndex = 0
+    for (const range of omitted.matchAll(/RANGE (\d+) (\d+)/g)) {
+      expect(Number(range[1])).toEqual(expectedIndex)
+      expectedIndex += Number(range[2])
+    }
+    expect(expectedIndex).toEqual(attributeCount)
+
+    // The same has to hold for the cluster table that the SDK generates from
+    // this data with its own helper.
+    let clusterTable = endpointConfigSection(ept, 'OMITTED CLUSTER TABLE')
+    expect(clusterTable).toMatch(
+      /Cluster: On\/Off \(server\) \*\/ \\\s+\.clusterId = 0x00000006, \\\s+\.attributes = ZAP_ATTRIBUTE_INDEX\(\d+\), \\\s+\.attributeCount = 0,/
+    )
+  },
+  testUtil.timeout.long()
+)
+
 test(
   `Zap multiple device type per endpoint file generation: ${path.relative(
     __dirname,

--- a/test/gen-template/matter3/endpoint_config_iterators.zapt
+++ b/test/gen-template/matter3/endpoint_config_iterators.zapt
@@ -1,0 +1,183 @@
+// Template driven endpoint configuration.
+//
+// Every table below is generated twice: once with the aggregate helper that
+// builds the table in javascript, and once by iterating the same data in this
+// template. The test asserts that both halves are identical, which is what
+// makes it safe for an SDK to move a table into its own template and then
+// change only the part it cares about.
+
+{{#endpoint_config allowUnknownStorageOption="false" spaceForDefaultValue=4}}
+// BEGIN AGGREGATE ATTRIBUTES
+{{endpoint_attribute_list order='default,id,size,type,mask'~}}
+// END AGGREGATE ATTRIBUTES
+
+// BEGIN ITERATED ATTRIBUTES
+{ \
+{{#endpoint_attributes}}
+{{#if isNewComment}}
+\
+  /* {{comment}} */ \
+{{/if}}
+  { {{endpoint_attribute_items order='default,id,size,type,mask'}} }, /* {{name}} */  \
+{{/endpoint_attributes}}
+}
+// END ITERATED ATTRIBUTES
+
+// BEGIN AGGREGATE MIN MAX
+{{endpoint_attribute_min_max_list~}}
+// END AGGREGATE MIN MAX
+
+// BEGIN ITERATED MIN MAX
+{ \
+{{#endpoint_min_max_defaults}}
+{{#if isNewComment}}
+\
+  /* {{comment}} */ \
+{{/if}}
+  { {{endpoint_min_max_default}}, {{endpoint_min_max_min}}, {{endpoint_min_max_max}} }{{#not_last}},{{/not_last}} /* {{name}} */ \
+{{/endpoint_min_max_defaults}}
+}
+// END ITERATED MIN MAX
+
+// BEGIN AGGREGATE CLUSTERS
+{{endpoint_cluster_list~}}
+// END AGGREGATE CLUSTERS
+
+// BEGIN ITERATED CLUSTERS
+{ \
+{{#endpoint_clusters}}
+  { {{clusterId}}, ZAP_ATTRIBUTE_INDEX({{attributeIndex}}), {{attributeCount}}, {{attributeSize}}, {{endpoint_cluster_mask}}, {{functions}} }, /* {{comment}} */ \
+{{/endpoint_clusters}}
+}
+// END ITERATED CLUSTERS
+
+// BEGIN AGGREGATE COMMANDS
+{{endpoint_command_list~}}
+// END AGGREGATE COMMANDS
+
+// BEGIN ITERATED COMMANDS
+{ \
+{{#endpoint_commands}}
+{{#if isNewComment}}
+\
+  /* {{comment}} */ \
+{{/if}}
+  { {{clusterId}}, {{commandId}}, {{endpoint_command_mask}} }, /* {{name}} */ \
+{{/endpoint_commands}}
+}
+// END ITERATED COMMANDS
+
+// BEGIN AGGREGATE ENDPOINT TYPES
+{{endpoint_types_list~}}
+// END AGGREGATE ENDPOINT TYPES
+
+// BEGIN ITERATED ENDPOINT TYPES
+{ \
+{{#endpoint_types}}
+  { ZAP_CLUSTER_INDEX({{clusterIndex}}), {{clusterCount}}, {{attributeSize}} }, \
+{{/endpoint_types}}
+}
+// END ITERATED ENDPOINT TYPES
+
+// BEGIN AGGREGATE LONG DEFAULTS
+{{endpoint_attribute_long_defaults endian="little"~}}
+// END AGGREGATE LONG DEFAULTS
+
+// BEGIN ITERATED LONG DEFAULTS
+{ \
+{{#endpoint_long_defaults}}
+{{#if isNewComment}}
+\
+  /* {{comment}}, little-endian */\
+\
+{{/if}}
+  /* {{offset}} - {{name}}, */\
+  {{endpoint_long_default_value endian="little"}}\
+\
+{{/endpoint_long_defaults}}
+}
+// END ITERATED LONG DEFAULTS
+
+// BEGIN LONG DEFAULT POSITIONS
+{{#endpoint_long_defaults}}
+POSITION {{index}} of {{count}} offset {{offset}}{{#first}} FIRST{{/first}}{{#last}} LAST{{/last}}
+{{/endpoint_long_defaults}}
+// END LONG DEFAULT POSITIONS
+
+// BEGIN AGGREGATE ATTRIBUTE MFG CODES
+{{endpoint_attribute_manufacturer_codes~}}
+// END AGGREGATE ATTRIBUTE MFG CODES
+
+// BEGIN ITERATED ATTRIBUTE MFG CODES
+{ \
+{{#endpoint_manufacturer_codes type="attribute"}}
+  { {{entryIndex}}, {{mfgCode}} },\
+{{else}}
+  { 0x00, 0x00 } \
+{{/endpoint_manufacturer_codes}}
+}
+// END ITERATED ATTRIBUTE MFG CODES
+
+// BEGIN AGGREGATE FIXED ARRAYS
+{{endpoint_fixed_endpoint_array}}
+{{endpoint_fixed_profile_id_array}}
+{{endpoint_fixed_parent_id_array}}
+{{endpoint_fixed_network_array}}
+{{endpoint_fixed_endpoint_type_array}}
+{{endpoint_fixed_device_type_array}}
+{{endpoint_fixed_device_type_array isEndpointIncluded=true}}
+{{endpoint_fixed_device_type_array_offsets}}
+{{endpoint_fixed_device_type_array_lengths}}
+// END AGGREGATE FIXED ARRAYS
+
+// BEGIN ITERATED FIXED ARRAYS
+{ {{#endpoint_fixed_endpoints}}{{endpointIdHex}}{{#not_last}}, {{/not_last}}{{/endpoint_fixed_endpoints}} }
+{ {{#endpoint_fixed_endpoints}}{{profileIdHex}}{{#not_last}}, {{/not_last}}{{/endpoint_fixed_endpoints}} }
+{ {{#endpoint_fixed_endpoints}}{{parentId}}{{#not_last}}, {{/not_last}}{{/endpoint_fixed_endpoints}} }
+{ {{#endpoint_fixed_endpoints}}{{networkId}}{{#not_last}}, {{/not_last}}{{/endpoint_fixed_endpoints}} }
+{ {{#endpoint_fixed_endpoints}}{{endpointTypeIndex}}{{#not_last}}, {{/not_last}}{{/endpoint_fixed_endpoints}} }
+{ {{~#endpoint_device_types}}{ {{~deviceIdHex}},{{deviceVersion~}} }{{#not_last}},{{/not_last}}{{/endpoint_device_types~}} }
+{ {{~#endpoint_device_types}}{ {{~deviceIdHex}},{{deviceVersion}},{{endpointId~}} }{{#not_last}},{{/not_last}}{{/endpoint_device_types~}} }
+{ {{#endpoint_fixed_endpoints}}{{deviceTypeOffset}}{{#not_last}},{{/not_last}}{{/endpoint_fixed_endpoints~}} }
+{ {{#endpoint_fixed_endpoints}}{{deviceTypeCount}}{{#not_last}},{{/not_last}}{{/endpoint_fixed_endpoints~}} }
+// END ITERATED FIXED ARRAYS
+{{/endpoint_config}}
+
+// Attribute metadata of code driven clusters, which keep their own tables in
+// C++, can be left out. The cluster stays in the cluster table with a count of
+// zero, so indexes into the attribute table stay consistent.
+{{#endpoint_config allowUnknownStorageOption="false" spaceForDefaultValue=4 omitAttributeMetadataClusters="Level Control,0x0006" omitCommandMetadataClusters="0x0006"}}
+// BEGIN OMITTED
+ATTRIBUTE COUNT {{endpoint_attribute_count}}
+COMMAND COUNT {{endpoint_command_count}}
+{{#endpoint_clusters}}
+{{#if_endpoint_cluster_in "Level Control,0x0006,0x0003"}}
+CLUSTER {{clusterName}} attributes={{attributeCount}} commands={{commandCount}} attributesOmitted={{omitsAttributeMetadata}} commandsOmitted={{omitsCommandMetadata}}
+{{/if_endpoint_cluster_in}}
+{{/endpoint_clusters}}
+{{#endpoint_attributes}}
+{{#if_endpoint_cluster_in "Level Control"}}
+LEFTOVER {{clusterName}}.{{name}}
+{{/if_endpoint_cluster_in}}
+{{/endpoint_attributes}}
+{{! Rows are matched by the cluster they belong to, by name and by code, }}
+{{! and not by their own name or code. }}
+{{#endpoint_attributes}}
+{{#if_endpoint_cluster_in "Identify"}}
+BY NAME {{clusterName}}.{{name}}
+{{/if_endpoint_cluster_in}}
+{{#if_endpoint_cluster_in "0x0003"}}
+BY CODE {{clusterName}}.{{name}}
+{{/if_endpoint_cluster_in}}
+{{/endpoint_attributes}}
+{{#endpoint_clusters}}
+RANGE {{attributeIndex}} {{attributeCount}}
+{{/endpoint_clusters}}
+// END OMITTED
+
+// The cluster table of the SDK is generated from the same data, so it has to
+// stay consistent with the shortened attribute table.
+// BEGIN OMITTED CLUSTER TABLE
+{{chip_endpoint_cluster_list~}}
+// END OMITTED CLUSTER TABLE
+{{/endpoint_config}}

--- a/test/gen-template/matter3/t.json
+++ b/test/gen-template/matter3/t.json
@@ -136,6 +136,11 @@
       "output": "endpoint_config_v2.h"
     },
     {
+      "path": "endpoint_config_iterators.zapt",
+      "name": "Endpoint Config Iterators",
+      "output": "endpoint_config_iterators.h"
+    },
+    {
       "path": "miscellaneous_helper_tests.zapt",
       "name": "miscellaneous helper",
       "output": "miscellaneous_helper_tests.out"

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -89,7 +89,7 @@ exports.testTemplate = {
   matter2: './test/gen-template/matter2/templates.json',
   matter2Count: 1,
   matter3: './test/gen-template/matter3/t.json',
-  matter3Count: 19,
+  matter3Count: 20,
   matter4: './test/gen-template/matter4/m4.json',
   matter4Count: 1,
   matterApiMaturity: './test/gen-template/matter-api-maturity/templates.json',


### PR DESCRIPTION
**Background**
ZAP generates the endpoint configuration (attribute tables, cluster tables, etc.) that the Matter SDK compiles into firmware. Today, the generated attribute array comes from a single template helper:

#define GENERATED_ATTRIBUTES {{ endpoint_attribute_list order='default,id,size,type,mask'}}
That helper builds the entire C array as one big string inside JavaScript. Template authors can't reshape it, filter it, or leave parts out. This is a problem for clusters that are moving to code-driven implementations: those clusters manage their own attribute metadata in C++, so having ZAP also emit that same metadata is redundant and wastes flash. There was no way to tell ZAP "skip these clusters' attributes."

**What this PR does**
It gives templates real control over how attribute metadata is generated, without changing any existing behavior.

**1. Iterators for attributes and clusters**

New block helpers usable inside {{#endpoint_config}}:

{{#endpoint_attributes}} — iterate one block per attribute
{{#endpoint_clusters}} — iterate one block per cluster
Templates can now format each row themselves instead of receiving a pre-built string:

#define GENERATED_ATTRIBUTES { \
{{#endpoint_attributes}}
  { {{endpoint_attribute_default}}, {{id}}, {{size}}, {{type}}, {{endpoint_attribute_mask}} }, /* {{clusterName}}.{{name}} */ \
{{/endpoint_attributes}}
}
**2. Richer per-attribute data and formatting helpers**

Each attribute now exposes structured fields (clusterName, clusterId, endpointId, code, storage, isWritable, isNullable, and more), so templates can filter or branch by cluster. Two helpers, {{endpoint_attribute_mask}} and {{endpoint_attribute_default}}, produce the correctly formatted C tokens (the same logic the existing helper used, refactored so it can run per-row).

**3. Ability to omit attribute metadata per cluster**

A new option on {{#endpoint_config}}:

{{#endpoint_config omitAttributeMetadataClusters="Level Control,0x0006"}}
For the listed clusters, the attribute metadata is dropped (attributeCount becomes 0) while the cluster entry itself is preserved. This is the flash-saving path: code-driven clusters can own their attribute tables instead of ZAP duplicating them. Clusters may be matched by name or by code (codes are recommended for names containing /, such as On/Off, because Handlebars treats / specially inside block tags).

**Backward compatibility**
The existing endpoint_attribute_list helper is unchanged, so all current Matter and Zigbee templates continue to work exactly as before.
No new override framework was introduced. Integrators can already replace any built-in helper by declaring a same-named helper in gen-templates.json (helpers load after built-ins and take precedence). This is now documented.
Correctness note
The omit step runs while attributes are being loaded, before ZAP calculates array indexes and counts. This guarantees that the attribute array, its count, and the index/count pointers in the cluster array remain mutually consistent when a cluster's attributes are removed.

**Testing**
Added endpoint-config-control.zapt, a template that exercises the new iterators and verifies the omit option removes a cluster's attributes while keeping the cluster (attrs=0).
All existing byte-exact endpoint_config test suites pass (gen-matter-1, gen-matter-3-1, custom-xml-device-type, endpoint-config).
**Documentation**
docs/external-helpers.md now describes the iterators, the formatting helpers, the omitAttributeMetadataClusters option, and how to override built-in helpers. Generated API docs (docs/api.md, docs/helpers.md) are updated for the new helpers.