### PR TITLE
Avoid false template-render stall timeouts under concurrent generation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8533,6 +8533,7 @@ Get endpoint type events from the given endpoint type ID.
     * [~postProcessGeneratedFiles(outputDirectory, genResult)](#module_JS API_ generator logic..postProcessGeneratedFiles) ⇒
     * [~contentIndexer(content)](#module_JS API_ generator logic..contentIndexer)
     * [~generateSingleFileForPreview(db, sessionId, fileName)](#module_JS API_ generator logic..generateSingleFileForPreview) ⇒
+    * [~reportRenderProgress()](#module_JS API_ generator logic..reportRenderProgress)
     * [~produceCompiledTemplate(singleTemplatePkg)](#module_JS API_ generator logic..produceCompiledTemplate) ⇒
     * [~produceIterativeContent(hb, metaInfo, db, sessionId, singleTemplatePkg, genTemplateJsonPackage, options)](#module_JS API_ generator logic..produceIterativeContent) ⇒
     * [~produceContent(hb, metaInfo, db, sessionId, singlePkg, overridePath:)](#module_JS API_ generator logic..produceContent) ⇒
@@ -8889,6 +8890,13 @@ Generates a single file and feeds it back for preview.
 | sessionId | <code>\*</code> | 
 | fileName | <code>\*</code> | 
 
+<a name="module_JS API_ generator logic..reportRenderProgress"></a>
+
+### JS API: generator logic~reportRenderProgress()
+Reports that template rendering made progress, keeping the idle watchdog of
+every in-flight render alive.
+
+**Kind**: inner method of [<code>JS API: generator logic</code>](#module_JS API_ generator logic)  
 <a name="module_JS API_ generator logic..produceCompiledTemplate"></a>
 
 ### JS API: generator logic~produceCompiledTemplate(singleTemplatePkg) ⇒
@@ -14711,6 +14719,7 @@ This module contains the API for templating. For more detailed instructions, rea
     * [~postProcessGeneratedFiles(outputDirectory, genResult)](#module_JS API_ generator logic..postProcessGeneratedFiles) ⇒
     * [~contentIndexer(content)](#module_JS API_ generator logic..contentIndexer)
     * [~generateSingleFileForPreview(db, sessionId, fileName)](#module_JS API_ generator logic..generateSingleFileForPreview) ⇒
+    * [~reportRenderProgress()](#module_JS API_ generator logic..reportRenderProgress)
     * [~produceCompiledTemplate(singleTemplatePkg)](#module_JS API_ generator logic..produceCompiledTemplate) ⇒
     * [~produceIterativeContent(hb, metaInfo, db, sessionId, singleTemplatePkg, genTemplateJsonPackage, options)](#module_JS API_ generator logic..produceIterativeContent) ⇒
     * [~produceContent(hb, metaInfo, db, sessionId, singlePkg, overridePath:)](#module_JS API_ generator logic..produceContent) ⇒
@@ -15067,6 +15076,13 @@ Generates a single file and feeds it back for preview.
 | sessionId | <code>\*</code> | 
 | fileName | <code>\*</code> | 
 
+<a name="module_JS API_ generator logic..reportRenderProgress"></a>
+
+### JS API: generator logic~reportRenderProgress()
+Reports that template rendering made progress, keeping the idle watchdog of
+every in-flight render alive.
+
+**Kind**: inner method of [<code>JS API: generator logic</code>](#module_JS API_ generator logic)  
 <a name="module_JS API_ generator logic..produceCompiledTemplate"></a>
 
 ### JS API: generator logic~produceCompiledTemplate(singleTemplatePkg) ⇒
@@ -15487,6 +15503,7 @@ await initAsync(); const hb = templateEngine.hbInstance();
     * [~postProcessGeneratedFiles(outputDirectory, genResult)](#module_JS API_ generator logic..postProcessGeneratedFiles) ⇒
     * [~contentIndexer(content)](#module_JS API_ generator logic..contentIndexer)
     * [~generateSingleFileForPreview(db, sessionId, fileName)](#module_JS API_ generator logic..generateSingleFileForPreview) ⇒
+    * [~reportRenderProgress()](#module_JS API_ generator logic..reportRenderProgress)
     * [~produceCompiledTemplate(singleTemplatePkg)](#module_JS API_ generator logic..produceCompiledTemplate) ⇒
     * [~produceIterativeContent(hb, metaInfo, db, sessionId, singleTemplatePkg, genTemplateJsonPackage, options)](#module_JS API_ generator logic..produceIterativeContent) ⇒
     * [~produceContent(hb, metaInfo, db, sessionId, singlePkg, overridePath:)](#module_JS API_ generator logic..produceContent) ⇒
@@ -15843,6 +15860,13 @@ Generates a single file and feeds it back for preview.
 | sessionId | <code>\*</code> | 
 | fileName | <code>\*</code> | 
 
+<a name="module_JS API_ generator logic..reportRenderProgress"></a>
+
+### JS API: generator logic~reportRenderProgress()
+Reports that template rendering made progress, keeping the idle watchdog of
+every in-flight render alive.
+
+**Kind**: inner method of [<code>JS API: generator logic</code>](#module_JS API_ generator logic)  
 <a name="module_JS API_ generator logic..produceCompiledTemplate"></a>
 
 ### JS API: generator logic~produceCompiledTemplate(singleTemplatePkg) ⇒

--- a/src-electron/generator/template-engine.js
+++ b/src-electron/generator/template-engine.js
@@ -72,12 +72,39 @@ const precompiledTemplates = {}
 
 const handlebarsInstance = {}
 
-// Per-render idle watchdog: a render is killed if it makes no progress
+// Idle watchdog: renders are killed if rendering makes no progress
 // (no helper invocation, no deferred block) for this long. Reset on activity
 // so long-but-healthy generations keep running.
-const TEMPLATE_RENDER_IDLE_TIMEOUT = 60000 // 1 minute of no progress
+const TEMPLATE_RENDER_IDLE_TIMEOUT = 120000 // 2 minutes of no progress
 // Absolute safety net; a render cannot exceed this even if it keeps kicking.
 const TEMPLATE_RENDER_HARD_TIMEOUT = 540000 // 9 minutes
+
+// Templates are rendered concurrently on a single event loop and against a
+// single database, so a render is only truly hung if nothing at all is
+// happening. Tracking progress per render would flag a big templates as
+// stalled merely because hundreds of sibling renders got to the database
+// first, hence one shared set of the in-flight watchdogs.
+const activeRenderWatchdogs = new Set()
+
+// This runs on every helper invocation, so broadcasting to each in-flight
+// watchdog every time costs seconds over a large generation. Kicking the
+// watchdogs this often is pointless against TEMPLATE_RENDER_IDLE_TIMEOUT, so
+// broadcasts are throttled to keep the common path a single clock read.
+const PROGRESS_BROADCAST_INTERVAL = 1000
+let lastProgressBroadcast = 0
+
+/**
+ * Reports that template rendering made progress, keeping the idle watchdog of
+ * every in-flight render alive.
+ */
+function reportRenderProgress() {
+  const now = performance.now()
+  if (now - lastProgressBroadcast < PROGRESS_BROADCAST_INTERVAL) return
+  lastProgressBroadcast = now
+  for (const renderWatchdog of activeRenderWatchdogs) {
+    renderWatchdog.reset(now)
+  }
+}
 
 /**
  * Resolves into a precompiled template, either from previous precompile or freshly compiled.
@@ -252,7 +279,7 @@ async function produceContent(
   }
   let content
   // Render the template (main pass + deferred blocks) under two timers:
-  //  - An idle watchdog that trips only if the render makes no progress
+  //  - An idle watchdog that trips only if rendering makes no progress
   //    for TEMPLATE_RENDER_IDLE_TIMEOUT ms (reset on every helper call and
   //    on each deferred block). This catches true hangs quickly without
   //    penalizing large, healthy generations.
@@ -279,14 +306,16 @@ async function produceContent(
     )
     if (typeof hardTimer.unref === 'function') hardTimer.unref()
   })
-  context.global.watchdog = idleWatchdog
+  if (idleWatchdog != null) {
+    activeRenderWatchdogs.add(idleWatchdog)
+  }
   try {
     content = await Promise.race([
       (async () => {
         const mainContent = await template(context)
         const deferredParts = await Promise.all(
           context.global.deferredBlocks.map((block) => {
-            idleWatchdog.reset()
+            reportRenderProgress()
             return block(context)
           })
         )
@@ -310,9 +339,11 @@ async function produceContent(
     )
     throw error
   } finally {
-    idleWatchdog?.stop()
+    if (idleWatchdog != null) {
+      activeRenderWatchdogs.delete(idleWatchdog)
+      idleWatchdog.stop()
+    }
     if (hardTimer != null) clearTimeout(hardTimer)
-    context.global.watchdog = null
   }
   return [
     {
@@ -388,9 +419,10 @@ function loadPartial(hb, name, data) {
  */
 function helperWrapper(wrappedHelper) {
   return function w(...args) {
-    // Kick the per-render watchdog: a helper call is a sign of progress,
-    // so the idle timer should not expire.
-    this.global?.watchdog?.reset()
+    // A helper call is a sign of progress, so the idle watchdogs should not
+    // expire. This cannot go through `this.global`, which is absent in plain
+    // handlebars subcontexts such as the body of an `{{#each}}` block.
+    reportRenderProgress()
     let helperName = wrappedHelper.name
     if (wrappedHelper.originalHelper != null) {
       helperName = wrappedHelper.originalHelper

--- a/src-electron/main-process/watchdog.js
+++ b/src-electron/main-process/watchdog.js
@@ -34,14 +34,55 @@
  * @returns {{ reset: Function, stop: Function }}
  */
 function createWatchdog(expirationInterval, triggerFunction) {
-  let id = setTimeout(triggerFunction, expirationInterval)
-  // Do not keep the event loop alive just because of this timer.
-  if (typeof id.unref === 'function') id.unref()
   let stopped = false
+  let lastActivity = performance.now()
+  let id = null
+
+  /**
+   * Arms the watchdog timer for the given interval.
+   * @param {number} interval - ms until the next expire check.
+   */
+  function arm(interval) {
+    id = setTimeout(expire, interval)
+    // Do not keep the event loop alive just because of this timer.
+    if (typeof id.unref === 'function') id.unref()
+  }
+
+  /**
+   * Handles watchdog expiry: re-arms if activity was recent, otherwise triggers.
+   */
+  function expire() {
+    if (stopped) return
+    // Timers fire late when the event loop is blocked, so by the time we get
+    // here activity may already have been recorded. Compare against the last
+    // activity instead of trusting the timer, and re-arm for whatever time is
+    // left, so only genuine inactivity triggers.
+    let idleTime = performance.now() - lastActivity
+    if (!(idleTime >= 0)) {
+      // reset() was handed a timestamp that did not come from this clock, so
+      // it is either not a number or lies in the future. Restart from now,
+      // which costs one extra interval instead of muting the watchdog.
+      lastActivity = performance.now()
+      arm(expirationInterval)
+    } else if (idleTime < expirationInterval) {
+      arm(expirationInterval - idleTime)
+    } else {
+      id = null
+      triggerFunction()
+    }
+  }
+
+  arm(expirationInterval)
+
   return {
-    reset() {
+    /**
+     * Records activity so the idle timer does not expire.
+     * @param {number} [time=performance.now()] - optional pre-computed timestamp
+     *   for callers that reset many watchdogs in one pass.
+     */
+    reset(time = performance.now()) {
       if (stopped) return
-      if (id != null && typeof id.refresh === 'function') id.refresh()
+      lastActivity = time
     },
     stop() {
       stopped = true


### PR DESCRIPTION
- Share idle-watchdog progress across in-flight renders and verify expiry against last activity, so large Matter templates like Accessors.cpp are not killed while sibling renders are still making progress. Also raise the idle window to 2 minutes for safety
- JIRA: ZAPP-1730